### PR TITLE
Normalize timestamp parsing in benchmark tooling

### DIFF
--- a/scripts/_ts_utils.py
+++ b/scripts/_ts_utils.py
@@ -1,0 +1,61 @@
+"""Shared helpers for timestamp parsing in operational scripts."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Sequence
+
+
+def _normalize_iso_string(value: str) -> str:
+    """Normalize timestamp string for ``datetime.fromisoformat``.
+
+    Currently handles the common case where providers emit ``Z`` suffix to
+    indicate UTC. ``datetime.fromisoformat`` does not accept that shorthand, so
+    we replace it with ``+00:00``.
+    """
+    normalized = value
+    if normalized.endswith(("Z", "z")):
+        normalized = normalized[:-1] + "+00:00"
+    return normalized
+
+
+def parse_naive_utc_timestamp(value: str, *, fallback_formats: Sequence[str] | None = None) -> datetime:
+    """Parse ``value`` into a naive ``datetime`` in UTC.
+
+    The helper mirrors the various timestamp formats encountered across ingest
+    and benchmark scripts:
+
+    - ISO 8601 strings with ``T`` or space separators
+    - Values with ``Z`` suffix or explicit offsets such as ``+09:00``
+    - Optional fallback ``strptime`` formats (e.g. legacy CSV exports)
+
+    Args:
+        value: Raw timestamp string from CSV/API sources.
+        fallback_formats: Additional ``strptime`` formats to try when
+            ``datetime.fromisoformat`` fails.
+
+    Returns:
+        ``datetime`` without ``tzinfo`` in UTC.
+
+    Raises:
+        ValueError: If the value is empty or cannot be parsed.
+    """
+
+    text = value.strip()
+    if not text:
+        raise ValueError("empty timestamp")
+
+    normalized = _normalize_iso_string(text)
+    try:
+        dt = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        if fallback_formats:
+            for fmt in fallback_formats:
+                try:
+                    return datetime.strptime(text, fmt)
+                except ValueError:
+                    continue
+        raise ValueError(f"invalid timestamp: {value!r}") from exc
+
+    if dt.tzinfo is not None:
+        dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+    return dt

--- a/scripts/pull_prices.py
+++ b/scripts/pull_prices.py
@@ -29,6 +29,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+from scripts._ts_utils import parse_naive_utc_timestamp
 from core.feature_store import adx as calc_adx
 from core.feature_store import atr as calc_atr
 from core.feature_store import opening_range, realized_vol
@@ -63,21 +64,10 @@ def _save_snapshot(path: Path, data: dict) -> None:
 
 
 def _parse_ts(value: str) -> datetime:
-    value = value.strip()
-    if not value:
-        raise ValueError("empty timestamp")
-    if "T" in value or " " in value:
-        normalized = value
-        if normalized.endswith("Z"):
-            normalized = normalized[:-1] + "+00:00"
-        dt = datetime.fromisoformat(normalized)
-        if dt.tzinfo is not None:
-            dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
-        return dt
-    try:
-        return datetime.strptime(value, "%Y-%m-%d %H:%M:%S")
-    except ValueError:
-        return datetime.strptime(value, "%Y-%m-%d")
+    return parse_naive_utc_timestamp(
+        value,
+        fallback_formats=("%Y-%m-%d %H:%M:%S", "%Y-%m-%d"),
+    )
 
 
 def _last_ts_from_snapshot(snapshot: dict, key: str) -> Optional[datetime]:

--- a/scripts/run_benchmark_runs.py
+++ b/scripts/run_benchmark_runs.py
@@ -18,6 +18,11 @@ from typing import Dict, Iterable, List, Optional, Tuple
 SNAPSHOT_PATH = Path("ops/runtime_snapshot.json")
 ROOT = Path(__file__).resolve().parents[1]
 
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts._ts_utils import parse_naive_utc_timestamp
+
 
 def _load_snapshot(path: Path) -> dict:
     if not path.exists():
@@ -125,9 +130,10 @@ def _post_webhook(url: str, payload: Dict[str, object], timeout: float = 5.0) ->
 
 
 def _parse_ts(value: str) -> datetime:
-    if "T" in value:
-        return datetime.fromisoformat(value)
-    return datetime.strptime(value, "%Y-%m-%d %H:%M:%S")
+    return parse_naive_utc_timestamp(
+        value,
+        fallback_formats=("%Y-%m-%d %H:%M:%S",),
+    )
 
 
 def _filter_window(rows: List[dict], days: int) -> List[dict]:

--- a/tests/test_run_benchmark_runs.py
+++ b/tests/test_run_benchmark_runs.py
@@ -1,0 +1,17 @@
+"""Tests for scripts.run_benchmark_runs utilities."""
+from __future__ import annotations
+
+from scripts.run_benchmark_runs import _filter_window
+
+
+def test_filter_window_handles_mixed_timestamp_formats() -> None:
+    rows = [
+        {"timestamp": "2024-01-01T00:00:00Z", "label": "z"},
+        {"timestamp": "2024-01-02 00:00:00", "label": "space"},
+        {"timestamp": "2024-01-03T12:34:56.789Z", "label": "fractional"},
+        {"timestamp": "2024-01-04T09:00:00+09:00", "label": "offset"},
+    ]
+
+    filtered = _filter_window(rows, days=2)
+
+    assert filtered == rows[1:]


### PR DESCRIPTION
## Summary
- add a shared timestamp parsing helper that normalizes ISO strings and offsets
- update run_benchmark_runs and pull_prices to reuse the utility
- cover mixed timestamp formats in _filter_window with a dedicated test

## Testing
- python3 -m pytest tests/test_run_benchmark_runs.py
- python3 -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7e5cbc220832ab903702d5139126d