### PR TITLE
Fix run_sim time window test to avoid MagicMock serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ print(metrics.as_dict())
 python3 scripts/run_sim.py --csv data/ohlc5m.csv --symbol USDJPY --mode conservative --equity 100000
 ```
 
+特定期間のみを対象にする場合は ISO8601 形式の `--start-ts` / `--end-ts` を指定します。
+
+```
+python3 scripts/run_sim.py --csv data/usdjpy_5m_2018-2024_utc.csv --symbol USDJPY --mode conservative \
+  --start-ts 2024-01-01T00:00:00Z --end-ts 2024-03-01T00:00:00Z
+```
+
 例: EV 閾値やセッション制限を調整した実行
 
 ```

--- a/docs/task_backlog.md
+++ b/docs/task_backlog.md
@@ -14,6 +14,7 @@
 - **state ヘルスチェック**: 最新 state から EV 下限、勝率 LCB、滑り推定値を抽出する `scripts/check_state_health.py` を活用し、結果を `ops/health/state_checks.json` に追記。逸脱時の通知/Runbook 追記を行う。
   - 2024-06-11: `check_state_health` の警告・履歴ローテーション・Webhook 送信を pytest で回帰テスト化し、デフォルト閾値 (勝率LCB/サンプル数/滑り上限) の期待挙動を明記。
 - **インシデントリプレイテンプレート**: 本番での負けトレードを `ops/incidents/` に保存し、同期間のリプレイを `scripts/run_sim.py --start-ts/--end-ts` で再実行する Notebook (`analysis/incident_review.ipynb`) にメモを残す。
+  - 2024-06-14: `scripts/run_sim.py` に `--start-ts` / `--end-ts` を追加し、README と pytest を更新。部分期間リプレイの準備が整った。
 
 ## P2: マルチ戦略ポートフォリオ化
 - **戦略マニフェスト整備**: スキャル/デイ/スイングの候補戦略ごとに、依存特徴量・セッション・リスク上限を YAML で定義し、ルーターが参照できるようにする (`configs/strategies/*.yaml`)。

--- a/state.md
+++ b/state.md
@@ -21,3 +21,5 @@
 - 2024-06-12: ベンチマークパイプラインを `scripts/run_benchmark_pipeline.py` として追加し、Webhook 伝播・スナップショット更新・`run_daily_workflow.py --benchmarks` からの一括実行を整備。`tests/test_run_benchmark_pipeline.py` を含む関連 pytest を更新してグリーン確認。
 - 2024-06-13: `run_daily_workflow.py` からベンチマークサマリー呼び出し時にも Webhook/閾値を伝播させる対応を実装し、README を追記。`python3 -m pytest tests/test_run_daily_workflow.py` を実行して回帰確認。
 - 2024-06-14: `run_daily_workflow.py` の最適化/レイテンシ/状態アーカイブコマンドで絶対パスを使用するよう更新し、pytest でコマンド引数に ROOT が含まれることを検証。
+- 2024-06-15: `scripts/run_sim.py` に `--start-ts` / `--end-ts` を追加し、部分期間のリプレイをテスト・README・バックログへ反映。DoD: pytest オールグリーンで Sharpe/最大DD 出力継続を確認。
+- 2024-06-16: `tests/test_run_sim_cli.py` の時間範囲テストで `BacktestRunner.run` をモック化した際に JSON へ MagicMock が混入する事象を調査し、ラップ関数で実体を返す形に修正。DoD: `python3 -m pytest` がグリーンで TypeError が再発しないこと。

--- a/tests/test_run_sim_cli.py
+++ b/tests/test_run_sim_cli.py
@@ -2,6 +2,7 @@ import json
 import os
 import tempfile
 import unittest
+from unittest import mock
 
 from scripts.run_sim import load_bars_csv, main as run_sim_main
 
@@ -52,6 +53,45 @@ class TestRunSimCLI(unittest.TestCase):
             ]
             rc = run_sim_main(args)
             self.assertEqual(rc, 0)
+            with open(json_out, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            self.assertIn("sharpe", data)
+            self.assertIn("max_drawdown", data)
+
+    def test_run_sim_respects_time_window(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = os.path.join(tmpdir, "bars.csv")
+            with open(csv_path, "w", encoding="utf-8") as f:
+                f.write(CSV_CONTENT)
+            json_out = os.path.join(tmpdir, "metrics.json")
+            args = [
+                "--csv", csv_path,
+                "--symbol", "USDJPY",
+                "--mode", "conservative",
+                "--equity", "100000",
+                "--json-out", json_out,
+                "--dump-max", "0",
+                "--no-auto-state",
+                "--no-ev-profile",
+                "--no-aggregate-ev",
+                "--start-ts", "2024-01-01T08:10:00Z",
+                "--end-ts", "2024-01-01T08:20:00Z",
+            ]
+            backtest_runner_cls = run_sim_main.__globals__["BacktestRunner"]
+            original_run = backtest_runner_cls.run
+            captured = {}
+
+            def _wrapped(self, bars, *run_args, **run_kwargs):
+                captured["bars"] = bars
+                return original_run(self, bars, *run_args, **run_kwargs)
+
+            with mock.patch.object(backtest_runner_cls, "run", autospec=True, side_effect=_wrapped) as patched_run:
+                rc = run_sim_main(args)
+            self.assertEqual(rc, 0)
+            patched_run.assert_called_once()
+            bars_arg = captured.get("bars")
+            self.assertIsNotNone(bars_arg)
+            self.assertEqual(len(bars_arg), 3)
             with open(json_out, "r", encoding="utf-8") as f:
                 data = json.load(f)
             self.assertIn("sharpe", data)


### PR DESCRIPTION
## Summary
- adjust the run_sim CLI time-window pytest to wrap BacktestRunner.run with a side-effect helper that preserves the real metrics object
- guard the captured bars argument lookup to ensure we assert on the filtered dataset without leaking MagicMock objects
- document the debugging outcome in state.md for future reference

## Testing
- python3 -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8972b3f5c832a8db7ff2803c75ac8