### PR TITLE
Add base strategy manifest template and document required sections

### DIFF
--- a/configs/strategies/README.md
+++ b/configs/strategies/README.md
@@ -18,6 +18,18 @@ basic validation.
 | `state`    | ❌        | Archive namespace & EV profile hints |
 | `notes`    | ❌        | Free-form operator notes |
 
+### Required blocks
+- `meta` — Identify the strategy with stable IDs, human-readable names, category, version, descriptive text, and discovery tags.
+- `strategy` — Point to the Python implementation (`class_path`), enumerate tradable instruments, and supply default parameter values used by loaders and runners.
+- `router` — Define execution guardrails such as allowed sessions, spread/realized-volatility bands, latency caps, and routing tags.
+- `risk` — Capture sizing guardrails including risk-per-trade, drawdown limits, notional caps, concurrency limits, and warm-up counts.
+
+### Optional blocks
+- `features` — Document required/optional feature columns for gating or sizing so data pipelines can validate coverage.
+- `runner` — Recommend `RunnerConfig` overrides and CLI defaults that orchestration tools can adopt when bootstrapping simulations.
+- `state` — Describe EV state archive namespaces and the EV profile seed to help automation locate persisted context.
+- `notes` — Leave free-form operational reminders or playbooks that do not belong in structured fields.
+
 ### Category
 `meta.category` must be one of `scalping`, `day`, or `swing`. This allows the
 router to enforce portfolio caps per bucket.
@@ -34,3 +46,8 @@ are advisory and can be used by orchestration tools to bootstrap runs.
 
 ### Example
 See `day_orb_5m.yaml` for a reference manifest covering the Day ORB 5m strategy.
+
+### Templates
+Start new manifests from `templates/base_strategy.yaml`, which contains inline
+guidance for each field plus suggested runner defaults inspired by the Day ORB
+manifest.

--- a/configs/strategies/templates/base_strategy.yaml
+++ b/configs/strategies/templates/base_strategy.yaml
@@ -1,0 +1,73 @@
+# Base template for strategy manifests.
+# Copy this file and replace placeholder values before loading via configs/strategies/loader.py.
+# Comments highlight how each field maps to RunnerConfig properties or CLI flags.
+
+meta:
+  id: your_strategy_id  # Stable slug consumed by the loader; keep unique per strategy release.
+  name: Your Strategy Name  # Human-readable label for reports and dashboards.
+  version: "1.0"  # Increment when behaviour/parameters change.
+  category: day  # One of: scalping, day, swing.
+  tags: [sample, breakout]  # Discovery tags for router filtering.
+  description: |
+    Short summary of the playbook, targets, and any deployment notes.
+    Use multiple lines as needed; YAML folds them into a block string.
+
+strategy:
+  class_path: strategies.your_module.YourStrategy  # Python import path (module.Class) used by the loader.
+  instruments:
+    - symbol: USDJPY  # Uppercase instrument symbol routed into BacktestRunner.
+      timeframe: 5m  # E.g. 5m, 15m, 1h; aligns with data loader cadence.
+      mode: conservative  # Optional: matches BacktestRunner mode / CLI --mode.
+  parameters:
+    or_n: 6  # Mirrors RunnerConfig.or_n property (derived from RunnerConfig.strategy.or_n) and CLI --or-n.
+    k_tp: 1.0  # RunnerConfig.k_tp / CLI --k-tp.
+    k_sl: 0.8  # RunnerConfig.k_sl / CLI --k-sl.
+    k_tr: 0.0  # RunnerConfig.k_tr / CLI --k-tr (trail multiple, 0 disables trailing).
+    require_close_breakout: false  # Example boolean toggle consumed by the strategy implementation.
+    min_or_atr_ratio: 0.6  # Keep in sync with RunnerConfig.min_or_atr_ratio and CLI --min-or-atr.
+
+router:
+  allowed_sessions: [LDN, NY]  # Router gate; aligns with RunnerConfig.allowed_sessions / CLI --allowed-sessions.
+  allow_spread_bands: [narrow, normal]  # Permitted spread regimes.
+  allow_rv_bands: [mid, high]  # Permitted realised-volatility bands.
+  max_latency_ms: 80  # Execution latency cap for routing decisions.
+  category_cap_pct: 40  # Portfolio budget cap for this category.
+  tags: [breakout, usd, jpy]  # Router hints for orchestration.
+
+risk:
+  risk_per_trade_pct: 0.25  # Fractional Kelly / sizing budget per position.
+  max_daily_dd_pct: 5.0  # Stop trading if daily drawdown exceeds this percentage.
+  notional_cap: 2000000  # Absolute notional limit enforced by the runner/router.
+  max_concurrent_positions: 1  # Hard cap on parallel trades for this manifest.
+  warmup_trades: 50  # Warmup count mirrored by RunnerConfig.warmup_trades / CLI --warmup.
+
+features:
+  required:
+    - atr14  # Enumerate inputs that must be present in feature pipelines.
+    - adx14
+    - spread_band
+    - session
+  optional:
+    - regime_flag  # Optional features improve sizing/gating when available.
+
+runner:
+  runner_config:
+    threshold_lcb_pip: 0.5  # RunnerConfig.threshold_lcb_pip → CLI --threshold-lcb (pips).
+    min_or_atr_ratio: 0.6  # RunnerConfig.min_or_atr_ratio → CLI --min-or-atr.
+    allowed_sessions: [LDN, NY]  # RunnerConfig.allowed_sessions → CLI --allowed-sessions.
+    warmup_trades: 50  # RunnerConfig.warmup_trades → CLI --warmup.
+    include_expected_slip: true  # RunnerConfig.include_expected_slip → CLI --include-expected-slip.
+  cli_args:
+    equity: 100000  # scripts/run_sim.py --equity
+    threshold_lcb: 0.5  # scripts/run_sim.py --threshold-lcb
+    min_or_atr: 0.6  # scripts/run_sim.py --min-or-atr
+    allowed_sessions: LDN,NY  # scripts/run_sim.py --allowed-sessions
+    mode: conservative  # scripts/run_sim.py --mode (matches instruments[].mode when set)
+
+state:
+  archive_namespace: strategies.your_module.YourStrategy/USDJPY/conservative  # Root passed to BacktestRunner state archiver.
+  ev_profile: configs/ev_profiles/your_strategy.yaml  # Seed profile path loaded unless CLI --no-ev-profile is set.
+
+notes:
+  - Document operational caveats, disabling conditions, or validation steps here.
+  - Reference related runbooks or dashboards for quick navigation.

