### PR TITLE
Align runs index rebuild with run_sim outputs

### DIFF
--- a/docs/task_backlog.md
+++ b/docs/task_backlog.md
@@ -4,6 +4,7 @@
 
 ## P0: 即着手（オンデマンドインジェスト + 基盤整備）
 - ~~**state 更新ワーカー**~~ (完了): `scripts/update_state.py` に部分実行ワークフローを実装し、`BacktestRunner.run_partial` と状態スナップショット/EVアーカイブ連携を整備。`ops/state_archive/<strategy>/<symbol>/<mode>/` へ最新5件を保持し、更新後は `scripts/aggregate_ev.py` を自動起動するようにした。
+- ~~**runs/index 再構築スクリプト整備**~~ (完了): `scripts/rebuild_runs_index.py` が `scripts/run_sim.py` の出力列 (k_tr, gate/EV debug など) と派生指標 (win_rate, pnl_per_trade) を欠損なく復元し、`tests/test_rebuild_runs_index.py` で fixtures 検証を追加。
 - **ベースライン/ローリング run 起動ジョブ**: ORB コア設定の通し run と直近ローリング run を起動時にまとめて再計算し、`runs/index.csv`・`reports/baseline/*.json`・`reports/rolling/<window>/` を更新。前回結果との乖離が閾値超過したら Webhook 通知。
 
 ## P1: ローリング検証 + 健全性モニタリング

--- a/state.md
+++ b/state.md
@@ -7,3 +7,4 @@
 ## Log
 - 2024-06-01: Initialized state tracking log and documented the review/update workflow rule.
 - 2024-06-02: Targeting P0 reliability by ensuring strategy manifests and CLI runners work without optional dependencies. DoD: pytest passes and run_sim/loader can parse manifests/EV profiles after removing the external PyYAML requirement.
+- 2024-06-03: 同期 `scripts/rebuild_runs_index.py` を拡充し、`runs/index.csv` の列網羅性テストを追加。DoD: pytest オールパスと CSV 列の欠損ゼロ。

--- a/tests/test_rebuild_runs_index.py
+++ b/tests/test_rebuild_runs_index.py
@@ -1,0 +1,81 @@
+import csv
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.rebuild_runs_index import DEFAULT_COLUMNS, gather_rows, write_index
+
+
+@pytest.fixture
+def sample_run_dir(tmp_path: Path) -> Path:
+    runs_dir = tmp_path / "runs"
+    run_dir = runs_dir / "demo_20240101_010101"
+    run_dir.mkdir(parents=True)
+    params = {
+        "symbol": "USDJPY",
+        "mode": "conservative",
+        "equity": 100000.0,
+        "or_n": 5,
+        "k_tp": 1.2,
+        "k_sl": 0.8,
+        "k_tr": 0.5,
+        "threshold_lcb": 0.1,
+        "min_or_atr": 0.4,
+        "rv_cuts": "0.005,0.015",
+        "allow_low_rv": True,
+        "allowed_sessions": "LDN,NY",
+        "warmup": 15,
+    }
+    metrics = {
+        "trades": 5,
+        "wins": 3,
+        "total_pips": 25.0,
+        "debug": {
+            "gate_block": 2,
+            "ev_reject": 1,
+            "ev_bypass": 4,
+        },
+        "dump_rows": 50,
+        "state_loaded": "ops/state_archive/demo.json",
+        "state_archive_path": "ops/state_archive/demo_saved.json",
+        "ev_profile_path": "configs/ev_profiles/day_orb_5m.yaml",
+    }
+    (run_dir / "params.json").write_text(json.dumps(params))
+    (run_dir / "metrics.json").write_text(json.dumps(metrics))
+    (run_dir / "state.json").write_text(json.dumps({"state": "demo"}))
+    return runs_dir
+
+
+def test_rebuild_runs_index_preserves_columns(sample_run_dir: Path, tmp_path: Path) -> None:
+    rows = gather_rows(sample_run_dir)
+    assert len(rows) == 1
+    row = rows[0]
+
+    # Derived metrics must be recomputed from metrics.json
+    assert row["win_rate"] == pytest.approx(0.6)
+    assert row["pnl_per_trade"] == pytest.approx(5.0)
+    assert row["gate_block"] == 2
+    assert row["ev_reject"] == 1
+    assert row["ev_bypass"] == 4
+    assert row["k_tr"] == 0.5
+    assert row["dump_rows"] == 50
+    assert str(row["state_path"]).endswith("state.json")
+
+    out_path = tmp_path / "index.csv"
+    write_index(rows, out_path)
+
+    with out_path.open(newline="") as f:
+        reader = csv.DictReader(f)
+        assert reader.fieldnames == DEFAULT_COLUMNS
+        csv_row = next(reader)
+
+    expected = {}
+    for col in DEFAULT_COLUMNS:
+        value = row.get(col, "")
+        if value in (None, ""):
+            expected[col] = ""
+        else:
+            expected[col] = str(value)
+
+    assert csv_row == expected


### PR DESCRIPTION
## Summary
- ensure scripts/rebuild_runs_index.py writes every column produced by scripts/run_sim.py and recomputes derived metrics from metrics.json
- safely extract gate/EV debug counters and fallback state paths when reconstructing rows
- add pytest coverage that rebuilds a runs/index.csv fixture to verify column preservation and values

## Testing
- python3 -m pytest

## 日本語サマリ
- rebuild_runs_index.py を run_sim 出力と揃え、派生指標とゲート統計を欠損なく復元し、pytest で検証


------
https://chatgpt.com/codex/tasks/task_e_68d7edbd09bc832ab2ead319547ffd97