### PR TITLE
Propagate benchmark alert thresholds via CLI workflows

### DIFF
--- a/docs/benchmark_runbook.md
+++ b/docs/benchmark_runbook.md
@@ -19,6 +19,7 @@ python3 scripts/run_benchmark_pipeline.py \
   --bars validated/USDJPY/5m.csv \
   --windows 365,180,90 \
   --runs-dir runs --reports-dir reports \
+  --alert-pips 50 --alert-winrate 0.05 \
   --summary-json reports/benchmark_summary.json \
   --summary-plot reports/benchmark_summary.png \
   --min-sharpe 0.5 --max-drawdown 200 \

--- a/scripts/run_benchmark_pipeline.py
+++ b/scripts/run_benchmark_pipeline.py
@@ -69,6 +69,18 @@ def parse_args(argv=None) -> argparse.Namespace:
     parser.add_argument("--summary-plot", default="reports/benchmark_summary.png")
     parser.add_argument("--min-sharpe", type=float, default=None)
     parser.add_argument("--max-drawdown", type=float, default=None)
+    parser.add_argument(
+        "--alert-pips",
+        type=float,
+        default=50.0,
+        help="Abs diff in total_pips to trigger alert",
+    )
+    parser.add_argument(
+        "--alert-winrate",
+        type=float,
+        default=0.05,
+        help="Abs diff in win_rate to trigger alert",
+    )
     parser.add_argument("--webhook", default=None, help="Webhook URL(s) for alerts (comma separated)")
     parser.add_argument("--dry-run", action="store_true", help="Skip writes and subprocess execution")
     return parser.parse_args(argv)
@@ -96,6 +108,10 @@ def _build_benchmark_cmd(args: argparse.Namespace, snapshot_path: Path) -> List[
         "--snapshot",
         str(snapshot_path),
     ]
+    if args.alert_pips is not None:
+        cmd += ["--alert-pips", str(args.alert_pips)]
+    if args.alert_winrate is not None:
+        cmd += ["--alert-winrate", str(args.alert_winrate)]
     if args.webhook:
         cmd += ["--webhook", args.webhook]
     return cmd

--- a/scripts/run_daily_workflow.py
+++ b/scripts/run_daily_workflow.py
@@ -40,6 +40,18 @@ def main(argv=None) -> int:
         default=None,
         help="Warn when |max_drawdown| exceeds this value (pips)",
     )
+    parser.add_argument(
+        "--alert-pips",
+        type=float,
+        default=50.0,
+        help="Abs diff in total_pips to trigger alert",
+    )
+    parser.add_argument(
+        "--alert-winrate",
+        type=float,
+        default=0.05,
+        help="Abs diff in win_rate to trigger alert",
+    )
     parser.add_argument("--optimize", action="store_true", help="Run parameter optimization")
     parser.add_argument("--analyze-latency", action="store_true", help="Analyze signal latency")
     parser.add_argument("--archive-state", action="store_true", help="Archive state.json files")
@@ -84,6 +96,10 @@ def main(argv=None) -> int:
             "--windows",
             args.benchmark_windows,
         ]
+        if args.alert_pips is not None:
+            cmd += ["--alert-pips", str(args.alert_pips)]
+        if args.alert_winrate is not None:
+            cmd += ["--alert-winrate", str(args.alert_winrate)]
         if args.min_sharpe is not None:
             cmd += ["--min-sharpe", str(args.min_sharpe)]
         if args.max_drawdown is not None:

--- a/state.md
+++ b/state.md
@@ -51,3 +51,4 @@
 - [P1-04] 2025-09-29: Published `docs/codex_workflow.md` to outline Codex session operations and clarified references to `docs/state_runbook.md` and the shared templates. DoD: [docs/task_backlog.md#codex-session-operations-guide](docs/task_backlog.md#codex-session-operations-guide).
 - [P1-01] 2025-09-28: Normalized benchmark summary max drawdown thresholds to accept negative CLI inputs, added regression coverage, and revalidated with targeted pytest.
 - [P1-01] 2025-09-29: Refined drawdown threshold normalization via helper, captured warning logs for negative CLI input in regression tests, and reran targeted pytest & CLI verification.
+- [P1-01] 2025-09-30: Propagated `--alert-pips` / `--alert-winrate` through benchmark pipeline + daily workflow CLIs, refreshed pytest coverage, and synced runbook CLI examples.

--- a/tests/test_run_benchmark_pipeline.py
+++ b/tests/test_run_benchmark_pipeline.py
@@ -74,6 +74,10 @@ def test_pipeline_success_updates_snapshot(monkeypatch: pytest.MonkeyPatch, tmp_
         str(tmp_path / "reports" / "benchmark_summary.png"),
         "--windows",
         "365,180,90",
+        "--alert-pips",
+        "75",
+        "--alert-winrate",
+        "0.12",
         "--min-sharpe",
         "1.1",
         "--max-drawdown",
@@ -94,6 +98,8 @@ def test_pipeline_success_updates_snapshot(monkeypatch: pytest.MonkeyPatch, tmp_
     first_cmd, second_cmd = commands
     assert "run_benchmark_runs.py" in first_cmd[1]
     assert first_cmd[first_cmd.index("--windows") + 1] == "365,180,90"
+    assert float(first_cmd[first_cmd.index("--alert-pips") + 1]) == pytest.approx(75.0)
+    assert float(first_cmd[first_cmd.index("--alert-winrate") + 1]) == pytest.approx(0.12)
     assert first_cmd[first_cmd.index("--webhook") + 1] == "https://example.com/hook"
     assert "run_benchmark_summary.py" not in first_cmd[1]
     assert "report_benchmark_summary.py" in second_cmd[1]

--- a/tests/test_run_daily_workflow.py
+++ b/tests/test_run_daily_workflow.py
@@ -97,6 +97,8 @@ def test_benchmarks_pipeline_arguments(monkeypatch):
         "--symbol", "GBPJPY",
         "--mode", "bridge",
         "--equity", "250000",
+        "--alert-pips", "110",
+        "--alert-winrate", "0.2",
         "--min-sharpe", "1.0",
         "--max-drawdown", "150",
         "--webhook", "https://example.com/hook",
@@ -110,6 +112,8 @@ def test_benchmarks_pipeline_arguments(monkeypatch):
     assert cmd[cmd.index("--symbol") + 1] == "GBPJPY"
     assert cmd[cmd.index("--mode") + 1] == "bridge"
     assert cmd[cmd.index("--equity") + 1] == "250000"
+    assert float(cmd[cmd.index("--alert-pips") + 1]) == pytest.approx(110.0)
+    assert float(cmd[cmd.index("--alert-winrate") + 1]) == pytest.approx(0.2)
     assert float(cmd[cmd.index("--min-sharpe") + 1]) == pytest.approx(1.0)
     assert float(cmd[cmd.index("--max-drawdown") + 1]) == pytest.approx(150.0)
     assert cmd[cmd.index("--webhook") + 1] == "https://example.com/hook"


### PR DESCRIPTION
## Summary
- add `--alert-pips` and `--alert-winrate` to the benchmark pipeline CLI and forward them to `run_benchmark_runs.py`
- expose the same alert thresholds in the daily workflow CLI so benchmark executions pass them through consistently
- extend regression coverage and refresh the runbook CLI example to reflect the new flags

## Testing
- python3 -m pytest tests/test_run_benchmark_pipeline.py tests/test_run_daily_workflow.py


------
https://chatgpt.com/codex/tasks/task_e_68d9208dde18832a9ccbcde95570af81