### PR TITLE
Restructure P1 backlog tasks with individual DoD anchors

### DIFF
--- a/state.md
+++ b/state.md
@@ -5,8 +5,8 @@
 - Update this file after completing work to record outcomes, blockers, and next steps.
 
 ## Next Task
-- [P1-01] 2024-06-20 ローリング検証パイプライン — DoD: [docs/task_backlog.md#p1-ローリング検証--健全性モニタリング](docs/task_backlog.md#p1-ローリング検証--健全性モニタリング)
-- [P1-02] 2024-06-20 インシデントリプレイテンプレート — DoD: [docs/task_backlog.md#p1-ローリング検証--健全性モニタリング](docs/task_backlog.md#p1-ローリング検証--健全性モニタリング)
+- [P1-01] 2024-06-20 ローリング検証パイプライン — DoD: [docs/task_backlog.md#p1-01-ローリング検証パイプライン](docs/task_backlog.md#p1-01-ローリング検証パイプライン)
+- [P1-02] 2024-06-20 インシデントリプレイテンプレート — DoD: [docs/task_backlog.md#p1-02-インシデントリプレイテンプレート](docs/task_backlog.md#p1-02-インシデントリプレイテンプレート)
 
 ### 運用メモ
 - バックログから着手するタスクは先にこのリストへ追加し、ID・着手予定日・DoD リンクを明示する。


### PR DESCRIPTION
## Summary
- split the P1 backlog items into dedicated subsections with per-task DoD bullet lists and preserved progress notes
- formalize the state health check entry with its own DoD list for clarity and future linking
- update `state.md` to reference the new task-specific anchors instead of the shared heading

## Testing
- `python - <<'PY'
import re
import string
from collections import Counter

def slugify(text, counts):
    text = text.strip().lower()
    remove = ''.join(ch for ch in string.punctuation if ch not in '-')
    trans = str.maketrans({ch: ' ' for ch in remove})
    text = text.translate(trans)
    text = re.sub(r'\s+', '-', text)
    text = re.sub(r'-+', '-', text)
    slug = text
    counts[slug] += 1
    if counts[slug] > 1:
        slug = f"{slug}-{counts[slug]-1}"
    return slug

counts = Counter()
anchors = {}
with open('docs/task_backlog.md', encoding='utf-8') as f:
    for line in f:
        if line.startswith('#'):
            level = len(line) - len(line.lstrip('#'))
            if level >= 1:
                heading = line[level:].strip()
                slug = slugify(heading, counts)
                anchors[heading] = slug

for key in ['P1-01 ローリング検証パイプライン', 'P1-02 インシデントリプレイテンプレート']:
    print(key, anchors.get(key))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68d8a94c2c6c832ab003de236703e92a