### PR TITLE
Add scoped AGENTS guidelines based on agent notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# Repo Agent Guidelines
+
+## Shared Principles
+- Keep all code comments, design notes, and commit messages in **English**, while final status summaries for collaborators remain in **Japanese**.
+- Always answer in Japanese and provide full terminal commands without ellipses when suggesting shell usage.
+- Review the project README, key design docs, and [docs/task_backlog.md](docs/task_backlog.md) at the start of work, then state the chosen task and definition of done.
+
+## Workflow Expectations
+1. Select a task from the P0/P1 backlog, and jot down the intended deliverables (code, docs, reports) in English notes.
+2. Inspect directory-level READMEs or design specs to identify dependencies and required tests before changing files.
+3. After implementation, run `python3 -m pytest` and add targeted validations such as `python3 scripts/run_sim.py --csv <sample>` when needed.
+4. Update [docs/task_backlog.md](docs/task_backlog.md) and any related documents to reflect the completed work, adding links or commentary.
+5. Write commit messages and PR descriptions in English covering task context, major changes, and executed tests, then summarize the PR in Japanese.
+
+## Documentation & Operations
+- Remove finished items from the backlog, and add new tasks with priorities (English allowed).
+- Record new operational flows or parameter changes in the README and relevant runbooks, and share a Japanese synopsis.
+- When updating critical outputs such as `runs/index.csv`, `reports/*`, or `ops/state_archive/*`, document the reason and reproduction steps in commits/PRs and be prepared to explain them in Japanese.
+- Use [docs/task_backlog.md](docs/task_backlog.md) as the hub for ongoing task tracking and link back to supporting docs like `docs/state_runbook.md` or `readme/` design notes as appropriate.

--- a/configs/strategies/AGENTS.md
+++ b/configs/strategies/AGENTS.md
@@ -1,0 +1,5 @@
+# Strategy Config Guidelines
+
+- Follow the manifest specification in [`configs/strategies/README.md`](README.md) when adding or updating YAML files.
+- Validate manifests with `python3 -m pytest tests/test_strategy_manifest.py` before committing.
+- Link any configuration changes back to relevant items in [../../docs/task_backlog.md](../../docs/task_backlog.md) so reviewers understand the motivation.

--- a/core/AGENTS.md
+++ b/core/AGENTS.md
@@ -1,0 +1,6 @@
+# Core Module Guidelines
+
+- Follow PEP 8 formatting and include type hints for new or modified code.
+- Add or update unit tests that cover the affected modules; coordinate with [`tests/test_runner.py`](../tests/test_runner.py) and related suites.
+- After changes, execute `python3 -m pytest` (or targeted subsets) to confirm the core logic passes.
+- Reference the backlog at [../docs/task_backlog.md](../docs/task_backlog.md) to ensure core updates align with current priorities.

--- a/router/AGENTS.md
+++ b/router/AGENTS.md
@@ -1,0 +1,5 @@
+# Router Guidelines
+
+- When introducing new routing rules or signals, run comparative backtests such as `python3 scripts/run_compare.py` to measure performance shifts.
+- Summarize routing changes and key metrics in Japanese for reporting, while keeping code-level notes in English.
+- Coordinate router updates with strategy definitions in [../strategies](../strategies) and reference [../docs/task_backlog.md](../docs/task_backlog.md) for current objectives.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,6 @@
+# Scripts Guidelines
+
+- Maintain CLI compatibility and avoid breaking existing arguments or defaults.
+- Ensure usage examples referenced in `README.md` or script-specific docs continue to run as written.
+- Run scenario-appropriate commands such as `python3 scripts/run_sim.py --csv <sample>` when validating changes.
+- Check [../docs/task_backlog.md](../docs/task_backlog.md) for context on operational scripts that may need updates alongside code changes.

--- a/strategies/AGENTS.md
+++ b/strategies/AGENTS.md
@@ -1,0 +1,5 @@
+# Strategies Guidelines
+
+- Document new signals or logic adjustments in English within the code and design notes, while preparing Japanese summaries for stakeholders.
+- Validate behavior through comparative runs (`python3 scripts/run_compare.py` or similar) and capture key deltas for review.
+- Keep strategy implementations consistent with configuration manifests in [../configs/strategies](../configs/strategies) and planned work in [../docs/task_backlog.md](../docs/task_backlog.md).


### PR DESCRIPTION
## Summary
- add a repository-level AGENTS file that captures the shared principles and workflow rules from agent.md with links to supporting docs
- introduce scoped AGENTS files for core, scripts, configs/strategies, router, and strategies highlighting directory-specific expectations and cross-references

## Testing
- not run (documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68d7d2639a6c832a813b3a53f727baa9