### PR TITLE
Add next task tracker to state log

### DIFF
--- a/state.md
+++ b/state.md
@@ -1,5 +1,16 @@
 # Work State Log
 
+## Next Task
+- Backlog Item: [P1: state ヘルスチェック](docs/task_backlog.md#p1-ローリング検証--健全性モニタリング)
+- Docs to Review: docs/task_backlog.md / docs/state_runbook.md
+- Definition of Done: Webhook/履歴ローテーション警告を含む state ヘルスチェックの回帰テストがグリーン。
+- Target Date: 2024-06-18
+
+### Checklist
+1. Update this block before starting work.
+2. Log results under `## Log` after completion.
+3. Refresh this block with the next backlog link.
+
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
 - Update this file after completing work to record outcomes, blockers, and next steps.


### PR DESCRIPTION
## Summary
- add a Next Task section to state.md with backlog link, documentation references, definition of done, and target date
- document the checklist loop for updating the state log between tasks

## Testing
- not run (documentation only)

## PR要約
- state.md に次タスクの記載枠と運用チェックリストを追記


------
https://chatgpt.com/codex/tasks/task_e_68d8a01a10fc832a9a955947da8c0dbb