### PR TITLE
Support strategy manifest parameters in run_sim

### DIFF
--- a/configs/strategies/reversion_stub.yaml
+++ b/configs/strategies/reversion_stub.yaml
@@ -1,0 +1,63 @@
+meta:
+  id: mean_reversion_stub_v1
+  name: Mean Reversion Stub (USDJPY)
+  version: "1.0"
+  category: day
+  description: |
+    Mean reversion stub used for regression tests. Demonstrates how strategy
+    manifests supply custom parameters such as z-score thresholds and RV gate
+    toggles.
+
+strategy:
+  class_path: strategies.reversion_stub.MeanReversionStrategy
+  instruments:
+    - symbol: USDJPY
+      timeframe: 5m
+      mode: conservative
+  parameters:
+    or_n: 2
+    k_tp: 0.5
+    k_sl: 0.7
+    cooldown_bars: 1
+    zscore_threshold: 0.5
+    allow_high_rv: true
+
+router:
+  allowed_sessions: [LDN, NY, TOK]
+  allow_rv_bands: [low, mid, high]
+
+risk:
+  risk_per_trade_pct: 0.1
+  max_daily_dd_pct: 8.0
+  notional_cap: 500000
+  max_concurrent_positions: 1
+  warmup_trades: 0
+
+features:
+  required:
+    - zscore
+    - rv_band
+  optional:
+    - atr14
+    - adx14
+
+runner:
+  runner_config:
+    threshold_lcb_pip: 0.0
+    min_or_atr_ratio: 0.0
+    allowed_sessions: [LDN, NY, TOK]
+    allow_low_rv: true
+    spread_bands:
+      narrow: 3.0
+      normal: 5.0
+      wide: 99.0
+    warmup_trades: 0
+  cli_args:
+    equity: 100000
+    allowed_sessions: LDN,NY,TOK
+
+state:
+  archive_namespace: strategies.reversion_stub.MeanReversionStrategy/USDJPY/conservative
+
+notes:
+  - Example manifest for the mean reversion stub leveraged by CLI regression tests.

--- a/docs/progress_phase1.md
+++ b/docs/progress_phase1.md
@@ -4,6 +4,7 @@
 - `strategies/day_orb_5m.py` に `strategy_gate` / `ev_threshold` 実装済み。
 - サンプル戦略として `strategies/reversion_stub.py` を追加。低ボラ時の閾値緩和・高ボラ時のブロック動作を確認済み。`
 - CLI `run_sim.py --strategy <module.Class>` で任意戦略を注入可能。
+- `scripts/run_sim.py --strategy-manifest` が `configs/strategies/*.yaml` を読み込み、RunnerConfig の許容セッション/リスク上限を適用しつつ戦略パラメータ（例: `allow_high_rv` / `zscore_threshold`）を `Strategy.on_start` にそのまま渡すフローを整備。回帰テスト: `tests/test_run_sim_cli.py::test_run_sim_manifest_mean_reversion`。DoD: [docs/task_backlog.md#p2-マルチ戦略ポートフォリオ化](docs/task_backlog.md#p2-マルチ戦略ポートフォリオ化)。
 
 ## 2. EV 閾値ケーススタディ
 - ユーティリティ `scripts/generate_ev_case_study.py` を追加し、複数の `threshold_lcb` を一括比較可能。

--- a/docs/task_backlog.md
+++ b/docs/task_backlog.md
@@ -76,6 +76,7 @@ Document the repeatable workflow that lets Codex keep `state.md`, `docs/todo_nex
 ## P2: マルチ戦略ポートフォリオ化
 - **戦略マニフェスト整備**: スキャル/デイ/スイングの候補戦略ごとに、依存特徴量・セッション・リスク上限を YAML で定義し、ルーターが参照できるようにする (`configs/strategies/*.yaml`)。
   - 2025-10-09: `configs/strategies/templates/base_strategy.yaml` に共通テンプレートと記述ガイドを追加し、新規戦略のマニフェスト整備を着手しやすくした。
+  - 2024-06-22: `scripts/run_sim.py --strategy-manifest` でマニフェストを読み込み、RunnerConfig の許容セッション/リスク上限と戦略固有パラメータを `Strategy.on_start` に直結するフローを整備。`tests/test_run_sim_cli.py::test_run_sim_manifest_mean_reversion` で `allow_high_rv` / `zscore_threshold` が `strategy_gate`・`ev_threshold` へ渡ることを確認。DoD: [フェーズ1-戦略別ゲート整備](docs/progress_phase1.md#1-戦略別ゲート整備)。
 - **ルーター拡張**: 現行ルールベース (`router/router_v0.py`) を拡張し、カテゴリ配分・相関・キャパ制約を反映。戦略ごとの state/EV/サイズ情報を統合してスコアリングする。
 - **ポートフォリオ評価レポート**: 複数戦略を同時に流した場合の資本使用率・相関・ドローダウンを集計する `analysis/portfolio_monitor.ipynb` と `reports/portfolio_summary.json` を追加。
 - **マルチ戦略比較バリデーション**: Day ORB と Mean Reversion (reversion_stub) を同一 CSV で走らせ、`docs/checklists/multi_strategy_validation.md` に沿ってゲート通過数・EV リジェクト数・期待値差をレビュー。DoD: チェックリストの全項目を完了し、比較サマリをレビュー用ドキュメントへ共有する。

--- a/state.md
+++ b/state.md
@@ -25,6 +25,7 @@
   - 2025-09-28: 手動でローリング 365/180/90D を再生成し、Sharpe・最大DD・勝率が揃って出力されていることと `benchmark_runs.alert` の delta_sharpe トリガーを確認。Slack Webhook が 403 で失敗したため、ランブックへサンドボックス時の扱いを追記する。
 
 ## Log
+- [P2-MS] 2024-06-22: `scripts/run_sim.py --strategy-manifest` を実装し、`RunnerConfig` がマニフェスト経由の許容セッション/リスク上限と戦略パラメータを取り込むよう更新。`core/runner.py` の `StrategyConfig` を汎用辞書対応に拡張し、`tests/test_run_sim_cli.py::test_run_sim_manifest_mean_reversion` で `allow_high_rv` / `zscore_threshold` が `strategy_gate`・`ev_threshold` へ届くことを検証。関連ドキュメント: [docs/task_backlog.md](docs/task_backlog.md)、[docs/progress_phase1.md](docs/progress_phase1.md)。
 - [P0-01] 2024-06-01: Initialized state tracking log and documented the review/update workflow rule.
 - [P0-02] 2024-06-02: Targeting P0 reliability by ensuring strategy manifests and CLI runners work without optional dependencies. DoD: pytest passes and run_sim/loader can parse manifests/EV profiles after removing the external PyYAML requirement.
 - [P0-03] 2024-06-03: 同期 `scripts/rebuild_runs_index.py` を拡充し、`runs/index.csv` の列網羅性テストを追加。DoD: pytest オールパスと CSV 列の欠損ゼロ。


### PR DESCRIPTION
## Summary
- allow `StrategyConfig` and `RunnerConfig` to merge arbitrary parameters so manifests can reach strategy hooks
- add a `--strategy-manifest` option to `scripts/run_sim.py` that loads YAML defaults, merges runner/risk settings, and tracks the manifest used during runs
- create a regression manifest and CLI test for the mean reversion stub while documenting the manifest workflow updates

## Testing
- python3 -m pytest tests/test_run_sim_cli.py


------
https://chatgpt.com/codex/tasks/task_e_68d9d97d81f0832a9c4c7ed3f405098e