--- a/docs/task_backlog.md
+++ b/docs/task_backlog.md
@@ -75,6 +75,7 @@ Document the repeatable workflow that lets Codex keep `state.md`, `docs/todo_nex
 
 ## P2: マルチ戦略ポートフォリオ化
 - **戦略マニフェスト整備**: スキャル/デイ/スイングの候補戦略ごとに、依存特徴量・セッション・リスク上限を YAML で定義し、ルーターが参照できるようにする (`configs/strategies/*.yaml`)。
+  - 2025-10-09: `configs/strategies/templates/base_strategy.yaml` に共通テンプレートと記述ガイドを追加し、新規戦略のマニフェスト整備を着手しやすくした。
 - **ルーター拡張**: 現行ルールベース (`router/router_v0.py`) を拡張し、カテゴリ配分・相関・キャパ制約を反映。戦略ごとの state/EV/サイズ情報を統合してスコアリングする。
 - **ポートフォリオ評価レポート**: 複数戦略を同時に流した場合の資本使用率・相関・ドローダウンを集計する `analysis/portfolio_monitor.ipynb` と `reports/portfolio_summary.json` を追加。
 - **マルチ戦略比較バリデーション**: Day ORB と Mean Reversion (reversion_stub) を同一 CSV で走らせ、`docs/checklists/multi_strategy_validation.md` に沿ってゲート通過数・EV リジェクト数・期待値差をレビュー。DoD: チェックリストの全項目を完了し、比較サマリをレビュー用ドキュメントへ共有する。

--- a/state.md
+++ b/state.md
@@ -54,3 +54,4 @@
 - [P1-05] 2025-10-08: BacktestRunner debug visibility refresh — helper-based `strategy_gate`/`ev_threshold` dispatch, normalized debug counters/records, and new investigation guide. Executed `python3 -m pytest` before wrap-up.
 - [DOC-06] 2025-10-08: Documented Day ORB parameter dependency matrix, noted transfer checklist, and linked the update from the simulation plan Phase1 task.
 - [DOC-07] 2025-10-09: Mean Reversion スタブの入力想定を整理し、Day ORB との比較チェックリストを公開。`docs/checklists/multi_strategy_validation.md` を追加し、backlog へマルチ戦略レビュータスクを追記。
+- [DOC-08] 2025-10-09: 戦略マニフェストの必須/任意ブロックを README に整理し、Day ORB を基にしたテンプレート (`configs/strategies/templates/base_strategy.yaml`) と runner ガイドを追加。DoD: `python3 -m pytest tests/test_strategy_manifest.py` 通過・バックログへ整備済みノート追記。


### PR DESCRIPTION
## Summary
- summarize required and optional strategy manifest blocks in the strategy config README and link to the new template
- add a base strategy manifest template with inline guidance derived from the Day ORB configuration
- record the template availability in the backlog and state log for easier discovery

## Testing
- python3 -m pytest tests/test_strategy_manifest.py

------
https://chatgpt.com/codex/tasks/task_e_68d9b9bab348832a8492e91d23fcd496