### PR TITLE
Document mean reversion stub inputs and multi-strategy validation flow

### DIFF
--- a/docs/checklists/multi_strategy_validation.md
+++ b/docs/checklists/multi_strategy_validation.md
@@ -1,0 +1,89 @@
+# マルチ戦略比較チェックリスト
+
+Day ORB と Mean Reversion (reversion_stub) を同一 CSV で比較し、EV ゲートや RV バンドの影響を検証するための手順をまとめる。CLI での実行・出力確認・評価観点を順番に消化し、チームへ結果を共有する。
+
+## 前提条件
+- 入力 CSV に Day ORB で利用しているカラム（timestamp, symbol, tf, o, h, l, c, v, spread）が揃っていること。
+- `features/` もしくは事前処理で Mean Reversion が参照する `zscore` フィールドと、`core.runner` が生成する `rv_band` ラベルが供給されること。
+- `python3 scripts/run_sim.py` が実行できるローカル環境であり、`runs/` 以下への書き込み権限があること。
+- 既存の Day ORB EV プロファイル（例: `configs/ev_profiles/day_orb_5m.yaml`）が利用可能で、必要に応じて `--no-ev-profile` で無効化できること。
+
+## 手順
+1. **共通出力ディレクトリの作成**
+   ```bash
+   mkdir -p runs/multi_strategy && rm -f runs/multi_strategy/day_orb.json runs/multi_strategy/reversion.json
+   ```
+
+2. **Day ORB のベースライン実行**
+   ```bash
+   python3 scripts/run_sim.py --csv data/sample_orb.csv --symbol USDJPY \
+       --mode conservative --equity 100000 --json-out runs/multi_strategy/day_orb.json \
+       --dump-csv runs/multi_strategy/day_orb_records.csv --dump-daily runs/multi_strategy/day_orb_daily.csv \
+       --out-dir runs/multi_strategy --debug
+   ```
+   - 期待出力: `runs/multi_strategy/day_orb.json` に `trades`・`fills`・`debug` カウント、`dump_csv`/`dump_daily` パスが含まれる。
+   - チェック: `dump-csv` と `dump-daily` で指定したファイルが作成され、`gate_pass`/`ev_reject` など日次カラムが出力されていること。
+
+3. **Mean Reversion (reversion_stub) の実行**
+   ```bash
+   python3 scripts/run_sim.py --csv data/sample_orb.csv --symbol USDJPY \
+       --mode conservative --equity 100000 --strategy reversion_stub.MeanReversionStrategy \
+       --json-out runs/multi_strategy/reversion.json \
+       --dump-csv runs/multi_strategy/reversion_records.csv --dump-daily runs/multi_strategy/reversion_daily.csv \
+       --out-dir runs/multi_strategy --debug
+   ```
+   - 期待出力: JSON に `ev_profile_path` が記録され、Day ORB と同じディレクトリ配下にランフォルダが生成される。
+   - チェック: `reversion_records.csv` の `zscore` カラムが埋まっていること、`reversion_daily.csv` で `gate_block` が RV ハイで増えていないかを確認。
+
+4. **EV プロファイル適用有無の確認**
+   - **適用あり**: 上記コマンドの JSON に `ev_profile_path` が含まれているか、`runs/multi_strategy/*/metrics.json` で確認する。
+   - **適用なし比較**:
+     ```bash
+     python3 scripts/run_sim.py --csv data/sample_orb.csv --symbol USDJPY \
+         --mode conservative --equity 100000 --strategy reversion_stub.MeanReversionStrategy \
+         --json-out runs/multi_strategy/reversion_no_profile.json --no-ev-profile --debug
+     ```
+     出力 JSON に `ev_profile_path` が無いこと、`debug` の `ev_reject` が増減していないかを比較する。
+
+5. **ゲート/EV 指標の比較**
+   ```bash
+   python3 - <<'PY'
+import csv, json
+from pathlib import Path
+base = Path('runs/multi_strategy')
+with open(base/'day_orb.json') as f:
+    day = json.load(f)
+with open(base/'reversion.json') as f:
+    rev = json.load(f)
+print('Day ORB trades:', day.get('trades'), 'EV rejects:', day.get('debug', {}).get('ev_reject', 'n/a'))
+print('Reversion trades:', rev.get('trades'), 'EV rejects:', rev.get('debug', {}).get('ev_reject', 'n/a'))
+for name in ['day_orb_daily.csv', 'reversion_daily.csv']:
+    rows = list(csv.DictReader(open(base/name)))
+    gate_pass = sum(float(r.get('gate_pass', 0)) for r in rows)
+    ev_reject = sum(float(r.get('ev_reject', 0)) for r in rows)
+    print(name, 'gate_pass', gate_pass, 'ev_reject', ev_reject)
+PY
+   ```
+   - 比較観点: `gate_pass`/`gate_block`/`ev_reject` の総数、`debug` セクションの `rv_high_block` や `ev_reject_lcb` などの差分。
+   - 補足: `--dump-csv` により取得した詳細レコードで、RV バンドとシグナル方向の対応を spot チェックする。
+
+6. **結果サマリの共有**
+   - 差分（ゲート通過数、EV リジェクト数、期待値ギャップなど）を箇条書きにまとめ、`docs/todo_next.md` もしくはレポートに貼り付ける。
+   - EV プロファイル適用の有無で挙動が変化した場合は、`configs/ev_profiles/` の更新計画を backlog へ登録する。
+
+## 評価指標テンプレート
+| 指標 | Day ORB | Mean Reversion | メモ |
+| --- | --- | --- | --- |
+| Trades |  |  | 主要エントリー数の差異 |
+| Gate Pass / Gate Block |  |  | RV バンドでの抑制状況 |
+| EV Pass / EV Reject |  |  | LCB 閾値でのフィルタリング |
+| Wins / Win Rate |  |  | `metrics.json` の `wins`・`win_rate` を利用 |
+| Total PnL (pips) |  |  | `metrics.json` の `total_pips` |
+| Debug Counters |  |  | `debug` セクションの `ev_reject_*` など |
+
+## チェックリスト
+- [ ] Day ORB / Mean Reversion それぞれで `--dump-csv` / `--dump-daily` の出力が生成され、列構成が期待どおりか確認した。
+- [ ] `--strategy reversion_stub.MeanReversionStrategy` 指定で Day ORB のコマンドラインを流用できることを確認した。
+- [ ] `ev_profile_path` の有無を確認し、`--no-ev-profile` 実行結果との差分を記録した。
+- [ ] `debug` と `daily.csv` のゲート通過数 (`gate_pass`/`gate_block`) と EV リジェクト数 (`ev_reject`) を比較し、差異を説明できる。
+- [ ] 主要指標（Trades, Win Rate, Total PnL, Gate/Ev カウント）を表に転記し、レビュー用ドキュメントへ共有した。

