### PR TITLE
Propagate webhook flag to benchmark summary command

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ python3 scripts/optimize_params.py \
 
 ### 日次ワークフロー実行
 - `scripts/run_daily_workflow.py` でインジェスト、state 更新、ベンチマーク実行、レポート集約を順番に呼び出せる。
-- `--benchmarks` フラグは `scripts/run_benchmark_pipeline.py` を起動し、ベースライン/ローリング run → サマリー生成 → `ops/runtime_snapshot.json` の更新まで一括で実行する。`--min-sharpe`・`--max-drawdown`・`--benchmark-windows`・`--webhook` を指定すると、パイプライン全体へ同じ値が伝播する。
+- `--benchmarks` フラグは `scripts/run_benchmark_pipeline.py` を起動し、ベースライン/ローリング run → サマリー生成 → `ops/runtime_snapshot.json` の更新まで一括で実行する。`--min-sharpe`・`--max-drawdown`・`--benchmark-windows`・`--webhook` を指定すると、パイプライン全体へ同じ値が伝播する。`--benchmark-summary` 単体で実行した場合も、同じ引数が `scripts/report_benchmark_summary.py` へ伝搬し、Webhook が指定されていればまとめて通知される。
 - いずれかの工程が非ゼロ終了コードを返した場合はその時点で終了し、返り値として失敗コードをそのまま伝播する（例: `--benchmarks` で失敗した場合は `--benchmark-summary` へ進まずに同じコードで停止する）。
 
 ベンチマーク専用で実行したい場合は以下のように呼び出せる。

--- a/scripts/run_daily_workflow.py
+++ b/scripts/run_daily_workflow.py
@@ -109,6 +109,8 @@ def main(argv=None) -> int:
             cmd += ["--min-sharpe", str(args.min_sharpe)]
         if args.max_drawdown is not None:
             cmd += ["--max-drawdown", str(args.max_drawdown)]
+        if args.webhook:
+            cmd += ["--webhook", args.webhook]
         exit_code = run_cmd(cmd)
         if exit_code:
             return exit_code

--- a/state.md
+++ b/state.md
@@ -19,3 +19,4 @@
 - 2024-06-11: P1「state ヘルスチェック」タスクに着手。DoD: `check_state_health` 用 pytest 追加・履歴ローテーション/警告/Webhook 回帰テストが通り、`python3 -m pytest tests/test_check_state_health.py` を完走すること。
 - 2024-06-11 (完了): 追加テストで警告生成・履歴トリム・Webhook を検証し、`python3 -m pytest tests/test_check_state_health.py` がグリーン。docs/task_backlog.md へ進捗を反映。
 - 2024-06-12: ベンチマークパイプラインを `scripts/run_benchmark_pipeline.py` として追加し、Webhook 伝播・スナップショット更新・`run_daily_workflow.py --benchmarks` からの一括実行を整備。`tests/test_run_benchmark_pipeline.py` を含む関連 pytest を更新してグリーン確認。
+- 2024-06-13: `run_daily_workflow.py` からベンチマークサマリー呼び出し時にも Webhook/閾値を伝播させる対応を実装し、README を追記。`python3 -m pytest tests/test_run_daily_workflow.py` を実行して回帰確認。

--- a/tests/test_run_daily_workflow.py
+++ b/tests/test_run_daily_workflow.py
@@ -64,6 +64,25 @@ def test_benchmark_summary_without_thresholds(monkeypatch):
     assert cmd[cmd.index("--windows") + 1] == "365,180,90"
 
 
+def test_benchmark_summary_with_webhook(monkeypatch):
+    captured = _capture_run_cmd(monkeypatch)
+
+    exit_code = run_daily_workflow.main([
+        "--benchmark-summary",
+        "--webhook",
+        "https://example.com/summary",
+        "--benchmark-windows",
+        "120,30",
+    ])
+
+    assert exit_code == 0
+    assert captured, "run_cmd should be invoked"
+    cmd = captured[0]
+    assert "--webhook" in cmd
+    assert cmd[cmd.index("--webhook") + 1] == "https://example.com/summary"
+    assert cmd[cmd.index("--windows") + 1] == "120,30"
+
+
 def test_benchmarks_pipeline_arguments(monkeypatch):
     captured = _capture_run_cmd(monkeypatch)
 


### PR DESCRIPTION
## Summary
- propagate the webhook flag from run_daily_workflow to report_benchmark_summary when a benchmark summary run is requested
- extend the daily workflow test suite to cover webhook propagation and document the behavior in the README

## Testing
- python3 -m pytest tests/test_run_daily_workflow.py


------
https://chatgpt.com/codex/tasks/task_e_68d880e570fc832abdac77ab4f743724