### PR TITLE
Ensure CI installs pytest dependencies

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,29 @@
+name: Pytest
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+          python -m pip install pytest pyyaml
+
+      - name: Run pytest
+        run: python -m pytest


### PR DESCRIPTION
## Summary
- install pytest and PyYAML within the GitHub Actions workflow before executing tests
- run the suite with `python -m pytest` to align with local instructions

## Testing
- python3 -m pytest *(fails: container cannot install PyYAML from PyPI due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d7df2fa2d4832a9f6e7e9f11cb6425