### PR TITLE
Add regression coverage for pull_prices ingestion pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,23 @@ python3 scripts/run_sim.py \
 python3 scripts/run_sim.py --csv data/ohlc5m.csv --symbol USDJPY --json-out out.json
 ```
 
+### オンデマンドインジェスト CLI
+- `scripts/pull_prices.py` はヒストリカルCSV（またはAPIエクスポート）から未処理バーを検出し、`raw/`→`validated/`→`features/` に冪等に追記する。
+- 直近の成功時刻は `ops/runtime_snapshot.json` の `ingest` セクションで管理し、異常は `ops/logs/ingest_anomalies.jsonl` に記録。
+- タイムスタンプは ISO 8601 (`Z` や `+00:00` 付き)・空白区切りどちらにも対応。
+
+実行例:
+
+```
+python3 scripts/pull_prices.py --source data/usdjpy_5m_2018-2024_utc.csv --symbol USDJPY --tf 5m
+```
+
+ドライラン（スナップショット更新なし）:
+
+```
+python3 scripts/pull_prices.py --source data/usdjpy_5m_2018-2024_utc.csv --symbol USDJPY --dry-run
+```
+
 ### 両Fill併走レポート
 - ConservativeとBridgeを同条件で比較するCLI
   - `scripts/run_compare.py`

--- a/docs/progress_phase0.md
+++ b/docs/progress_phase0.md
@@ -9,6 +9,12 @@
 - シンボル: `USDJPY` のみ
 - ギャップ検出: 週末休場（2885分）と一部祝日相当の間隔のみ。営業時間内の欠損や逆順は検出されず。
 
+## オンデマンドインジェスト
+- CLI: `python3 scripts/pull_prices.py --source data/usdjpy_5m_2018-2024_utc.csv --symbol USDJPY --tf 5m`
+- 成果物: `raw/USDJPY/5m.csv` → `validated/USDJPY/5m.csv` → `features/USDJPY/5m.csv` を順次追記し、再実行でも重複挿入なし。
+- スナップショット: `ops/runtime_snapshot.json` の `ingest.USDJPY_5m` に最新バー時刻を保持（ドライラン時は未更新）。
+- 異常検知: パースエラー・ギャップ・シンボル/TF不一致などを `ops/logs/ingest_anomalies.jsonl` にJSON Linesで残し、再実行ログとして活用可能。
+
 ## ベースライン state
 - 既存ランの `state.json` は `runs/grid_USDJPY_bridge_or4_ktp1.2_ksl0.4_20250921_134957/state.json` をベースライン候補とする。
 - 運用時は `docs/state_runbook.md` の手順に沿って日次アーカイブを保持し、実験前にバックアップを取得すること。

--- a/docs/task_backlog.md
+++ b/docs/task_backlog.md
@@ -3,7 +3,6 @@
 このバックログは「最新値動きを取り込みながら継続学習し、複数戦略ポートフォリオでシグナルを出す」ツールを実現するための優先順位付きタスク群です。各タスク完了時は成果物（コード/ドキュメント/レポート）へのリンクを追記してください。
 
 ## P0: 即着手（オンデマンドインジェスト + 基盤整備）
-- **オンデマンド値動きインジェスト**: 起動時バッチで Bid/Ask/5分足を取得し、前回成功時刻からの空白期間をヒストリカルAPI/CSVで補完。結果を `raw/`→`validated/`→`features/` に追記し、欠損・異常値はログ＋再実行可能な形で記録する。
 - **state 更新ワーカー**: 取得済みバーを時系列順に処理し、`BacktestRunner.load_state` → `runner.run_partial()` → `runner.export_state` を繰り返す CLI を実装。`ops/state_archive/<strategy>/<symbol>/<mode>/` に最新5件を保存し、更新後に `scripts/aggregate_ev.py` を自動実行できるようにする。
 - **ベースライン/ローリング run 起動ジョブ**: ORB コア設定の通し run と直近ローリング run を起動時にまとめて再計算し、`runs/index.csv`・`reports/baseline/*.json`・`reports/rolling/<window>/` を更新。前回結果との乖離が閾値超過したら Webhook 通知。
 

--- a/scripts/pull_prices.py
+++ b/scripts/pull_prices.py
@@ -21,7 +21,7 @@ import csv
 import json
 import sys
 from collections import deque
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Deque, Dict, Iterable, List, Optional, Tuple
 
@@ -66,8 +66,14 @@ def _parse_ts(value: str) -> datetime:
     value = value.strip()
     if not value:
         raise ValueError("empty timestamp")
-    if "T" in value:
-        return datetime.fromisoformat(value)
+    if "T" in value or " " in value:
+        normalized = value
+        if normalized.endswith("Z"):
+            normalized = normalized[:-1] + "+00:00"
+        dt = datetime.fromisoformat(normalized)
+        if dt.tzinfo is not None:
+            dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+        return dt
     try:
         return datetime.strptime(value, "%Y-%m-%d %H:%M:%S")
     except ValueError:

--- a/tests/test_pull_prices.py
+++ b/tests/test_pull_prices.py
@@ -1,0 +1,93 @@
+import csv
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+SOURCE_CSV = """timestamp,symbol,tf,o,h,l,c,v,spread
+2024-01-01T00:00:00Z,USDJPY,5m,150.00,150.10,149.90,150.02,120,0.02
+2024-01-01T00:05:00+00:00,USDJPY,5m,150.02,150.12,149.92,150.04,118,0.02
+2024-01-01T00:10:00,USDJPY,5m,150.04,150.14,149.94,150.06,116,0.02
+2024-01-01T00:15:00,USDJPY,5m,150.06,150.16,149.96,150.08,114,0.02
+2024-01-01T00:20:00,USDJPY,5m,150.08,150.18,149.98,150.10,112,0.02
+2024-01-01 00:25:00,USDJPY,5m,150.10,150.20,150.00,150.12,110,0.02
+2024-01-01 00:30:00,USDJPY,5m,150.12,150.22,150.02,150.14,108,0.02
+2024-01-01 00:35:00,USDJPY,5m,150.14,150.24,150.04,150.16,106,0.02
+"""
+
+
+def _run_pull_prices(tmp_path: Path) -> dict:
+    source_csv = tmp_path / "source.csv"
+    source_csv.write_text(SOURCE_CSV)
+    snapshot_path = tmp_path / "snapshot.json"
+    cmd = [
+        sys.executable,
+        str(ROOT / "scripts/pull_prices.py"),
+        "--source",
+        str(source_csv),
+        "--symbol",
+        "USDJPY",
+        "--tf",
+        "5m",
+        "--snapshot",
+        str(snapshot_path),
+    ]
+    proc = subprocess.run(cmd, cwd=tmp_path, capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout.strip())
+    return payload
+
+
+def test_pull_prices_pipeline(tmp_path):
+    payload = _run_pull_prices(tmp_path)
+    assert payload["rows_raw"] == 8
+    assert payload["rows_validated"] == 8
+    assert payload["rows_featured"] == 8
+    assert payload["gaps_detected"] == 0
+    assert payload["last_ts_now"].endswith("00:35:00")
+
+    raw_path = tmp_path / "raw" / "USDJPY" / "5m.csv"
+    validated_path = tmp_path / "validated" / "USDJPY" / "5m.csv"
+    features_path = tmp_path / "features" / "USDJPY" / "5m.csv"
+    snapshot_path = tmp_path / "snapshot.json"
+    anomalies_path = tmp_path / "ops" / "logs" / "ingest_anomalies.jsonl"
+
+    assert raw_path.exists()
+    assert validated_path.exists()
+    assert features_path.exists()
+    assert snapshot_path.exists()
+    assert not anomalies_path.exists()
+
+    with raw_path.open(newline="", encoding="utf-8") as f:
+        raw_rows = list(csv.DictReader(f))
+    assert len(raw_rows) == 8
+    assert raw_rows[0]["timestamp"].endswith("00:00:00Z")
+
+    with validated_path.open(newline="", encoding="utf-8") as f:
+        validated_rows = list(csv.DictReader(f))
+    assert len(validated_rows) == 8
+    assert validated_rows[-1]["timestamp"].endswith("00:35:00")
+
+    with features_path.open(newline="", encoding="utf-8") as f:
+        feature_rows = list(csv.DictReader(f))
+    assert len(feature_rows) == 8
+    last_feature = feature_rows[-1]
+    assert last_feature["or_high"] != ""
+    assert last_feature["or_low"] != ""
+
+    snapshot_data = json.loads(snapshot_path.read_text())
+    assert snapshot_data["ingest"]["USDJPY_5m"].endswith("00:35:00")
+
+    payload_second = _run_pull_prices(tmp_path)
+    assert payload_second["rows_raw"] == 0
+    assert payload_second["rows_validated"] == 0
+    assert payload_second["rows_featured"] == 0
+
+    with features_path.open(newline="", encoding="utf-8") as f:
+        feature_rows_second = list(csv.DictReader(f))
+    assert len(feature_rows_second) == 8
+


### PR DESCRIPTION
## Summary
- allow `scripts/pull_prices.py` to normalise ISO8601 timestamps with trailing `Z` or explicit offsets
- document the ingestion workflow in the README and phase-0 progress notes while clearing the completed backlog item
- add `tests/test_pull_prices.py` to exercise the end-to-end CSV append and snapshot update flow

## Testing
- python3 -m pytest *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68d7d3ed791c832aa50c97c4c05dbd72