### PR TITLE
Add BacktestRunner partial update flow

### DIFF
--- a/docs/task_backlog.md
+++ b/docs/task_backlog.md
@@ -3,7 +3,7 @@
 このバックログは「最新値動きを取り込みながら継続学習し、複数戦略ポートフォリオでシグナルを出す」ツールを実現するための優先順位付きタスク群です。各タスク完了時は成果物（コード/ドキュメント/レポート）へのリンクを追記してください。
 
 ## P0: 即着手（オンデマンドインジェスト + 基盤整備）
-- **state 更新ワーカー**: 取得済みバーを時系列順に処理し、`BacktestRunner.load_state` → `runner.run_partial()` → `runner.export_state` を繰り返す CLI を実装。`ops/state_archive/<strategy>/<symbol>/<mode>/` に最新5件を保存し、更新後に `scripts/aggregate_ev.py` を自動実行できるようにする。
+- ~~**state 更新ワーカー**~~ (完了): `scripts/update_state.py` に部分実行ワークフローを実装し、`BacktestRunner.run_partial` と状態スナップショット/EVアーカイブ連携を整備。`ops/state_archive/<strategy>/<symbol>/<mode>/` へ最新5件を保持し、更新後は `scripts/aggregate_ev.py` を自動起動するようにした。
 - **ベースライン/ローリング run 起動ジョブ**: ORB コア設定の通し run と直近ローリング run を起動時にまとめて再計算し、`runs/index.csv`・`reports/baseline/*.json`・`reports/rolling/<window>/` を更新。前回結果との乖離が閾値超過したら Webhook 通知。
 
 ## P1: ローリング検証 + 健全性モニタリング

--- a/scripts/update_state.py
+++ b/scripts/update_state.py
@@ -198,11 +198,11 @@ def main(argv=None) -> int:
         chunk.append(bar)
         latest_ts_str = bar.get("timestamp") if isinstance(bar.get("timestamp"), str) else latest_ts_str
         if len(chunk) >= chunk_size:
-            metrics = runner.run(chunk, mode=args.mode)
+            metrics = runner.run_partial(chunk, mode=args.mode)
             total_processed += len(chunk)
             chunk = []
     if chunk:
-        metrics = runner.run(chunk, mode=args.mode)
+        metrics = runner.run_partial(chunk, mode=args.mode)
         total_processed += len(chunk)
         latest_ts_str = chunk[-1].get("timestamp") if isinstance(chunk[-1].get("timestamp"), str) else latest_ts_str
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -40,6 +40,32 @@ class TestRunner(unittest.TestCase):
         # At least attempted one trade
         self.assertGreaterEqual(d["trades"], 0)
 
+    def test_run_partial_matches_full_run(self):
+        symbol = "USDJPY"
+        t0 = datetime(2024, 1, 2, 8, 0, tzinfo=timezone.utc)
+        bars = []
+        price = 151.00
+        for i in range(6):
+            bars.append(make_bar(t0 + timedelta(minutes=5 * i), symbol, price, price + 0.10, price - 0.10, price + 0.02, spread=0.02))
+            price += 0.01
+        or_high = max(b["h"] for b in bars)
+        breakout = make_bar(t0 + timedelta(minutes=5 * 6), symbol, price, or_high + 0.15, price - 0.05, price, spread=0.02)
+        bars.append(breakout)
+
+        runner_full = BacktestRunner(equity=200_000.0, symbol=symbol)
+        metrics_full = runner_full.run(list(bars), mode="conservative")
+
+        runner_partial = BacktestRunner(equity=200_000.0, symbol=symbol)
+        runner_partial.run_partial(bars[:4], mode="conservative")
+        metrics_partial = runner_partial.run_partial(bars[4:], mode="conservative")
+
+        self.assertEqual(metrics_full.as_dict(), metrics_partial.as_dict())
+
+        state = runner_partial.export_state()
+        self.assertIn("runtime", state)
+        self.assertIn("warmup_left", state["runtime"])
+        self.assertIn("last_timestamp", state.get("meta", {}))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add `BacktestRunner.run_partial` with runtime state persistence in `export_state`/`load_state`
- update `scripts/update_state.py` to stream chunks through the new partial runner API and refresh the backlog entry
- cover incremental execution with a unit test matching full-run metrics

## Testing
- python3 -m pytest *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68d7d78906a0832a96141f191fe6c512