### PR TITLE
Update benchmark runbook alert schedule details

### DIFF
--- a/docs/benchmark_runbook.md
+++ b/docs/benchmark_runbook.md
@@ -15,18 +15,18 @@
 
 ## スケジュールとアラート管理
 
-- 運用 Cron は UTC 22:30（JST 07:30）に `python3 scripts/run_daily_workflow.py --benchmarks` を起動し、`--windows 365,180,90` をまとめて更新する。ジョブ定義の引数（`ops` 側のジョブ設定ファイル/インフラ管理リポジトリ）に以下のパラメータを記録し、この表と整合させる。
-- それぞれのウィンドウは同一コマンドで更新されるが、レビュー頻度と責任者は下表の通りに運用する。レビュー結果や例外対応は `docs/todo_next.md` または `state.md` に追記する。
+- 運用 Cron は UTC 22:30（JST 07:30）に `python3 scripts/run_daily_workflow.py --benchmarks` を起動し、`--windows 365,180,90` をまとめて更新する。ジョブ定義の引数（`ops` 側のジョブ設定ファイル/インフラ管理リポジトリ）には、下表で示すアラート閾値（`--alert-pips 60` / `--alert-winrate 0.04`）と併せて記録し、このランブックと整合させる。
+- それぞれのウィンドウは同一コマンドで更新されるが、レビュー頻度・責任者・アラート確認ポイントは下表の通りに運用する。レビュー結果や例外対応は `docs/todo_next.md` または `state.md` に追記する。
 
-| ウィンドウ | 更新頻度 / 想定タイミング | 主コマンド / 担当 | レビュー観点 |
-| --- | --- | --- | --- |
-| 365D | 毎日 07:30 JST（Cron `30 22 * * *`）で実行し、毎週月曜 Ops 定例で結果レビュー | `run_daily_workflow.py --benchmarks --windows 365,180,90` （担当: Ops） | 長期EVの崩れ、週次での Sharpe・DD トレンド、アラート履歴の確認 |
-| 180D | 毎日 07:30 JST 実行、火曜/木曜に Ops チェック | 同上 | 直近半年の勝率ブレと総pips差分、`benchmark_shift` 通知有無 |
-| 90D | 毎営業日 07:30 JST 実行、日次モニタリング | 同上（レビュー: 日次担当） | 日次での勝率急落や負け越しトレンド、`benchmark_summary_warnings` の確認 |
+| ウィンドウ | 更新頻度 / 想定タイミング | 主コマンド / 担当 | アラート設定 / 通知チャネル | レビュー観点 |
+| --- | --- | --- | --- | --- |
+| 365D | 毎日 07:30 JST（Cron `30 22 * * *`）で実行し、毎週月曜 Ops 定例で結果レビュー | `run_daily_workflow.py --benchmarks --windows 365,180,90` （担当: Ops） | `--alert-pips 60` / `--alert-winrate 0.04` → `benchmark_shift`（Slack `#ops-benchmark-critical`） | 長期EVの崩れ、週次での Sharpe・DD トレンド、アラート履歴の確認 |
+| 180D | 毎日 07:30 JST 実行、火曜/木曜に Ops チェック | 同上 | `--alert-pips 60` / `--alert-winrate 0.04` → 同上 | 直近半年の勝率ブレと総pips差分、`benchmark_shift` 通知有無 |
+| 90D | 毎営業日 07:30 JST 実行、日次モニタリング | 同上（レビュー: 日次担当） | `--alert-pips 60` / `--alert-winrate 0.04` → 同上 | 日次での勝率急落や負け越しトレンド、`benchmark_summary_warnings` の確認 |
 
 ### アラート閾値と通知チャネル
 
-- `scripts/run_benchmark_runs.py` の `--alert-pips` / `--alert-winrate` は、Ops Slack の `#ops-benchmark-critical` Webhook を指定して実行する。現在の本番値は `--alert-pips 60`、`--alert-winrate 0.04`。どちらかを超えた場合は `benchmark_shift` イベントが `#ops-benchmark-critical` に送信される。
+- `scripts/run_benchmark_runs.py` の `--alert-pips` / `--alert-winrate` は、Ops Slack の `#ops-benchmark-critical` Webhook を指定して実行する。現在の本番値は `--alert-pips 60`、`--alert-winrate 0.04` で、Cron 実行時は上表の通り全ウィンドウで同じ設定を共有する。どちらかを超えた場合は `benchmark_shift` イベントが `#ops-benchmark-critical` に送信される。
 - `scripts/report_benchmark_summary.py` は同じ Cron で `--webhook https://hooks.slack.com/.../ops-benchmark-review` を指定し、Sharpe/最大DD 閾値 (`--min-sharpe`, `--max-drawdown`) 違反や欠損があると `benchmark_summary_warnings` を `#ops-benchmark-review` に送信する。
 - 閾値の議論が発生した場合は、本セクションの数値と Cron 定義の両方を同時に更新し、理由を `state.md` / `docs/todo_next.md` の該当タスクへ記録する。
 

