### PR TITLE
Propagate benchmark thresholds through daily workflow

### DIFF
--- a/scripts/run_daily_workflow.py
+++ b/scripts/run_daily_workflow.py
@@ -24,6 +24,18 @@ def main(argv=None) -> int:
     parser.add_argument("--benchmarks", action="store_true", help="Run baseline + rolling benchmarks")
     parser.add_argument("--state-health", action="store_true", help="Run state health checker")
     parser.add_argument("--benchmark-summary", action="store_true", help="Aggregate benchmark reports")
+    parser.add_argument(
+        "--min-sharpe",
+        type=float,
+        default=None,
+        help="Warn when Sharpe ratio falls below this value",
+    )
+    parser.add_argument(
+        "--max-drawdown",
+        type=float,
+        default=None,
+        help="Warn when |max_drawdown| exceeds this value (pips)",
+    )
     parser.add_argument("--optimize", action="store_true", help="Run parameter optimization")
     parser.add_argument("--analyze-latency", action="store_true", help="Analyze signal latency")
     parser.add_argument("--archive-state", action="store_true", help="Archive state.json files")
@@ -73,6 +85,10 @@ def main(argv=None) -> int:
                "--reports-dir", str(ROOT / "reports"),
                "--json-out", str(ROOT / "reports/benchmark_summary.json"),
                "--plot-out", str(ROOT / "reports/benchmark_summary.png")]
+        if args.min_sharpe is not None:
+            cmd += ["--min-sharpe", str(args.min_sharpe)]
+        if args.max_drawdown is not None:
+            cmd += ["--max-drawdown", str(args.max_drawdown)]
         run_cmd(cmd)
 
     if args.optimize:

--- a/state.md
+++ b/state.md
@@ -11,3 +11,4 @@
 - 2024-06-04: Sharpe 比・最大 DD をランナー/CLI/ベンチマークに波及させ、runbook とテストを更新。DoD: `python3 -m pytest` パスと `run_sim` JSON に新指標が出力されること。
 - 2024-06-04 (完了): `core/runner` でエクイティカーブと Sharpe/最大DD を算出し、`run_sim.py`→`runs/index.csv`→`store_run_summary`→`report_benchmark_summary.py` まで連携。`--min-sharpe`/`--max-drawdown` を追加し、docs・テスト更新後に `python3 -m pytest` を通過。
 - 2024-06-05: `scripts/run_benchmark_runs.py` の CLI フローを網羅する pytest を追加し、ドライラン/本番実行/失敗ケースの挙動を検証。DoD: `python3 -m pytest` オールグリーン。
+- 2024-06-06: `scripts/run_daily_workflow.py` に `--min-sharpe`/`--max-drawdown` を追加し、ベンチマーク要約呼び出しへ閾値を伝播するテストを新設。DoD: `python3 -m pytest` オールパスで、組み立てコマンドに閾値引数が含まれること。

--- a/tests/test_run_daily_workflow.py
+++ b/tests/test_run_daily_workflow.py
@@ -1,0 +1,49 @@
+import sys
+from scripts import run_daily_workflow
+
+
+class DummyResult:
+    def __init__(self, returncode=0):
+        self.returncode = returncode
+
+
+def _capture_run_cmd(monkeypatch):
+    captured = []
+
+    def fake_run_cmd(cmd):
+        captured.append(cmd)
+        return DummyResult()
+
+    monkeypatch.setattr(run_daily_workflow, "run_cmd", fake_run_cmd)
+    return captured
+
+
+def test_benchmark_summary_threshold_arguments(monkeypatch):
+    captured = _capture_run_cmd(monkeypatch)
+
+    exit_code = run_daily_workflow.main([
+        "--benchmark-summary",
+        "--min-sharpe", "1.5",
+        "--max-drawdown", "250.5",
+    ])
+
+    assert exit_code == 0
+    assert captured, "run_cmd should be invoked"
+    cmd = captured[0]
+    assert cmd[0] == sys.executable
+    assert "--min-sharpe" in cmd
+    assert cmd[cmd.index("--min-sharpe") + 1] == "1.5"
+    assert "--max-drawdown" in cmd
+    assert cmd[cmd.index("--max-drawdown") + 1] == "250.5"
+
+
+def test_benchmark_summary_without_thresholds(monkeypatch):
+    captured = _capture_run_cmd(monkeypatch)
+
+    exit_code = run_daily_workflow.main(["--benchmark-summary"])
+
+    assert exit_code == 0
+    assert captured, "run_cmd should be invoked"
+    cmd = captured[0]
+    assert "--min-sharpe" not in cmd
+    assert "--max-drawdown" not in cmd


### PR DESCRIPTION
## Summary
- add `--min-sharpe` and `--max-drawdown` options to `run_daily_workflow` so the CLI matches the benchmark summary script
- forward the optional thresholds when constructing the benchmark summary command
- cover the new behavior with unit tests and record the workflow update in `state.md`

## Testing
- python3 -m pytest


------
https://chatgpt.com/codex/tasks/task_e_68d7fe410234832aa67fa33a92237b7c