### PR TITLE
Add workflow integration notes to task backlog

### DIFF
--- a/docs/task_backlog.md
+++ b/docs/task_backlog.md
@@ -2,6 +2,12 @@
 
 このバックログは「最新値動きを取り込みながら継続学習し、複数戦略ポートフォリオでシグナルを出す」ツールを実現するための優先順位付きタスク群です。各タスク完了時は成果物（コード/ドキュメント/レポート）へのリンクを追記してください。
 
+## ワークフロー統合
+
+各タスクに着手する前に、該当するバックログ項目を `state.md` の `Next Task` ブロックへ明示的に引き込み、進行中であることを記録してください。作業完了後は、成果ノートや反省点を `docs/todo_next.md` に反映し、`state.md` の完了ログと整合するよう同期します。
+
+- 例: `[P1-02] 2024-06-18 state.md ログ / docs/progress/phase1.md`
+
 ## P0: 即着手（オンデマンドインジェスト + 基盤整備）
 - ~~**state 更新ワーカー**~~ (完了): `scripts/update_state.py` に部分実行ワークフローを実装し、`BacktestRunner.run_partial` と状態スナップショット/EVアーカイブ連携を整備。`ops/state_archive/<strategy>/<symbol>/<mode>/` へ最新5件を保持し、更新後は `scripts/aggregate_ev.py` を自動起動するようにした。
 - ~~**runs/index 再構築スクリプト整備**~~ (完了): `scripts/rebuild_runs_index.py` が `scripts/run_sim.py` の出力列 (k_tr, gate/EV debug など) と派生指標 (win_rate, pnl_per_trade) を欠損なく復元し、`tests/test_rebuild_runs_index.py` で fixtures 検証を追加。

--- a/state.md
+++ b/state.md
@@ -23,3 +23,4 @@
 - 2024-06-14: `run_daily_workflow.py` の最適化/レイテンシ/状態アーカイブコマンドで絶対パスを使用するよう更新し、pytest でコマンド引数に ROOT が含まれることを検証。
 - 2024-06-15: `scripts/run_sim.py` に `--start-ts` / `--end-ts` を追加し、部分期間のリプレイをテスト・README・バックログへ反映。DoD: pytest オールグリーンで Sharpe/最大DD 出力継続を確認。
 - 2024-06-16: `tests/test_run_sim_cli.py` の時間範囲テストで `BacktestRunner.run` をモック化した際に JSON へ MagicMock が混入する事象を調査し、ラップ関数で実体を返す形に修正。DoD: `python3 -m pytest` がグリーンで TypeError が再発しないこと。
+- 2024-06-18: docs/task_backlog.md 冒頭にワークフロー統合指針を追記し、state.md / docs/todo_next.md 間の同期ルールと参照例を整備。


### PR DESCRIPTION
## Summary
- add a workflow integration subsection to docs/task_backlog.md so backlog usage stays aligned with state.md and docs/todo_next.md
- record the documentation guidance update in state.md for traceability

## Testing
- not run (documentation only)

## 概要
- docs/task_backlog.md にワークフロー同期ルールと参照例を追記
- state.md に同更新の記録を追加

------
https://chatgpt.com/codex/tasks/task_e_68d8a1b8714c832a8bb0d4b0b6d28eb3