### PR TITLE
chore: sync rolling validation task tracking

### DIFF
--- a/docs/checklists/p1-01.md
+++ b/docs/checklists/p1-01.md
@@ -1,0 +1,25 @@
+# DoD チェックリスト — ローリング検証パイプライン
+
+- タスク名: ローリング検証パイプライン
+- バックログ ID / アンカー: P1-01 / docs/task_backlog.md#p1-01-ローリング検証パイプライン
+- 担当: Codex Operator
+- チェックリスト保存先: docs/checklists/p1-01.md
+
+## Ready 昇格チェック項目
+- [ ] 高レベルのビジョンガイド（例: [docs/logic_overview.md](../logic_overview.md), [docs/simulation_plan.md](../simulation_plan.md)）を再読し、タスク方針が整合している。
+- [ ] 対象フェーズの進捗ノート（例: `docs/progress_phase*.md`）を確認し、前提条件や未解決の検証ギャップがない。
+- [ ] 関連ランブック（例: [docs/state_runbook.md](../state_runbook.md), [docs/benchmark_runbook.md](../benchmark_runbook.md)）を再読し、必要なオペレーション手順が揃っている。
+- [ ] バックログ該当項目の DoD を最新化し、関係者へ共有済みである。
+
+## バックログ固有の DoD
+- [ ] `scripts/run_benchmark_runs.py` / `scripts/report_benchmark_summary.py` を通じて365D・180D・90Dローリング run が定期更新されている。
+- [ ] `reports/rolling/<window>/*.json` と `reports/benchmark_summary.json` に勝率・Sharpe・最大DDが揃って出力されている。
+- [ ] ジョブ実行フローとアラート閾値の更新内容を README もしくは runbook に追記し、再実行手順が明文化されている。
+
+## 成果物とログ更新
+- [ ] `state.md` の `## Log` へ完了サマリを追記した。
+- [ ] [docs/todo_next.md](../todo_next.md) の該当エントリを Archive へ移動した。
+- [ ] 関連コード/レポート/Notebook のパスを記録した。
+- [ ] レビュー/承認者を記録した。
+
+> Ready 昇格チェックと固有 DoD は進捗に応じて更新し、完了後は関連ドキュメントから本チェックリストへリンクしてください。

--- a/docs/todo_next.md
+++ b/docs/todo_next.md
@@ -16,8 +16,7 @@
 
 ### In Progress
 
-
-- **ローリング検証パイプライン**（バックログ: `docs/task_backlog.md` → P1「ローリング検証 + 健全性モニタリング」） — `state.md` 2024-06-20, 2024-06-13, 2024-06-14, 2024-06-15, 2024-06-16 <!-- anchor: docs/task_backlog.md#p1-01-ローリング検証パイプライン -->
+- **ローリング検証パイプライン**（バックログ: `docs/task_backlog.md` → P1「ローリング検証 + 健全性モニタリング」） — `state.md` 2025-09-28, 2024-06-13, 2024-06-14, 2024-06-15, 2024-06-16 <!-- anchor: docs/task_backlog.md#p1-01-ローリング検証パイプライン -->
   - `scripts/run_benchmark_pipeline.py` の整備と `run_daily_workflow.py` 連携、期間指定リプレイ (`--start-ts` / `--end-ts`) の確認を継続中。
   - 次ステップ: ベンチマークランのローリング更新自動化と Sharpe / 最大 DD 指標の回帰監視強化。
   - 2025-09-30: `manage_task_cycle.py start-task` に runbook/pending 資料の上書きオプションを追加し、`sync_task_docs.py` のテンプレ適用を共通ヘルパーへ整理。`docs/codex_workflow.md` と README の手順を更新済み。
@@ -27,8 +26,9 @@
     - [docs/simulation_plan.md](docs/simulation_plan.md)
     - 主要ランブック: [docs/benchmark_runbook.md#スケジュールとアラート管理](docs/benchmark_runbook.md#スケジュールとアラート管理)
   - Pending Questions:
-    - [ ] なし（cadence/アラート閾値整理済み）
-  - DoD チェックリスト: [docs/templates/dod_checklist.md](docs/templates/dod_checklist.md) を [docs/checklists/p1-01.md](docs/checklists/p1-01.md) にコピーし、進捗リンクを更新する。
+    - [ ] なし
+  - Docs note: 参照: [docs/logic_overview.md](docs/logic_overview.md) / [docs/simulation_plan.md](docs/simulation_plan.md) / [docs/benchmark_runbook.md#スケジュールとアラート管理](docs/benchmark_runbook.md#スケジュールとアラート管理)
+  - DoD チェックリスト: [docs/checklists/p1-01.md](docs/checklists/p1-01.md) を更新して進捗を管理する。
 
 ### Ready
 

--- a/state.md
+++ b/state.md
@@ -13,6 +13,16 @@
 - 継続中に要調整点が出た場合はエントリ内に追記し、完了時にログへ移した後も追跡できるよう関連ドキュメントへリンクを残す。
 - 新規に `Next Task` へ追加する際は、方針整合性を確認するために [docs/logic_overview.md](docs/logic_overview.md) や [docs/simulation_plan.md](docs/simulation_plan.md) を参照し、必要なら関連メモへリンクする。
 
+- [P1-01] 2025-09-28 ローリング検証パイプライン — DoD: [docs/task_backlog.md#p1-01-ローリング検証パイプライン](docs/task_backlog.md#p1-01-ローリング検証パイプライン) — DoDを再確認し、365/180/90Dローリング更新と閾値監視の自動運用に向けたタスク整理を開始。
+  - Backlog Anchor: [ローリング検証パイプライン (P1-01)](docs/task_backlog.md#p1-01-ローリング検証パイプライン)
+  - Vision / Runbook References:
+    - [docs/logic_overview.md](docs/logic_overview.md)
+    - [docs/simulation_plan.md](docs/simulation_plan.md)
+    - 主要ランブック: [docs/benchmark_runbook.md#スケジュールとアラート管理](docs/benchmark_runbook.md#スケジュールとアラート管理)
+  - Pending Questions:
+    - [ ] なし
+  - Docs note: 参照: [docs/logic_overview.md](docs/logic_overview.md) / [docs/simulation_plan.md](docs/simulation_plan.md) / [docs/benchmark_runbook.md#スケジュールとアラート管理](docs/benchmark_runbook.md#スケジュールとアラート管理)
+
 ## Log
 - [P0-01] 2024-06-01: Initialized state tracking log and documented the review/update workflow rule.
 - [P0-02] 2024-06-02: Targeting P0 reliability by ensuring strategy manifests and CLI runners work without optional dependencies. DoD: pytest passes and run_sim/loader can parse manifests/EV profiles after removing the external PyYAML requirement.


### PR DESCRIPTION
## Summary
- record the P1-01 rolling validation pipeline task in state.md with references and a refreshed pending-questions list
- refresh docs/todo_next.md to align the In Progress entry with the latest start date, reference links, and checklist pointer
- add a dedicated DoD checklist for P1-01 so progress can be tracked directly from the shared docs

## Testing
- not run (documentation changes only)

## 日本語サマリ
- P1-01ローリング検証パイプラインのタスク記録とTODO同期を実施し、参照資料リンクと専用DoDチェックリストを整備しました。


------
https://chatgpt.com/codex/tasks/task_e_68d9c2f39ccc832a8cbe31bd3a2d611b