### PR TITLE
Add win rate checks to benchmark pipeline validations

### DIFF
--- a/docs/checklists/p1-01.md
+++ b/docs/checklists/p1-01.md
@@ -13,7 +13,7 @@
 
 ## バックログ固有の DoD
 - [ ] `scripts/run_benchmark_runs.py` / `scripts/report_benchmark_summary.py` を通じて365D・180D・90Dローリング run が定期更新されている。
-- [ ] `reports/rolling/<window>/*.json` と `reports/benchmark_summary.json` に勝率・Sharpe・最大DDが揃って出力されている。
+- [ ] `reports/rolling/<window>/*.json` と `reports/benchmark_summary.json` に勝率・Sharpe・最大DDが揃って出力され、`scripts/run_benchmark_pipeline.py` のバリデーションでも同項目が検証されている。
 - [ ] ジョブ実行フローとアラート閾値の更新内容を README もしくは runbook に追記し、再実行手順が明文化されている。
 
 ## 成果物とログ更新

--- a/state.md
+++ b/state.md
@@ -25,6 +25,7 @@
   - 2025-09-28: 手動でローリング 365/180/90D を再生成し、Sharpe・最大DD・勝率が揃って出力されていることと `benchmark_runs.alert` の delta_sharpe トリガーを確認。Slack Webhook が 403 で失敗したため、ランブックへサンドボックス時の扱いを追記する。
 
 ## Log
+- [P1-01] 2025-10-11: 強制バリデーションへ勝率を追加し、`run_benchmark_pipeline.py` がローリング/サマリー双方で win_rate・Sharpe・最大DD の欠損を検知するよう更新。`tests/test_run_benchmark_pipeline.py` に成功ケースの勝率出力と勝率欠損エラーの回帰テストを追加し、`docs/checklists/p1-01.md` の DoD に勝率検証ステップを追記。`python3 -m pytest tests/test_run_benchmark_pipeline.py` を実行し全件パス。
 - [P1-06] 2025-10-10: `docs/broker_oco_matrix.md` に OANDA / IG / SBI FXトレードの OCO 同足処理・トレール更新間隔を追記し、`analysis/broker_fills_cli.py` で Conservative / Bridge / 実仕様差分を Markdown テーブル化。`core/fill_engine.py` に `SameBarPolicy` とトレール更新ロジックを導入し、`tests/test_fill_engine.py` を新設して代表ケース（Tick 優先 / 保護優先 / トレール更新）を固定。`docs/progress_phase1.md` / `docs/benchmark_runbook.md` を再実行手順・検証フローで更新し、`python3 -m pytest` を完走。
 - [P2-MS] 2024-06-22: `scripts/run_sim.py --strategy-manifest` を実装し、`RunnerConfig` がマニフェスト経由の許容セッション/リスク上限と戦略パラメータを取り込むよう更新。`core/runner.py` の `StrategyConfig` を汎用辞書対応に拡張し、`tests/test_run_sim_cli.py::test_run_sim_manifest_mean_reversion` で `allow_high_rv` / `zscore_threshold` が `strategy_gate`・`ev_threshold` へ届くことを検証。関連ドキュメント: [docs/task_backlog.md](docs/task_backlog.md)、[docs/progress_phase1.md](docs/progress_phase1.md)。
 - [P0-01] 2024-06-01: Initialized state tracking log and documented the review/update workflow rule.


### PR DESCRIPTION
## Summary
- require win_rate alongside sharpe and max_drawdown in rolling metrics validation
- validate summary payload metrics and add pytest coverage for missing win_rate scenarios
- update the P1-01 checklist and state log to reflect the new win rate verification

## Testing
- python3 -m pytest tests/test_run_benchmark_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68d9f9f3a110832aa1254eaaf7f4901d