--- a/docs/task_backlog.md
+++ b/docs/task_backlog.md
@@ -77,6 +77,7 @@ Document the repeatable workflow that lets Codex keep `state.md`, `docs/todo_nex
 - **戦略マニフェスト整備**: スキャル/デイ/スイングの候補戦略ごとに、依存特徴量・セッション・リスク上限を YAML で定義し、ルーターが参照できるようにする (`configs/strategies/*.yaml`)。
 - **ルーター拡張**: 現行ルールベース (`router/router_v0.py`) を拡張し、カテゴリ配分・相関・キャパ制約を反映。戦略ごとの state/EV/サイズ情報を統合してスコアリングする。
 - **ポートフォリオ評価レポート**: 複数戦略を同時に流した場合の資本使用率・相関・ドローダウンを集計する `analysis/portfolio_monitor.ipynb` と `reports/portfolio_summary.json` を追加。
+- **マルチ戦略比較バリデーション**: Day ORB と Mean Reversion (reversion_stub) を同一 CSV で走らせ、`docs/checklists/multi_strategy_validation.md` に沿ってゲート通過数・EV リジェクト数・期待値差をレビュー。DoD: チェックリストの全項目を完了し、比較サマリをレビュー用ドキュメントへ共有する。
 
 ## P3: 観測性・レポート自動化
 - **シグナル/レイテンシ監視自動化**: `scripts/analyze_signal_latency.py` を日次ジョブ化し、`ops/signal_latency.csv` をローテーション。SLO違反でアラート。

--- a/state.md
+++ b/state.md
@@ -53,3 +53,4 @@
 - [P1-01] 2025-10-07: `report_benchmark_summary.py` に Matplotlib 未導入環境でのフォールバックを追加し、`summary plot skipped: missing dependency ...` 警告をスナップショットへ保存。USDJPY conservative を実行し直して `ops/runtime_snapshot.json` / `reports/benchmark_summary.json` を更新、`python3 -m pytest tests/test_run_benchmark_pipeline.py tests/test_report_benchmark_summary.py` で回帰確認。
 - [P1-05] 2025-10-08: BacktestRunner debug visibility refresh — helper-based `strategy_gate`/`ev_threshold` dispatch, normalized debug counters/records, and new investigation guide. Executed `python3 -m pytest` before wrap-up.
 - [DOC-06] 2025-10-08: Documented Day ORB parameter dependency matrix, noted transfer checklist, and linked the update from the simulation plan Phase1 task.
+- [DOC-07] 2025-10-09: Mean Reversion スタブの入力想定を整理し、Day ORB との比較チェックリストを公開。`docs/checklists/multi_strategy_validation.md` を追加し、backlog へマルチ戦略レビュータスクを追記。

--- a/strategies/reversion_stub.py
+++ b/strategies/reversion_stub.py
@@ -1,4 +1,34 @@
-"""Mean-reversion strategy stub for testing shared gating infrastructure."""
+"""Mean-reversion strategy stub for testing shared gating infrastructure.
+
+Expected inputs
+----------------
+* **Bars** supplied by the runner must expose the same OHLC keys as Day ORB
+  plus a floating-point ``zscore`` field describing how far the latest close
+  deviates from the recent mean.  The stub uses ``bar["c"]`` for the entry
+  price and the ``zscore`` value to decide whether to stage a BUY or SELL.
+* **Context** dictionaries provided to ``strategy_gate`` / ``ev_threshold``
+  should include an ``rv_band`` label (``"low"``, ``"mid"`, or ``"high"``)
+  emitted by the volatility band loader.  The optional config flag
+  ``allow_high_rv`` overrides the default behaviour that blocks trades in the
+  ``"high"`` regime.
+* **Config** parameters are passed from ``scripts/run_sim.py`` and mirror the
+  Day ORB CLI flags: ``zscore_threshold`` controls when to queue a trade, while
+  risk settings (``k_tp``/``k_sl``/``k_tr``) continue to be handled by the
+  shared runner.
+
+Switching via ``run_sim``
+-------------------------
+Run the stub from the command line with ``--strategy`` pointing to the fully
+qualified class name under ``strategies``.  For example::
+
+    python3 scripts/run_sim.py --csv data/sample_orb.csv --symbol USDJPY \
+        --strategy reversion_stub.MeanReversionStrategy --dump-csv out/reversion_records.csv \
+        --dump-daily out/reversion_daily.csv --debug
+
+The default Day ORB implementation remains ``day_orb_5m.DayORB5m``; passing the
+flag above switches the simulation to this stub while keeping every other CLI
+argument identical.
+"""
 from __future__ import annotations
 from typing import Dict, Any, Iterable, Optional, List
 


### PR DESCRIPTION
## Summary
- describe the expected zscore and rv_band inputs for the mean reversion stub and how to switch strategies via `run_sim`
- add a multi-strategy validation checklist detailing Day ORB vs Mean Reversion comparison steps, metrics, and dump checks
- surface the new checklist in the backlog and log the publication in `state.md`

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d9b80ae328832ab5dbdcc8ed3087b6