### PR TITLE
Refine task lifecycle templating and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ python3 scripts/manage_task_cycle.py --dry-run start-task \
     --title "ローリング検証パイプライン" \
     --state-note "Sharpe/DD 指標のローテーション検証を開始" \
     --doc-note "チェックリスト整備とローリングrunの引数洗い出し" \
-    --doc-section Ready
+    --doc-section Ready \
+    --runbook-links "[docs/benchmark_runbook.md](docs/benchmark_runbook.md)" \
+    --pending-questions "Rollingサマリーの更新タイミングを決める"
 
 # 完了処理（In Progress → Archive）
 python3 scripts/manage_task_cycle.py --dry-run finish-task \

--- a/docs/codex_workflow.md
+++ b/docs/codex_workflow.md
@@ -27,9 +27,13 @@ This guide summarizes the routine Codex agents should follow to keep tasks movin
        --title "<Task Title>" \
        --state-note "<State entry memo>" \
        --doc-note "<docs/todo_next.md memo>" \
-       --doc-section <Ready|In Progress>
+       --doc-section <Ready|In Progress> \
+       [--runbook-links "<Markdown links for runbooks>"] \
+       [--pending-questions "<Key questions to track>"]
    ```
    After confirming the preview, rerun the command without `--dry-run` to populate `state.md` and `docs/todo_next.md` with the appropriate template blocks.
+   - Use `--runbook-links` to override the default `[docs/state_runbook.md](docs/state_runbook.md)` reference when another runbook is more relevant.
+   - Provide `--pending-questions` to seed the checklist item that appears under "Pending Questions" in the template so the next session inherits the right context.
 
 ## Task Execution Loop
 ### 1. At task start

--- a/docs/todo_next.md
+++ b/docs/todo_next.md
@@ -18,6 +18,7 @@
 - **ローリング検証パイプライン**（バックログ: `docs/task_backlog.md` → P1「ローリング検証 + 健全性モニタリング」） — `state.md` 2024-06-12, 2024-06-13, 2024-06-14, 2024-06-15, 2024-06-16 <!-- anchor: docs/task_backlog.md#p1-01-ローリング検証パイプライン -->
   - `scripts/run_benchmark_pipeline.py` の整備と `run_daily_workflow.py` 連携、期間指定リプレイ (`--start-ts` / `--end-ts`) の確認を継続中。
   - 次ステップ: ベンチマークランのローリング更新自動化と Sharpe / 最大 DD 指標の回帰監視強化。
+  - 2025-09-30: `manage_task_cycle.py start-task` に runbook/pending 資料の上書きオプションを追加し、`sync_task_docs.py` のテンプレ適用を共通ヘルパーへ整理。`docs/codex_workflow.md` と README の手順を更新済み。
 
 ### Ready
 

--- a/scripts/manage_task_cycle.py
+++ b/scripts/manage_task_cycle.py
@@ -44,6 +44,8 @@ class StartParams:
     doc_note: str | None
     doc_section: str
     skip_record: bool
+    runbook_links: str | None
+    pending_questions: str | None
 
 
 @dataclass
@@ -174,6 +176,8 @@ def _collect_start_params(args: argparse.Namespace) -> StartParams:
         raise InputError("Docs section must be one of Ready, In Progress, Pending Review")
 
     skip_record = bool(args.skip_record)
+    runbook_links = args.runbook_links
+    pending_questions = args.pending_questions
     return StartParams(
         anchor=anchor,
         record_date=_parse_date(record_date),
@@ -184,6 +188,8 @@ def _collect_start_params(args: argparse.Namespace) -> StartParams:
         doc_note=doc_note,
         doc_section=doc_section,
         skip_record=skip_record,
+        runbook_links=runbook_links,
+        pending_questions=pending_questions,
     )
 
 
@@ -266,6 +272,18 @@ def build_parser() -> argparse.ArgumentParser:
     start.add_argument("--doc-note", help="Optional docs bullet appended under the task block")
     start.add_argument("--doc-section", choices=["Ready", "In Progress", "Pending Review"], help="Docs section used when recording")
     start.add_argument("--skip-record", action="store_true", help="Skip the record step even if the anchor is missing")
+    start.add_argument(
+        "--runbook-links",
+        help=(
+            "Optional Markdown list overriding the default runbook references in the next-task template"
+        ),
+    )
+    start.add_argument(
+        "--pending-questions",
+        help=(
+            "Optional text used for the pending-questions checklist in the next-task template"
+        ),
+    )
 
     finish = subparsers.add_parser("finish-task", help="Mark a task as completed")
     finish.add_argument("--anchor", help="Task DoD anchor (docs/task_backlog.md#...)")
@@ -290,6 +308,8 @@ def main(argv: Sequence[str] | None = None) -> None:
                     params.anchor,
                     title=params.title,
                     task_id=params.task_id,
+                    runbook_links=params.runbook_links,
+                    pending_questions=params.pending_questions,
                 )
         elif args.command == "finish-task":
             params = _collect_finish_params(args)

--- a/state.md
+++ b/state.md
@@ -6,6 +6,14 @@
 
 ## Next Task
 - [P1-01] 2024-06-20 ローリング検証パイプライン — DoD: [docs/task_backlog.md#p1-01-ローリング検証パイプライン](docs/task_backlog.md#p1-01-ローリング検証パイプライン)
+  - Backlog Anchor: [ローリング検証パイプライン (P1-01)](docs/task_backlog.md#p1-01-ローリング検証パイプライン)
+  - Vision / Runbook References:
+    - [docs/logic_overview.md](docs/logic_overview.md)
+    - [docs/simulation_plan.md](docs/simulation_plan.md)
+    - 主要ランブック: [docs/benchmark_runbook.md](docs/benchmark_runbook.md)
+  - Pending Questions:
+    - [ ] ローリング365/180/90Dレポートの更新頻度とアラート閾値をどう連動させるか整理する。
+  - 2025-09-30: `manage_task_cycle.py` の `start-task` で runbook/pending 指定を許可し、`sync_task_docs.py` のテンプレ統合処理をリファクタリング。テンプレ適用後に state/docs 双方へ同じチェックリストが維持されることを手動確認。
 
 ### 運用メモ
 - バックログから着手するタスクは先にこのリストへ追加し、ID・着手予定日・DoD リンクを明示する。

--- a/tests/test_sync_task_template.py
+++ b/tests/test_sync_task_template.py
@@ -36,6 +36,20 @@ def _write_docs(path: Path) -> None:
     )
 
 
+def _write_ready_docs(path: Path) -> None:
+    path.write_text(
+        """# 次のアクション
+
+## Current Pipeline
+
+### Ready
+- **Test Task** — `state.md` 2024-06-25 <!-- anchor: docs/task_backlog.md#p9-99-test-task -->
+  - DoD チェックリスト: [docs/templates/dod_checklist.md](docs/templates/dod_checklist.md) を [docs/checklists/p9-99.md](docs/checklists/p9-99.md) にコピーし、進捗リンクを更新する。
+""",
+        encoding="utf-8",
+    )
+
+
 def _write_template(path: Path) -> None:
     path.write_text(
         """  - Backlog Anchor: [{{TITLE}} ({{TASK_ID}})]({{BACKLOG_ANCHOR}})
@@ -96,3 +110,34 @@ def test_apply_next_task_template_updates_state_and_docs(tmp_path, monkeypatch):
 
     state_lines_second = state_path.read_text(encoding="utf-8").splitlines()
     assert state_lines_second.count("  - Backlog Anchor: [Test Task (P9-99)](docs/task_backlog.md#p9-99-test-task)") == 1
+
+
+def test_apply_next_task_template_defaults_ready_section(tmp_path, monkeypatch):
+    state_path = tmp_path / "state.md"
+    docs_path = tmp_path / "todo_next.md"
+    template_path = tmp_path / "next_task_template.md"
+
+    _write_state(state_path)
+    _write_ready_docs(docs_path)
+    _write_template(template_path)
+
+    monkeypatch.setattr(sync, "STATE_PATH", state_path)
+    monkeypatch.setattr(sync, "DOCS_PATH", docs_path)
+
+    sync.apply_next_task_template(
+        ANCHOR,
+        title="Test Task",
+        task_id="P9-99",
+        template_path=template_path,
+    )
+
+    docs_lines = docs_path.read_text(encoding="utf-8").splitlines()
+    ready_index = docs_lines.index("### Ready")
+    block_lines = docs_lines[ready_index + 1 :]
+    assert any(
+        "[docs/state_runbook.md](docs/state_runbook.md)" in line for line in block_lines
+    )
+    assert any(
+        "Clarify gating metrics, data dependencies, or open questions." in line
+        for line in block_lines
+    )


### PR DESCRIPTION
## Summary
- allow `scripts/manage_task_cycle.py start-task` to accept optional runbook and pending-question overrides and pass them to `apply_next_task_template`
- refactor `scripts/sync_task_docs.py` template handling into shared helpers and extend regression coverage for CLI/template flows
- update workflow documentation plus `state.md`/`docs/todo_next.md` to describe the new options and record the latest progress notes

## Testing
- python3 -m pytest


------
https://chatgpt.com/codex/tasks/task_e_68d90900d9a8832a9c4a517531b4dfb4