### PR TITLE
Update on-demand benchmark workflow documentation

### DIFF
--- a/docs/state_runbook.md
+++ b/docs/state_runbook.md
@@ -26,7 +26,7 @@ python3 scripts/run_daily_workflow.py --ingest --update-state --benchmarks --sta
 - 個別の実行例
   - 取り込み: `python3 scripts/pull_prices.py --source data/usdjpy_5m_2018-2024_utc.csv`
   - state更新: `python3 scripts/update_state.py --bars validated/USDJPY/5m.csv --chunk-size 20000`
-  - 検証・集計: `python3 scripts/run_benchmark_runs.py --bars validated/USDJPY/5m.csv --windows 365,180,90` → `python3 scripts/report_benchmark_summary.py --plot-out reports/benchmark_summary.png`
+  - 検証・集計: `python3 scripts/run_benchmark_pipeline.py --bars validated/USDJPY/5m.csv --symbol USDJPY --mode conservative --windows 365,180,90 --snapshot ops/runtime_snapshot.json` → `python3 scripts/report_benchmark_summary.py --reports-dir reports --windows 365,180,90 --plot-out reports/benchmark_summary.png`
   - ヘルスチェック: `python3 scripts/check_state_health.py`
 
 ## 推奨運用

--- a/readme/設計方針（投資_3_）v_1.md
+++ b/readme/設計方針（投資_3_）v_1.md
@@ -291,8 +291,8 @@ for row in bars_sorted:
 - **起動トリガー**: ノートPCを起動/ログインしたタイミングで `scripts/run_daily_workflow.py`（または Automator/launchd）を呼び出し、一連のジョブを順番に実行する。
 - **データ補完**: `scripts/pull_prices.py` が前回成功時刻を `ops/last_ingest.json` に保持し、停止中の期間をヒストリカルAPI/CSVからまとめて取得して `raw/`→`validated/`→`features/` に追記する。
 - **state 更新**: 取得したバーを時系列順に `scripts/update_state.py` が処理し、`BacktestRunner` の `load_state` → `run_partial` → `export_state` を繰り返して `ops/state_archive` と最新 `state.json` を更新する。途中で中断しても再実行で追いつけるよう冪等性を担保する。
-- **検証とレポート**: 補完後に `scripts/run_baseline.py` と `scripts/run_rolling.py` を起動してベースライン/ローリング run を再計算し、差分レポートとヘルスチェック結果を Webhook へ通知する。
-- **終了処理**: 成果物（metrics/daily/state/health）を `runs/` と `reports/` に保存し、次回起動時の再開地点を `ops/runtime_snapshot.json` に記録。オフライン中のギャップは次回起動で自動解消される。
+- **検証とレポート**: 補完後に `python3 scripts/run_benchmark_pipeline.py --windows 365,180,90` を実行してベースライン/ローリング run を再計算し、続けて `python3 scripts/report_benchmark_summary.py --reports-dir reports --windows 365,180,90` で最新サマリーを生成・通知する（詳細は [docs/state_runbook.md#オンデマンド起動フロー（ノートPC向け）](../docs/state_runbook.md#オンデマンド起動フロー（ノートpc向け）) を参照）。
+- **終了処理**: 成果物（metrics/daily/state/health）を `runs/` と `reports/` に保存し、スナップショットは `ops/runtime_snapshot.json` に固定で書き出して次回起動時の再開地点を残す。オフライン中のギャップは次回起動で自動解消される。
 
 
 

--- a/state.md
+++ b/state.md
@@ -36,6 +36,7 @@
   - 2025-10-16: 最新バーの供給が途絶しているため、P1-04 で API インジェスト基盤を設計・整備し、鮮度チェックのブロッカーを解消する計画。
 
 ## Log
+- [P1-01] 2025-10-17: Normalized on-demand workflow docs to reference `run_benchmark_pipeline.py` / `report_benchmark_summary.py`, clarified the `ops/runtime_snapshot.json` snapshot target, and aligned the state runbook linkages.
 - [P1-04] 2025-10-17: Added `--ingest-source` passthrough to `run_daily_workflow.py` ingest calls, documented usage in README/state runbook, and extended pytest coverage for the custom source path.
 - [P1-01] 2025-10-15: Added `--min-win-rate` health threshold to benchmark summary / pipeline / daily workflow CLIs, ensured `threshold_alerts` propagation into runtime snapshots, refreshed README + benchmark runbook + checklist guidance, linked the backlog progress note, and ran `python3 -m pytest`.
 - [P1-01] 2025-10-14: Added `scripts/check_benchmark_freshness.py` with regression tests, wired the CLI into `run_daily_workflow.py --check-benchmark-freshness`, and documented the 6h freshness threshold across the benchmark runbook / P1-01 checklist / backlog notes.


### PR DESCRIPTION
## Summary
- replace the on-demand workflow guidance to use the benchmark pipeline and summary scripts
- call out ops/runtime_snapshot.json as the fixed runtime snapshot destination
- align docs/state_runbook.md examples and record the documentation refresh in state.md

## Testing
- not run (docs only)

## サマリー
- ベンチマーク更新フローの記述を最新CLIに合わせ、スナップショット保存先を明記しました。


------
https://chatgpt.com/codex/tasks/task_e_68db05590880832ab921bdd686c1e81c