### PR TITLE
Add templated Next Task blocks to lifecycle workflow

### DIFF
--- a/docs/state_runbook.md
+++ b/docs/state_runbook.md
@@ -22,6 +22,7 @@ EV ゲートや滑り学習などの内部状態を `state.json` として保存
 - **ヘルスチェック:** `scripts/check_state_health.py` を日次（`run_daily_workflow.py --state-health`）で実行し、結果を `ops/health/state_checks.json` に追記する。勝率 LCB・バケット別サンプル・滑り係数を監視し、警告が出た場合は `--webhook` で Slack 等へ通知。`--fail-on-warning` を CI/バッチに組み込むと異常時にジョブを停止できる。
 - **履歴保持:** 標準では直近 90 レコードを保持する。上限を変更する場合は `--history-limit` を調整する。履歴の可視化は Notebook or BI で `checked_at` を横軸に `ev_win_lcb` やワーニング件数をプロットする。
 - **タスク同期:** `state.md` と `docs/todo_next.md` の整合を保つ際は `scripts/manage_task_cycle.py` を優先利用する。`start-task` で Ready 登録→In Progress 昇格を一括実行し、既存アンカー検知で重複記録を抑止する。完了時は `finish-task` でまとめてログとアーカイブへ送る。いずれも `--dry-run` でコマンド内容を確認してから本実行する。
+- **テンプレ適用:** `state.md` の `## Next Task` へ手動で項目を追加する場合は、必ず [docs/templates/next_task_entry.md](templates/next_task_entry.md) を貼り付けてアンカー・参照リンク・疑問点スロットを埋める。`scripts/manage_task_cycle.py start-task` を使うとテンプレが自動挿入されるため、手動調整より優先する。
 - **DoD チェックリスト:** Ready へ昇格する際は [docs/templates/dod_checklist.md](templates/dod_checklist.md) をコピーし、`docs/checklists/<task-slug>.md` として保存する。テンプレート内の Ready チェック項目は昇格時点で状態を更新し、バックログ固有の DoD 箇条書きをチェックボックスへ転記する。進行中は該当タスクの `docs/todo_next.md` エントリからリンクし、完了後も `docs/checklists/` に履歴として保管する。
 
 ## 実装メモ

--- a/docs/templates/next_task_entry.md
+++ b/docs/templates/next_task_entry.md
@@ -1,0 +1,11 @@
+# Next Task Entry Template
+
+使用方法: `state.md` の `## Next Task` や `docs/todo_next.md` に新規エントリを追加するとき、このブロックをコピーしてプレースホルダを埋めてください。
+
+  - Backlog Anchor: [{{TITLE}} ({{TASK_ID}})]({{BACKLOG_ANCHOR}})
+  - Vision / Runbook References:
+    - [docs/logic_overview.md](docs/logic_overview.md)
+    - [docs/simulation_plan.md](docs/simulation_plan.md)
+    - 主要ランブック: {{RUNBOOK_LINKS}}
+  - Pending Questions:
+    - [ ] {{PENDING_QUESTIONS}}

--- a/scripts/manage_task_cycle.py
+++ b/scripts/manage_task_cycle.py
@@ -285,6 +285,12 @@ def main(argv: Sequence[str] | None = None) -> None:
             params = _collect_start_params(args)
             commands = _build_start_commands(params)
             _run_commands(commands, dry_run=args.dry_run)
+            if not args.dry_run:
+                sync.apply_next_task_template(
+                    params.anchor,
+                    title=params.title,
+                    task_id=params.task_id,
+                )
         elif args.command == "finish-task":
             params = _collect_finish_params(args)
             commands = _build_finish_commands(params)
@@ -292,6 +298,8 @@ def main(argv: Sequence[str] | None = None) -> None:
         else:  # pragma: no cover - argparse prevents this
             parser.error(f"Unsupported command {args.command}")
     except InputError as exc:
+        parser.error(str(exc))
+    except sync.SyncError as exc:
         parser.error(str(exc))
 
 

