### PR TITLE
Add Day ORB parameter dependency matrix documentation

### DIFF
--- a/docs/logic_overview.md
+++ b/docs/logic_overview.md
@@ -5,6 +5,33 @@
 - **再現用サンプル**: `strategies/reversion_stub.py` を追加し、共通ゲート上で別戦略を動作させるテンプレートを整備。
 - **共通設定**: `RunnerConfig` と `StrategyConfig` で構成。`scripts/config_utils.py` を通じて CLI の上書き処理を共通化。
 
+### Day ORB パラメータ依存マトリクス
+
+| パラメータ/キー | 参照元 | 依存先 | 影響の概要 |
+| --- | --- | --- | --- |
+| `or_n` | `cfg` | `on_bar` の OR 更新 | OR ウィンドウのバー数を決定し、初期高値/安値の確定タイミングを制御する。【F:strategies/day_orb_5m.py†L32-L44】 |
+| `k_tp` / `k_sl` / `k_tr` | `cfg` | `on_bar` の TP/SL/トレール算出 | ATR14 から算出した pips 値に倍率を掛け、OCO パラメータを決定する。`k_tr` が 0 以下ならトレールを無効化。【F:strategies/day_orb_5m.py†L45-L58】 |
+| `require_close_breakout` | `cfg` | `on_bar` ブレイク条件 | ブレイク判定を終値基準に引き上げ、ヒゲ抜け時のシグナル発火を抑制する。【F:strategies/day_orb_5m.py†L58-L77】 |
+| `require_retest` / `retest_max_bars` / `retest_tol_k` | `cfg` | `on_bar` 再テスト管理 | 初回ブレイク後の再テスト待機と締切、許容トレランスを制御し、擬似フェイクアウト抑制に寄与する。【F:strategies/day_orb_5m.py†L58-L96】 |
+| `min_or_atr_ratio` / `or_atr_ratio` | `cfg` / `ctx` | `strategy_gate` と `ev_threshold` | OR 幅に対する ATR 比を下限チェックし、十分なボラティリティが確保できない場合のシグナル棄却や EV 閾値補正に利用する。【F:strategies/day_orb_5m.py†L119-L146】 |
+| `allow_low_rv` / `rv_band` | `ctx` | `strategy_gate` | RV バンドが mid/high 以外でも通過させるかを決定し、統計的ボラティリティの不足をフィルタする。【F:strategies/day_orb_5m.py†L135-L141】 |
+| `ev_threshold_boost` / `ev_threshold_relief` | `cfg` | `ev_threshold` | OR/ATR 条件に応じて EV 閾値を引き上げ・引き下げし、良条件時のエントリー加速と境界条件での保守運用を切り替える。【F:strategies/day_orb_5m.py†L148-L165】 |
+| `ev_profile_stats` / `ev_profile_obs_norm` | `ctx` / `cfg` | `ev_threshold` | 直近・長期の EV プロファイル統計を読み込み、観測数に基づいて期待値差分を平滑化しつつ EV 閾値を再調整する。【F:strategies/day_orb_5m.py†L165-L193】 |
+| `cost_pips` | `ctx` | `ev_threshold` | EV プロファイル補正時に取引コストを控除し、期待値の過大評価を避ける。【F:strategies/day_orb_5m.py†L170-L193】 |
+
+#### 再利用時の注意点
+
+- `min_or_atr_ratio` の閾値を引き上げた場合、`ev_threshold_boost` が過剰に高いと閾値が急上昇し約定機会が枯渇するため、両値を同時調整する際は OR 幅の分布を確認する。
+- `allow_low_rv=False` のまま RV バンドを低頻度シンボルへ適用するとシグナルが完全に遮断される可能性がある。低 RV でも許容したい場合は `rv_band` のラベルや `allow_low_rv` をシミュレーションで検証する。
+- `ev_profile_stats` を供給しない環境では EV 閾値補正が行われず、`ev_threshold_relief` だけが効く構造になる。ベンチマーク run ではプロファイル生成フェーズの完了を確認する。
+
+##### 新戦略転用チェックリスト
+
+1. OR 設計: `or_n`・再テスト関連の挙動が対象シンボルのボラティリティと時間足に合っているかを確認する。
+2. ボラティリティゲート: `min_or_atr_ratio` と `allow_low_rv` の両方について、サンプル分布を取得しながら棄却率をモニタする。
+3. EV プロファイル連携: `ev_profile_stats` の生成頻度と `ev_profile_obs_norm` のスケールが実データの観測数と乖離していないかをチェックする。
+4. コスト・閾値: `cost_pips` や `ev_threshold_boost/relief` が fill モデル（Bridge/Conservative など）と整合しているかを確認し、閾値変更時は `strategy_gate` の棄却理由をログで追跡する。
+
 ## データ品質・ベースライン
 - `scripts/check_data_quality.py` で 2018–2024 CSV の欠損/重複/週末ギャップを監査。結果は `docs/progress_phase0.md` に記録。
 - ベースライン `state.json` は `runs/grid_USDJPY_bridge_or4_ktp1.2_ksl0.4_.../state.json` を採用し、`docs/state_runbook.md` にアーカイブ手順をまとめた。

