### PR TITLE
Document Codex session workflow

### DIFF
--- a/docs/codex_workflow.md
+++ b/docs/codex_workflow.md
@@ -1,0 +1,73 @@
+# Codex Session Operations Guide
+
+This guide summarizes the routine Codex agents should follow to keep tasks moving continuously while maintaining alignment between `state.md`, `docs/task_backlog.md`, and `docs/todo_next.md`. It also highlights how to rely on `scripts/manage_task_cycle.py` so that each session preserves the same context.
+
+## Core References
+- **state.md** — Primary source for the latest `Next Task`, completion log, and operational notes. Always read and update it before and after work.
+- **docs/task_backlog.md** — Lists priorities and definitions of done. Use its anchors from `state.md`/`docs/todo_next.md` to share progress links.
+- **docs/todo_next.md** — Organizes practical next actions across In Progress, Ready, Pending Review, and Archive.
+- **docs/templates/** — Home of reusable templates such as `next_task_entry.md` and `dod_checklist.md` that Codex applies automatically.
+- **docs/state_runbook.md** — Baseline operational runbook for state synchronization and archive handling.
+
+## Pre-session Routine
+1. **Review the current situation**  
+   Read `state.md`, focusing on the `Next Task` entry and any outstanding questions or linked checklists.
+2. **Confirm the backlog anchor**  
+   Pick the target task from `docs/task_backlog.md`, record its DoD, and verify whether it is already marked Ready in `docs/todo_next.md`.
+3. **Prepare templates**  
+   When adding a new `Next Task`, start from `docs/templates/next_task_entry.md`. For Ready tasks, duplicate `docs/templates/dod_checklist.md` into `docs/checklists/<task-slug>.md`.
+4. **Dry-run the start command**  
+   Execute the following command with `--dry-run` to validate anchors and dates before making real changes.
+   ```bash
+   python3 scripts/manage_task_cycle.py --dry-run start-task \
+       --anchor <docs/task_backlog.md#anchor> \
+       --record-date <YYYY-MM-DD> \
+       --promote-date <YYYY-MM-DD> \
+       --task-id <ID> \
+       --title "<Task Title>" \
+       --state-note "<State entry memo>" \
+       --doc-note "<docs/todo_next.md memo>" \
+       --doc-section <Ready|In Progress>
+   ```
+   After confirming the preview, rerun the command without `--dry-run` to populate `state.md` and `docs/todo_next.md` with the appropriate template blocks.
+
+## Task Execution Loop
+### 1. At task start
+- Complete the template block inserted in `state.md` by summarizing context, external links, and open questions.
+- Add references to related runbooks or specifications (for example, `docs/logic_overview.md`) when extra background is required.
+- For any new subtasks, append anchor-backed notes to `docs/task_backlog.md` and cross-link them from `state.md`.
+
+### 2. During implementation and validation
+- Check the `AGENTS.md` file in each directory before editing to respect style and testing requirements.
+- Record insights or unresolved issues in the active task memo inside `state.md`, or in the relevant entry within `docs/todo_next.md`.
+- After significant changes, run `python3 -m pytest` or the appropriate CLI command. Capture the executed commands in your notes so the next session can reproduce them.
+
+### 3. Closing the task
+1. Run `python3 scripts/manage_task_cycle.py --dry-run finish-task ...` to preview what will be moved into the log.
+   ```bash
+   python3 scripts/manage_task_cycle.py --dry-run finish-task \
+       --anchor <docs/task_backlog.md#anchor> \
+       --date <YYYY-MM-DD> \
+       --note "<Completion summary for state.md log>" \
+       --task-id <ID>
+   ```
+2. If the dry run looks correct, rerun without `--dry-run` so `state.md` (`## Log`) and `docs/todo_next.md` update in tandem.
+3. Update the DoD checklist, archive it when done, and add links to `docs/task_backlog.md` or the relevant runbook.
+4. Provide a Japanese summary in the final Codex response, including executed test commands and any follow-up actions.
+
+## Ongoing Tips
+- **Chaining tasks:** List candidate follow-up tasks in the memo section of `state.md`; reuse these notes when preparing the next `start-task` command.
+- **Tracking questions:** Log open questions inside `docs/todo_next.md`. Move them to Archive once resolved so the conversation history stays searchable.
+- **Updating scripts:** Whenever `scripts/manage_task_cycle.py` or `scripts/sync_task_docs.py` changes, capture new dry-run output samples in `docs/state_runbook.md` or related READMEs so Codex can adopt new flags.
+- **Commits and PRs:** Keep commit messages and PR descriptions in English. Summaries sent back to collaborators should remain in Japanese per repo conventions.
+
+## Quick Reference
+| Action | Recommended command |
+| --- | --- |
+| Start task dry run | `python3 scripts/manage_task_cycle.py --dry-run start-task --anchor docs/task_backlog.md#<anchor> ...` |
+| Finish task dry run | `python3 scripts/manage_task_cycle.py --dry-run finish-task --anchor docs/task_backlog.md#<anchor> ...` |
+| Create DoD checklist | `cp docs/templates/dod_checklist.md docs/checklists/<task-slug>.md` |
+| Review the state runbook | `open docs/state_runbook.md` |
+| Run tests | `python3 -m pytest` |
+
+Following this guide keeps `state.md` and the documents in `docs/` synchronized, preserving continuity and reproducibility across Codex sessions.

--- a/docs/state_runbook.md
+++ b/docs/state_runbook.md
@@ -21,7 +21,7 @@ EV ゲートや滑り学習などの内部状態を `state.json` として保存
 - **EVプロファイル:** `scripts/aggregate_ev.py --strategy ... --symbol ... --mode ...` を使うと、アーカイブ済み state から長期/直近期の期待値統計を集約し、`configs/ev_profiles/` に YAML プロファイルを生成できます。`run_sim.py` は該当プロファイルを自動ロードして EV バケットをシードします（`--no-ev-profile` で無効化可能）。
 - **ヘルスチェック:** `scripts/check_state_health.py` を日次（`run_daily_workflow.py --state-health`）で実行し、結果を `ops/health/state_checks.json` に追記する。勝率 LCB・バケット別サンプル・滑り係数を監視し、警告が出た場合は `--webhook` で Slack 等へ通知。`--fail-on-warning` を CI/バッチに組み込むと異常時にジョブを停止できる。
 - **履歴保持:** 標準では直近 90 レコードを保持する。上限を変更する場合は `--history-limit` を調整する。履歴の可視化は Notebook or BI で `checked_at` を横軸に `ev_win_lcb` やワーニング件数をプロットする。
-- **タスク同期:** `state.md` と `docs/todo_next.md` の整合を保つ際は `scripts/manage_task_cycle.py` を優先利用する。`start-task` で Ready 登録→In Progress 昇格を一括実行し、既存アンカー検知で重複記録を抑止する。完了時は `finish-task` でまとめてログとアーカイブへ送る。いずれも `--dry-run` でコマンド内容を確認してから本実行する。
+- **タスク同期:** `state.md` と `docs/todo_next.md` の整合を保つ際は `scripts/manage_task_cycle.py` を優先利用する。`start-task` で Ready 登録→In Progress 昇格を一括実行し、既存アンカー検知で重複記録を抑止する。完了時は `finish-task` でまとめてログとアーカイブへ送る。いずれも `--dry-run` でコマンド内容を確認してから本実行する。Codex セッションにおける具体的な開始前チェックや終了処理は [docs/codex_workflow.md](codex_workflow.md) を参照する。
 - **テンプレ適用:** `state.md` の `## Next Task` へ手動で項目を追加する場合は、必ず [docs/templates/next_task_entry.md](templates/next_task_entry.md) を貼り付けてアンカー・参照リンク・疑問点スロットを埋める。`scripts/manage_task_cycle.py start-task` を使うとテンプレが自動挿入されるため、手動調整より優先する。
 - **DoD チェックリスト:** Ready へ昇格する際は [docs/templates/dod_checklist.md](templates/dod_checklist.md) をコピーし、`docs/checklists/<task-slug>.md` として保存する。テンプレート内の Ready チェック項目は昇格時点で状態を更新し、バックログ固有の DoD 箇条書きをチェックボックスへ転記する。進行中は該当タスクの `docs/todo_next.md` エントリからリンクし、完了後も `docs/checklists/` に履歴として保管する。
 

--- a/docs/task_backlog.md
+++ b/docs/task_backlog.md
@@ -8,6 +8,17 @@
 
 - 例: `[P1-02] 2024-06-18 state.md ログ / docs/progress/phase1.md`
 
+### Codex Session Operations Guide
+Document the repeatable workflow that lets Codex keep `state.md`, `docs/todo_next.md`, and `docs/task_backlog.md` synchronized across sessions, including how to use the supporting scripts and templates.
+
+**DoD**
+- `docs/codex_workflow.md` explains pre-session checks, the execution loop, wrap-up steps, and how to apply the shared templates.
+- The guide covers dry-run and live usage of `scripts/manage_task_cycle.py` for keeping state/doc updates in lockstep.
+- Links to related runbooks and templates are included so future sessions can reproduce the same procedure.
+
+**Progress Notes**
+- 2025-09-29: Added `docs/codex_workflow.md` to consolidate operational guidance for Codex agents and clarified the relationship with `docs/state_runbook.md` and the template directory.
+
 ## P0: 即着手（オンデマンドインジェスト + 基盤整備）
 - ~~**state 更新ワーカー**~~ (完了): `scripts/update_state.py` に部分実行ワークフローを実装し、`BacktestRunner.run_partial` と状態スナップショット/EVアーカイブ連携を整備。`ops/state_archive/<strategy>/<symbol>/<mode>/` へ最新5件を保持し、更新後は `scripts/aggregate_ev.py` を自動起動するようにした。
 - ~~**runs/index 再構築スクリプト整備**~~ (完了): `scripts/rebuild_runs_index.py` が `scripts/run_sim.py` の出力列 (k_tr, gate/EV debug など) と派生指標 (win_rate, pnl_per_trade) を欠損なく復元し、`tests/test_rebuild_runs_index.py` で fixtures 検証を追加。

--- a/docs/todo_next.md
+++ b/docs/todo_next.md
@@ -22,8 +22,8 @@
 ### Ready
 
 ### Pending Review
-- **ワークフロー統合ガイド**（バックログ: `docs/task_backlog.md` → 「ワークフロー統合」セクション） — `state.md` 2024-06-18 <!-- anchor: docs/task_backlog.md#ワークフロー統合ガイド -->
-  - `docs/todo_next.md` と `state.md` の同期ルール追記を実施済み。レビューで運用フローへの適用可否を確認し、承認後に Archive へ移動する。
+- **Workflow Integration Guide** (Backlog: `docs/task_backlog.md` → "ワークフロー統合" section) — `state.md` 2024-06-18, 2025-09-29 <!-- anchor: docs/task_backlog.md#codex-session-operations-guide -->
+  - Updated the synchronization rules between `docs/todo_next.md` and `state.md`. Added `docs/codex_workflow.md` to capture Codex session procedures. Confirm readiness for adoption before moving to Archive.
 
 ## Archive（達成済み）
 - ~~**目標指数の定義**~~ ✅ — `state.md` 2024-06-01 <!-- anchor: docs/task_backlog.md#目標指数の定義 -->

--- a/state.md
+++ b/state.md
@@ -40,3 +40,4 @@
 - [P1-04] 2024-06-22: `scripts/manage_task_cycle.py` を追加し、`sync_task_docs.py` の record/promote/complete をラップする `start-task` / `finish-task` を整備。README / state_runbook を更新し、pytest でドライラン出力を検証。
 - [P1-04] 2025-09-28: Ready/DoD チェックリスト テンプレートと `sync_task_docs.py` の自動リンク挿入を整備し、`docs/todo_next.md` / `docs/state_runbook.md` に運用手順を追記。DoD: [docs/task_backlog.md#ワークフロー統合ガイド](docs/task_backlog.md#ワークフロー統合ガイド).
 - [P1-04] 2025-09-28: `docs/templates/next_task_entry.md` を新設し、`manage_task_cycle.py start-task` がテンプレを自動適用するよう拡張。DoD: [docs/task_backlog.md#ワークフロー統合ガイド](docs/task_backlog.md#ワークフロー統合ガイド).
+- [P1-04] 2025-09-29: Published `docs/codex_workflow.md` to outline Codex session operations and clarified references to `docs/state_runbook.md` and the shared templates. DoD: [docs/task_backlog.md#codex-session-operations-guide](docs/task_backlog.md#codex-session-operations-guide).


### PR DESCRIPTION
## Summary
- add a Codex session operations guide describing pre-work checks, task execution loop, and close-out steps
- link the new guide from the state runbook and register the backlog/todo entries for workflow integration
- log the documentation update in `state.md` for P1-04 tracking

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d8f4c682f4832abc75f598eaaeab2c