### PR TITLE
Normalize negative max drawdown CLI thresholds

### DIFF
--- a/state.md
+++ b/state.md
@@ -42,3 +42,4 @@
 - [P1-04] 2025-09-28: `docs/templates/next_task_entry.md` を新設し、`manage_task_cycle.py start-task` がテンプレを自動適用するよう拡張。DoD: [docs/task_backlog.md#ワークフロー統合ガイド](docs/task_backlog.md#ワークフロー統合ガイド).
 - [P1-04] 2025-09-29: Published `docs/codex_workflow.md` to outline Codex session operations and clarified references to `docs/state_runbook.md` and the shared templates. DoD: [docs/task_backlog.md#codex-session-operations-guide](docs/task_backlog.md#codex-session-operations-guide).
 - [P1-01] 2025-09-28: Normalized benchmark summary max drawdown thresholds to accept negative CLI inputs, added regression coverage, and revalidated with targeted pytest.
+- [P1-01] 2025-09-29: Refined drawdown threshold normalization via helper, captured warning logs for negative CLI input in regression tests, and reran targeted pytest & CLI verification.

--- a/tests/test_report_benchmark_summary.py
+++ b/tests/test_report_benchmark_summary.py
@@ -96,11 +96,16 @@ class TestReportBenchmarkSummary(unittest.TestCase):
                 "-200",
             ]
 
-            rc = rbs.main(args_with_negative_threshold)
+            with self.assertLogs(rbs.LOGGER, level="WARNING") as log_ctx:
+                rc = rbs.main(args_with_negative_threshold)
             self.assertEqual(rc, 0)
             payload = json.loads(output_path.read_text())
             joined = " ".join(payload["warnings"])
             self.assertNotIn("max_drawdown", joined)
+            self.assertTrue(
+                any("negative --max-drawdown" in message for message in log_ctx.output),
+                msg=f"Expected normalization warning in logs, got {log_ctx.output}",
+            )
 
     def test_main_sends_webhook_when_warnings_present(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
- extract a helper to normalize max drawdown thresholds so negative CLI inputs are converted safely
- ensure normalization emits a logger warning without polluting the summary warning payload
- extend regression coverage to assert the logged warning and absence of threshold warnings for negative inputs, updating state tracking notes

## Testing
- python3 -m pytest tests/test_report_benchmark_summary.py
- python3 scripts/report_benchmark_summary.py --symbol USDJPY --mode conservative --reports-dir reports --windows 365,180,90 --json-out /tmp/benchmark_summary.json --max-drawdown -200 --min-sharpe 0.5

## 日本語サマリ
- 最大DD閾値の正規化ヘルパーを追加し、負のCLI入力をログ警告付きで吸収
- 正規化した閾値がサマリ警告へ混入しないことをテストで担保
- state.md に今回の調整と検証コマンドの実行を追記

------
https://chatgpt.com/codex/tasks/task_e_68d904755008832a94f1fe99c7cd2605