### PR TITLE
Add P1-01 rolling pipeline DoD checklist

### DIFF
--- a/docs/checklists/p1-01.md
+++ b/docs/checklists/p1-01.md
@@ -1,0 +1,25 @@
+# P1-01 ローリング検証パイプライン — DoD チェックリスト
+
+- タスク名: ローリング検証パイプライン
+- バックログ ID / アンカー: P1-01 / [docs/task_backlog.md#p1-01-ローリング検証パイプライン](../task_backlog.md#p1-01-ローリング検証パイプライン)
+- 担当: Codex Operator
+- チェックリスト保存先: docs/checklists/p1-01.md
+
+## Ready 昇格チェック項目
+- [ ] 高レベルのビジョンガイド（例: [docs/logic_overview.md](../logic_overview.md), [docs/simulation_plan.md](../simulation_plan.md)）を再読し、タスク方針が整合している。
+- [ ] 対象フェーズの進捗ノート（例: `docs/progress_phase*.md`）を確認し、前提条件や未解決の検証ギャップがない。
+- [ ] 関連ランブック（例: [docs/state_runbook.md](../state_runbook.md), [docs/benchmark_runbook.md](../benchmark_runbook.md)）を再読し、必要なオペレーション手順が揃っている。
+- [ ] バックログ該当項目の DoD を最新化し、関係者へ共有済みである。
+
+## バックログ固有の DoD
+- [ ] `scripts/run_benchmark_runs.py` と `scripts/report_benchmark_summary.py` を通じて 365D / 180D / 90D のローリング run が日次バッチで更新される。
+- [ ] `reports/rolling/<window>/*.json` と `reports/benchmark_summary.json` に勝率・Sharpe・最大 DD が揃って出力される。
+- [ ] 07:30 JST 実行のローリング検証パイプライン手順と Slack アラート閾値（pips60 / winrate0.04）が [docs/benchmark_runbook.md](../benchmark_runbook.md) に追記され、再実行フローが明文化されている。
+
+## 成果物とログ更新
+- [ ] `state.md` の `## Log` へ完了サマリを追記した。
+- [ ] [docs/todo_next.md](../todo_next.md) の該当エントリを Archive へ移動した。
+- [ ] 関連コード/レポート/Notebook のパスを記録した。
+- [ ] レビュー/承認者を記録した。
+
+> Ready 昇格チェックと固有 DoD の達成状況は進捗に応じて更新し、完了後も `docs/checklists/` 配下に保持したまま関連ドキュメントから参照できるようにしてください。

--- a/docs/todo_next.md
+++ b/docs/todo_next.md
@@ -28,7 +28,7 @@
     - 主要ランブック: [docs/benchmark_runbook.md#スケジュールとアラート管理](docs/benchmark_runbook.md#スケジュールとアラート管理)
   - Pending Questions:
     - [ ] なし（cadence/アラート閾値整理済み）
-  - DoD チェックリスト: [docs/templates/dod_checklist.md](docs/templates/dod_checklist.md) を [docs/checklists/p1-01.md](docs/checklists/p1-01.md) にコピーし、進捗リンクを更新する。
+  - DoD チェックリスト: [docs/checklists/p1-01.md](docs/checklists/p1-01.md) を参照し、進捗更新時は本チェックリストへ記録する。
 
 ### Ready
 

--- a/state.md
+++ b/state.md
@@ -15,6 +15,7 @@
     - [ ] なし（cadence/アラート閾値整理済み）
   - 2025-10-02: `run_benchmark_pipeline.py` で 365/180/90D ローリング JSON の存在/Sharpe・最大DD を検証し、`run_daily_workflow.py --benchmarks` から必須ウィンドウを確実に流すよう正規化。ランブックへ Cron 後の確認手順と再実行 CLI を追記。
   - 2025-09-30: `manage_task_cycle.py` の `start-task` で runbook/pending 指定を許可し、`sync_task_docs.py` のテンプレ統合処理をリファクタリング。テンプレ適用後に state/docs 双方へ同じチェックリストが維持されることを手動確認。
+  - 2025-10-05: `docs/checklists/p1-01.md` にローリング検証パイプライン専用の DoD チェックリストを整備し、`docs/todo_next.md` から参照できるよう更新。
 
 ### 運用メモ
 - バックログから着手するタスクは先にこのリストへ追加し、ID・着手予定日・DoD リンクを明示する。


### PR DESCRIPTION
## Summary
- add a dedicated P1-01 rolling verification pipeline DoD checklist derived from the shared template
- record the new checklist in state.md and update docs/todo_next.md to point at the maintained copy

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d934fd1c00832ab83be494953989d8