--- a/state.md
+++ b/state.md
@@ -39,3 +39,4 @@
 - [P1-02] 2024-06-21: incident ノートテンプレを整備し、ops/incidents/ へ雛形を配置. DoD: [docs/task_backlog.md#p1-02-インシデントリプレイテンプレート](docs/task_backlog.md#p1-02-インシデントリプレイテンプレート).
 - [P1-04] 2024-06-22: `scripts/manage_task_cycle.py` を追加し、`sync_task_docs.py` の record/promote/complete をラップする `start-task` / `finish-task` を整備。README / state_runbook を更新し、pytest でドライラン出力を検証。
 - [P1-04] 2025-09-28: Ready/DoD チェックリスト テンプレートと `sync_task_docs.py` の自動リンク挿入を整備し、`docs/todo_next.md` / `docs/state_runbook.md` に運用手順を追記。DoD: [docs/task_backlog.md#ワークフロー統合ガイド](docs/task_backlog.md#ワークフロー統合ガイド).
+- [P1-04] 2025-09-28: `docs/templates/next_task_entry.md` を新設し、`manage_task_cycle.py start-task` がテンプレを自動適用するよう拡張。DoD: [docs/task_backlog.md#ワークフロー統合ガイド](docs/task_backlog.md#ワークフロー統合ガイド).

--- a/tests/test_sync_task_template.py
+++ b/tests/test_sync_task_template.py
@@ -1,0 +1,98 @@
+from pathlib import Path
+
+import scripts.sync_task_docs as sync
+
+
+ANCHOR = "docs/task_backlog.md#p9-99-test-task"
+
+
+def _write_state(path: Path) -> None:
+    path.write_text(
+        """# Work State Log
+
+## Workflow Rule
+- dummy
+
+## Next Task
+- [P9-99] 2024-06-25 Test Task — DoD: [docs/task_backlog.md#p9-99-test-task](docs/task_backlog.md#p9-99-test-task)
+
+## Log
+""",
+        encoding="utf-8",
+    )
+
+
+def _write_docs(path: Path) -> None:
+    path.write_text(
+        """# 次のアクション
+
+## Current Pipeline
+
+### In Progress
+- **Test Task** — `state.md` 2024-06-25 <!-- anchor: docs/task_backlog.md#p9-99-test-task -->
+  - DoD チェックリスト: [docs/templates/dod_checklist.md](docs/templates/dod_checklist.md) を [docs/checklists/p9-99.md](docs/checklists/p9-99.md) にコピーし、進捗リンクを更新する。
+""",
+        encoding="utf-8",
+    )
+
+
+def _write_template(path: Path) -> None:
+    path.write_text(
+        """  - Backlog Anchor: [{{TITLE}} ({{TASK_ID}})]({{BACKLOG_ANCHOR}})
+  - Vision / Runbook References:
+    - [docs/logic_overview.md](docs/logic_overview.md)
+    - [docs/simulation_plan.md](docs/simulation_plan.md)
+    - 主要ランブック: {{RUNBOOK_LINKS}}
+  - Pending Questions:
+    - [ ] {{PENDING_QUESTIONS}}
+""",
+        encoding="utf-8",
+    )
+
+
+def test_apply_next_task_template_updates_state_and_docs(tmp_path, monkeypatch):
+    state_path = tmp_path / "state.md"
+    docs_path = tmp_path / "todo_next.md"
+    template_path = tmp_path / "next_task_template.md"
+
+    _write_state(state_path)
+    _write_docs(docs_path)
+    _write_template(template_path)
+
+    monkeypatch.setattr(sync, "STATE_PATH", state_path)
+    monkeypatch.setattr(sync, "DOCS_PATH", docs_path)
+
+    sync.apply_next_task_template(
+        ANCHOR,
+        title="Test Task",
+        task_id="P9-99",
+        template_path=template_path,
+        runbook_links="[docs/state_runbook.md](docs/state_runbook.md)",
+        pending_questions="Clarify EV guardrails.",
+    )
+
+    state_lines = state_path.read_text(encoding="utf-8").splitlines()
+    docs_lines = docs_path.read_text(encoding="utf-8").splitlines()
+
+    assert any("Backlog Anchor: [Test Task (P9-99)]" in line for line in state_lines)
+    assert any("docs/logic_overview.md" in line for line in state_lines)
+    assert any("Clarify EV guardrails." in line for line in state_lines)
+
+    in_progress_index = docs_lines.index("### In Progress")
+    block_lines = docs_lines[in_progress_index + 1 :]
+    assert any("Backlog Anchor: [Test Task (P9-99)]" in line for line in block_lines)
+    assert any("docs/simulation_plan.md" in line for line in block_lines)
+    assert any("Clarify EV guardrails." in line for line in block_lines)
+
+    # Idempotent re-run should not duplicate template sections
+    sync.apply_next_task_template(
+        ANCHOR,
+        title="Test Task",
+        task_id="P9-99",
+        template_path=template_path,
+        runbook_links="[docs/state_runbook.md](docs/state_runbook.md)",
+        pending_questions="Clarify EV guardrails.",
+    )
+
+    state_lines_second = state_path.read_text(encoding="utf-8").splitlines()
+    assert state_lines_second.count("  - Backlog Anchor: [Test Task (P9-99)](docs/task_backlog.md#p9-99-test-task)") == 1


### PR DESCRIPTION
## Summary
- add a reusable docs/templates/next_task_entry.md snippet so Next Task entries capture anchors, references, and open questions
- document the template requirement in the state runbook and log the workflow integration update in state.md
- extend manage_task_cycle start-task plus sync_task_docs to handle multi-line Next Task blocks, auto-apply the template, and expose supporting helpers with tests

## Testing
- python3 -m pytest tests/test_manage_task_cycle.py tests/test_sync_task_template.py

------
https://chatgpt.com/codex/tasks/task_e_68d8ec033954832a97502fec4aa1b2ac