### PR TITLE
Handle rebuild index failures in benchmark runner

### DIFF
--- a/state.md
+++ b/state.md
@@ -14,3 +14,4 @@
 - 2024-06-06: `scripts/run_daily_workflow.py` に `--min-sharpe`/`--max-drawdown` を追加し、ベンチマーク要約呼び出しへ閾値を伝播するテストを新設。DoD: `python3 -m pytest` オールパスで、組み立てコマンドに閾値引数が含まれること。
 - 2024-06-07: ベースライン/ローリング run を再実行して Sharpe・最大DD 指標をレポートに含め、`report_benchmark_summary.py` で新指標が集計されることを確認。DoD: ベンチマーク run コマンド完走・サマリー更新後に `python3 -m pytest` を実行しオールパス。
 - 2024-06-08: `scripts/run_sim.py` のパラメータ保存に EV ゲート関連引数を追加し、`runs/index.csv` / `rebuild_runs_index.py` / テストを同期。DoD: `python3 -m pytest` オールパスで新列が確認できること。
+- 2024-06-09: `scripts/run_benchmark_runs.py` で `rebuild_runs_index.py` の失敗コード伝播とログ詳細出力を追加し、失敗時 JSON にエラー情報を含める回帰テストを作成。DoD: `python3 -m pytest` オールパスで失敗コードが伝播すること。


### PR DESCRIPTION
## Summary
- surface non-zero exits from rebuild_runs_index.py in run_benchmark_runs by capturing stdout/stderr, enriching the emitted JSON, and returning the failing code
- expand run_benchmark_runs tests with a regression case for rebuild failures and adjust subprocess stubs for the new capture arguments
- record the workflow update in state.md

## Testing
- python3 -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68d85f159180832a8ad6fd2a88a6a7d6