### PR TITLE
Add GitHub Actions workflow for pytest

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,28 @@
+name: Pytest
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+
+      - name: Run pytest
+        run: pytest


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to run pytest on pushes, pull requests, and manual triggers
- install dependencies from available requirements files before executing pytest

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d7df2fa2d4832a9f6e7e9f11cb6425