### PR TITLE
Install pandas for CI pytest workflow

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,29 @@
+name: Pytest
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+          python -m pip install pytest pyyaml pandas
+
+      - name: Run pytest
+        run: python -m pytest


### PR DESCRIPTION
## Summary
- ensure the GitHub Actions pytest workflow installs pandas alongside the existing pytest dependencies so the CLI modules import cleanly

## Testing
- python3 -m pytest *(fails: local environment cannot install pandas/pyyaml because outbound PyPI access is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68d7df2fa2d4832a9f6e7e9f11cb6425