### PR TITLE
Document Ready checklist vision prerequisites

### DIFF
--- a/docs/todo_next.md
+++ b/docs/todo_next.md
@@ -5,6 +5,7 @@
 - `state.md` に記録されていないアクティビティは、このファイルにも掲載しない方針です。新しい作業を始める前に `state.md` へ日付と目的を追加しましょう。
 
 ## Ready 昇格チェックリスト
+- 高レベルのビジョンガイド（例: [docs/logic_overview.md](docs/logic_overview.md), [docs/simulation_plan.md](docs/simulation_plan.md)）を再読し、昇格対象タスクが最新戦略方針と整合しているか確認する。
 - `docs/progress_phase*.md`（特に対象フェーズの記録）を確認し、未完了の前提条件や検証ギャップがないかレビューする。
 - 関連するランブック（例: `docs/state_runbook.md`, `docs/benchmark_runbook.md`）を再読し、必要なオペレーション手順が揃っているかを点検する。
 - バックログ該当項目の DoD を最新化し、関係チームへ通知済みであることを確認する。

--- a/state.md
+++ b/state.md
@@ -12,6 +12,7 @@
 - バックログから着手するタスクは先にこのリストへ追加し、ID・着手予定日・DoD リンクを明示する。
 - DoD を満たして完了したタスクは `## Log` に成果サマリを移し、`docs/todo_next.md` と整合するよう更新する。
 - 継続中に要調整点が出た場合はエントリ内に追記し、完了時にログへ移した後も追跡できるよう関連ドキュメントへリンクを残す。
+- 新規に `Next Task` へ追加する際は、方針整合性を確認するために [docs/logic_overview.md](docs/logic_overview.md) や [docs/simulation_plan.md](docs/simulation_plan.md) を参照し、必要なら関連メモへリンクする。
 
 ## Log
 - [P0-01] 2024-06-01: Initialized state tracking log and documented the review/update workflow rule.
@@ -34,3 +35,4 @@
 - [P1-02] 2024-06-16: `tests/test_run_sim_cli.py` の時間範囲テストで `BacktestRunner.run` をモック化した際に JSON へ MagicMock が混入する事象を調査し、ラップ関数で実体を返す形に修正。DoD: `python3 -m pytest` がグリーンで TypeError が再発しないこと。
 - [P1-04] 2024-06-18: docs/task_backlog.md 冒頭にワークフロー統合指針を追記し、state.md / docs/todo_next.md 間の同期ルールと参照例を整備。
 - [P1-04] 2024-06-19: `docs/todo_next.md` を In Progress / Ready / Pending Review / Archive セクション構成へ刷新し、`state.md` のログ日付とバックログ連携を明示。DoD: ガイドライン/チェックリストの追記と過去成果のアーカイブ保持。
+- [P1-04] 2024-06-20: Ready 昇格チェックリストにビジョンガイド再読を追加し、`Next Task` 登録時の参照先として `docs/logic_overview.md` / `docs/simulation_plan.md` を明記。


### PR DESCRIPTION
## Summary
- extend the Ready promotion checklist to require reviewing docs/logic_overview.md and docs/simulation_plan.md before advancing tasks
- remind Next Task logging to reference the same vision guides within state.md
- capture the documentation tweak in the state log for traceability

## Testing
- not run (docs only)

## 備考
- Ready昇格チェックリストとNext Task登録手順でビジョン文書再確認を明示しました。


------
https://chatgpt.com/codex/tasks/task_e_68d8aa565660832a95b0ce5a1d1eb921