### PR TITLE
Add ingest source override to daily workflow CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ python3 scripts/run_daily_workflow.py \
   --symbol USDJPY --mode conservative --equity 100000
 ```
 
+`--ingest-source path/to.csv` を併用すると、日次ワークフロー経由でも `pull_prices.py --source` へ任意の CSV を渡せます（既定は `data/usdjpy_5m_2018-2024_utc.csv`）。
+
 ベンチマーク窓ごとの実行スケジュールとアラート閾値の管理方針は、[docs/benchmark_runbook.md#スケジュールとアラート管理](docs/benchmark_runbook.md#スケジュールとアラート管理) を参照してください。`scripts/manage_task_cycle.py start-task` を使って `state.md` / `docs/todo_next.md` と整合を取る手順も同セクションにまとめています。
 
 個別実行の例（必要なものだけ）:

--- a/docs/state_runbook.md
+++ b/docs/state_runbook.md
@@ -21,6 +21,8 @@ EV ゲートや滑り学習などの内部状態を `state.json` として保存
 python3 scripts/run_daily_workflow.py --ingest --update-state --benchmarks --state-health --benchmark-summary
 ```
 
+`--ingest-source path/to.csv` を付与すると、手元の CSV を `pull_prices.py --source` にそのまま引き渡せます（既定は `data/usdjpy_5m_2018-2024_utc.csv`）。
+
 - 個別の実行例
   - 取り込み: `python3 scripts/pull_prices.py --source data/usdjpy_5m_2018-2024_utc.csv`
   - state更新: `python3 scripts/update_state.py --bars validated/USDJPY/5m.csv --chunk-size 20000`

--- a/scripts/run_daily_workflow.py
+++ b/scripts/run_daily_workflow.py
@@ -23,6 +23,11 @@ def main(argv=None) -> int:
     parser.add_argument("--mode", default="conservative", choices=["conservative", "bridge"])
     parser.add_argument("--equity", default="100000")
     parser.add_argument("--ingest", action="store_true", help="Run pull_prices to append latest bars")
+    parser.add_argument(
+        "--ingest-source",
+        default=None,
+        help="Override source CSV path passed to pull_prices.py",
+    )
     parser.add_argument("--update-state", action="store_true", help="Replay new bars and update state.json")
     parser.add_argument("--benchmarks", action="store_true", help="Run baseline + rolling benchmarks")
     parser.add_argument("--state-health", action="store_true", help="Run state health checker")
@@ -96,9 +101,15 @@ def main(argv=None) -> int:
     bars_csv = args.bars or str(ROOT / f"validated/{args.symbol}/5m.csv")
 
     if args.ingest:
-        cmd = [sys.executable, str(ROOT / "scripts/pull_prices.py"),
-               "--source", str(ROOT / "data/usdjpy_5m_2018-2024_utc.csv"),
-               "--symbol", args.symbol]
+        ingest_source = args.ingest_source or str(ROOT / "data/usdjpy_5m_2018-2024_utc.csv")
+        cmd = [
+            sys.executable,
+            str(ROOT / "scripts/pull_prices.py"),
+            "--source",
+            ingest_source,
+            "--symbol",
+            args.symbol,
+        ]
         exit_code = run_cmd(cmd)
         if exit_code:
             return exit_code

--- a/state.md
+++ b/state.md
@@ -36,6 +36,7 @@
   - 2025-10-16: 最新バーの供給が途絶しているため、P1-04 で API インジェスト基盤を設計・整備し、鮮度チェックのブロッカーを解消する計画。
 
 ## Log
+- [P1-04] 2025-10-17: Added `--ingest-source` passthrough to `run_daily_workflow.py` ingest calls, documented usage in README/state runbook, and extended pytest coverage for the custom source path.
 - [P1-01] 2025-10-15: Added `--min-win-rate` health threshold to benchmark summary / pipeline / daily workflow CLIs, ensured `threshold_alerts` propagation into runtime snapshots, refreshed README + benchmark runbook + checklist guidance, linked the backlog progress note, and ran `python3 -m pytest`.
 - [P1-01] 2025-10-14: Added `scripts/check_benchmark_freshness.py` with regression tests, wired the CLI into `run_daily_workflow.py --check-benchmark-freshness`, and documented the 6h freshness threshold across the benchmark runbook / P1-01 checklist / backlog notes.
 - [P1-05] 2025-10-13: Added deterministic hook-failure regression for `run_sim` debug counters/records, updated

--- a/tests/test_run_daily_workflow.py
+++ b/tests/test_run_daily_workflow.py
@@ -130,6 +130,23 @@ def test_benchmarks_pipeline_arguments(monkeypatch):
     assert cmd[cmd.index("--windows") + 1] == "200,60"
 
 
+def test_ingest_with_custom_source(monkeypatch, tmp_path):
+    captured = _capture_run_cmd(monkeypatch)
+    custom_source = tmp_path / "custom.csv"
+
+    exit_code = run_daily_workflow.main([
+        "--ingest",
+        "--ingest-source",
+        str(custom_source),
+    ])
+
+    assert exit_code == 0
+    assert captured, "run_cmd should be invoked"
+    cmd = captured[0]
+    assert "--source" in cmd
+    assert Path(cmd[cmd.index("--source") + 1]) == custom_source
+
+
 def test_optimize_uses_absolute_paths(monkeypatch):
     captured = _capture_run_cmd(monkeypatch)
 


### PR DESCRIPTION
## Summary
- add a `--ingest-source` flag to `run_daily_workflow.py` so custom CSV locations can be forwarded to `pull_prices.py`
- cover the new option with a regression test for the ingest command invocation
- document the override in the README and state runbook and log the workflow update in `state.md`

## Testing
- python3 -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68db03516234832aa94be325d9afc9e0