### PR TITLE
Add threshold alert payloads to benchmark summary warnings

### DIFF
--- a/docs/benchmark_runbook.md
+++ b/docs/benchmark_runbook.md
@@ -72,6 +72,7 @@ python3 scripts/run_benchmark_pipeline.py \
 - **CSV が大きすぎて時間内に終わらない**: `--windows` を縮めてテスト→本番は夜間バッチで実行。`--dry-run` で I/O だけ確認。
 - **Webhook 失敗**: `alert.deliveries` に HTTP ステータスが記録される。ネットワーク不通時は `ok=false` で残るため、手動復旧後に再実行。
 - **runs/index.csv が更新されない**: `--runs-dir` に書き込み権限が無いケース。`rebuild_runs_index.py` の return code を `runs_index_rc` でチェック。
+- **Sharpe / 最大DD が閾値を外れる**: `reports/benchmark_summary.json` の `warnings` と `threshold_alerts` を確認し、どのウィンドウ・指標が `lt`（下回り）/`gt_abs`（絶対値超過）で検知されたか把握する。同時に Cron ログか `python3 scripts/report_benchmark_summary.py ... --min-sharpe <値> --max-drawdown <値>` 実行時の標準出力で WARN ログが出ているか確認し、Slack の `benchmark_summary_warnings` 通知と照合する。再評価のためには `python3 scripts/run_daily_workflow.py --benchmarks --windows 365,180,90 --alert-pips 60 --alert-winrate 0.04 --min-sharpe <値> --max-drawdown <値>` を手動実行し、復旧後に `ops/runtime_snapshot.json` の `benchmark_pipeline.<symbol>_<mode>.threshold_alerts` がクリアされたことをチェックする。
 
 ## TODO / 拡張
 - `reports/benchmark_summary.json` を Notion/BI に自動掲載する。

--- a/scripts/run_benchmark_pipeline.py
+++ b/scripts/run_benchmark_pipeline.py
@@ -233,6 +233,7 @@ def _update_snapshot(snapshot_path: Path, key: str, benchmark_payload: Dict[str,
         "latest_ts": latest_ts,
         "summary_generated_at": summary_payload.get("generated_at"),
         "warnings": summary_payload.get("warnings", []),
+        "threshold_alerts": summary_payload.get("threshold_alerts", []),
     }
     _save_snapshot_atomic(snapshot_path, snapshot)
 

--- a/state.md
+++ b/state.md
@@ -55,3 +55,4 @@
 - [P1-01] 2025-09-30: Propagated `--alert-pips` / `--alert-winrate` through benchmark pipeline + daily workflow CLIs, refreshed pytest coverage, and synced runbook CLI examples.
 - [P1-01] 2025-10-01: 固定パス参照の `aggregate_ev.py` をリファクタし、リポジトリルートを `sys.path` と I/O 基準に統一する REPO_ROOT を導入。CLI 回帰テストを追加し、`python3 -m pytest tests/test_aggregate_ev_script.py` とベンチマーク実行を再確認。
 - [P1-01] 2025-10-02: `run_benchmark_pipeline.py` がローリング JSON の必須メトリクスを検証し、`reports/benchmark_summary.json` の書き込みを確認する安全策を追加。`tests/test_run_benchmark_pipeline.py` で Sharpe/DD の存在を回帰確認し、`docs/benchmark_runbook.md` に Cron モニタリングと再実行手順を追記。`python3 -m pytest` 完走で挙動を再検証。
+- [P1-01] 2025-10-03: `report_benchmark_summary.py` に Sharpe/最大DD 閾値逸脱の構造化アラートを追加し、`threshold_alerts` を Webhook・`run_benchmark_pipeline.py` のスナップショットにも伝播。負の閾値正規化の回帰テストと runbook のトラブルシュート項目を更新し、`python3 -m pytest tests/test_report_benchmark_summary.py` を実行して確認。


### PR DESCRIPTION
## Summary
- add structured `threshold_alerts` records when Sharpe or max drawdown cross configured limits and include them in the webhook payload
- persist the new threshold alerts in the benchmark pipeline snapshot so downstream tooling can audit regressions
- extend regression coverage for out-of-bounds metrics and document troubleshooting steps for Sharpe/最大DD regressions

## Testing
- python3 -m pytest tests/test_report_benchmark_summary.py


------
https://chatgpt.com/codex/tasks/task_e_68d92f5a7abc832aae4ce08a2905501d