--- a/state.md
+++ b/state.md
@@ -5,16 +5,7 @@
 - Update this file after completing work to record outcomes, blockers, and next steps.
 
 ## Next Task
-- [P1-01] 2024-06-20 ローリング検証パイプライン — DoD: [docs/task_backlog.md#p1-01-ローリング検証パイプライン](docs/task_backlog.md#p1-01-ローリング検証パイプライン) — 07:30JST 日次ベンチマーク実行と Slack アラート閾値（pips60 / winrate0.04）をランブック表へ確定。
-  - Backlog Anchor: [ローリング検証パイプライン (P1-01)](docs/task_backlog.md#p1-01-ローリング検証パイプライン)
-  - Vision / Runbook References:
-    - [docs/logic_overview.md](docs/logic_overview.md)
-    - [docs/simulation_plan.md](docs/simulation_plan.md)
-    - 主要ランブック: [docs/benchmark_runbook.md#スケジュールとアラート管理](docs/benchmark_runbook.md#スケジュールとアラート管理)
-  - Pending Questions:
-    - [ ] なし（cadence/アラート閾値整理済み）
-  - 2025-10-02: `run_benchmark_pipeline.py` で 365/180/90D ローリング JSON の存在/Sharpe・最大DD を検証し、`run_daily_workflow.py --benchmarks` から必須ウィンドウを確実に流すよう正規化。ランブックへ Cron 後の確認手順と再実行 CLI を追記。
-  - 2025-09-30: `manage_task_cycle.py` の `start-task` で runbook/pending 指定を許可し、`sync_task_docs.py` のテンプレ統合処理をリファクタリング。テンプレ適用後に state/docs 双方へ同じチェックリストが維持されることを手動確認。
+- 未設定（次の優先タスク選定待ち）
 
 ### 運用メモ
 - バックログから着手するタスクは先にこのリストへ追加し、ID・着手予定日・DoD リンクを明示する。
@@ -50,6 +41,7 @@
 - [P1-04] 2025-09-28: Ready/DoD チェックリスト テンプレートと `sync_task_docs.py` の自動リンク挿入を整備し、`docs/todo_next.md` / `docs/state_runbook.md` に運用手順を追記。DoD: [docs/task_backlog.md#ワークフロー統合ガイド](docs/task_backlog.md#ワークフロー統合ガイド).
 - [P1-04] 2025-09-28: `docs/templates/next_task_entry.md` を新設し、`manage_task_cycle.py start-task` がテンプレを自動適用するよう拡張。DoD: [docs/task_backlog.md#ワークフロー統合ガイド](docs/task_backlog.md#ワークフロー統合ガイド).
 - [P1-04] 2025-09-29: Published `docs/codex_workflow.md` to outline Codex session operations and clarified references to `docs/state_runbook.md` and the shared templates. DoD: [docs/task_backlog.md#codex-session-operations-guide](docs/task_backlog.md#codex-session-operations-guide).
+- [P1-01] 2025-10-04: Updated the benchmark runbook schedule to surface the shared `--alert-pips 60` / `--alert-winrate 0.04` thresholds for each window and aligned the 07:30 JST workflow with DoD references.
 - [P1-01] 2025-09-28: Normalized benchmark summary max drawdown thresholds to accept negative CLI inputs, added regression coverage, and revalidated with targeted pytest.
 - [P1-01] 2025-09-29: Refined drawdown threshold normalization via helper, captured warning logs for negative CLI input in regression tests, and reran targeted pytest & CLI verification.
 - [P1-01] 2025-09-30: Propagated `--alert-pips` / `--alert-winrate` through benchmark pipeline + daily workflow CLIs, refreshed pytest coverage, and synced runbook CLI examples.


### PR DESCRIPTION
## Summary
- clarify the benchmark runbook schedule table with shared alert thresholds per rolling window
- sync the state log to capture the completed update and note that the next task is pending selection

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d93805e6f8832aaabd1c47cefcd654