--- a/docs/simulation_plan.md
+++ b/docs/simulation_plan.md
@@ -6,7 +6,7 @@
 - **state.json 管理体制**: `docs/state_runbook.md` に沿って初期ベースライン state を決め、以後の最適化で同一基準を使う。
 
 ## フェーズ1: 戦略とゲートの強化
-- **戦略別ゲート整備**: DayORB をテンプレートに、他戦略でも `strategy_gate` / `ev_threshold` を実装できるよう共通インターフェースを整理。必要に応じて `StrategyConfig` の拡張項目を定義。
+- **戦略別ゲート整備**: DayORB をテンプレートに、他戦略でも `strategy_gate` / `ev_threshold` を実装できるよう共通インターフェースを整理。必要に応じて `StrategyConfig` の拡張項目を定義し、`docs/logic_overview.md#day-orb-パラメータ依存マトリクス` を参照しながら依存関係を反映する。
 - **EVチューニング**: decay・prior・ウォームアップの推奨値を実測で比較し、`docs/ev_tuning.md` にケーススタディを追加。閾値自動調整の挙動をヒートマップで可視化。
 - **Fillモデル検証**: `docs/broker_oco_matrix.md` の調査完了後、Bridge/Conservativeの差分を `analysis/broker_fills.ipynb` で比較し、必要に応じて `core/fill_engine.py` を拡張。
 

--- a/state.md
+++ b/state.md
@@ -52,3 +52,4 @@
 - [P1-01] 2025-10-06: Sharpe / 最大DD 差分アラートを `run_benchmark_runs.py`・パイプライン・日次ワークフローに伝播し、`docs/benchmark_runbook.md` を新閾値とレビュー観点で更新。DoD: `python3 -m pytest tests/test_run_benchmark_pipeline.py tests/test_run_daily_workflow.py` パスで新デルタ通知を確認。
 - [P1-01] 2025-10-07: `report_benchmark_summary.py` に Matplotlib 未導入環境でのフォールバックを追加し、`summary plot skipped: missing dependency ...` 警告をスナップショットへ保存。USDJPY conservative を実行し直して `ops/runtime_snapshot.json` / `reports/benchmark_summary.json` を更新、`python3 -m pytest tests/test_run_benchmark_pipeline.py tests/test_report_benchmark_summary.py` で回帰確認。
 - [P1-05] 2025-10-08: BacktestRunner debug visibility refresh — helper-based `strategy_gate`/`ev_threshold` dispatch, normalized debug counters/records, and new investigation guide. Executed `python3 -m pytest` before wrap-up.
+- [DOC-06] 2025-10-08: Documented Day ORB parameter dependency matrix, noted transfer checklist, and linked the update from the simulation plan Phase1 task.


### PR DESCRIPTION
## Summary
- document the configuration keys that control Day ORB breakout handling, RV filtering, and EV adjustments in docs/logic_overview.md
- add guidance and a transfer checklist for reusing the strategy in new contexts
- link the simulation plan to the new dependency matrix for Phase 1 gate work

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d9b6c5cf6c832a9b81df6d89c1f1aa