### PR TITLE
Expand pull_prices anomaly regression coverage

### DIFF
--- a/state.md
+++ b/state.md
@@ -36,6 +36,7 @@
   - 2025-10-16: 最新バーの供給が途絶しているため、P1-04 で API インジェスト基盤を設計・整備し、鮮度チェックのブロッカーを解消する計画。
 
 ## Log
+- [P1-04] 2025-10-17: Hardened `pull_prices` ingestion tests to cover gap detection, mismatch anomaly retention, and dry-run output. Verified `python3 -m pytest tests/test_pull_prices.py` completes successfully.
 - [P1-01] 2025-10-17: Normalized on-demand workflow docs to reference `run_benchmark_pipeline.py` / `report_benchmark_summary.py`, clarified the `ops/runtime_snapshot.json` snapshot target, and aligned the state runbook linkages.
 - [P1-04] 2025-10-17: Added `--ingest-source` passthrough to `run_daily_workflow.py` ingest calls, documented usage in README/state runbook, and extended pytest coverage for the custom source path.
 - [P1-01] 2025-10-15: Added `--min-win-rate` health threshold to benchmark summary / pipeline / daily workflow CLIs, ensured `threshold_alerts` propagation into runtime snapshots, refreshed README + benchmark runbook + checklist guidance, linked the backlog progress note, and ran `python3 -m pytest`.

--- a/tests/test_pull_prices.py
+++ b/tests/test_pull_prices.py
@@ -20,9 +20,27 @@ SOURCE_CSV = """timestamp,symbol,tf,o,h,l,c,v,spread
 """
 
 
-def _run_pull_prices(tmp_path: Path) -> dict:
+GAP_SOURCE_CSV = """timestamp,symbol,tf,o,h,l,c,v,spread
+2024-01-01T00:00:00Z,USDJPY,5m,150.00,150.10,149.90,150.02,120,0.02
+2024-01-01T00:15:00Z,USDJPY,5m,150.02,150.12,149.92,150.04,118,0.02
+2024-01-01T00:20:00Z,USDJPY,5m,150.04,150.14,149.94,150.06,116,0.02
+"""
+
+
+MISMATCH_SOURCE_CSV = """timestamp,symbol,tf,o,h,l,c,v,spread
+2024-01-01T00:40:00Z,USDJPY,1m,150.20,150.30,150.10,150.22,100,0.02
+2024-01-01T00:45:00Z,EURUSD,5m,150.22,150.32,150.12,150.24,98,0.02
+"""
+
+
+def _run_pull_prices(
+    tmp_path: Path,
+    *,
+    csv_text: str = SOURCE_CSV,
+    extra_args: list[str] | None = None,
+) -> dict:
     source_csv = tmp_path / "source.csv"
-    source_csv.write_text(SOURCE_CSV)
+    source_csv.write_text(csv_text)
     snapshot_path = tmp_path / "snapshot.json"
     cmd = [
         sys.executable,
@@ -36,6 +54,8 @@ def _run_pull_prices(tmp_path: Path) -> dict:
         "--snapshot",
         str(snapshot_path),
     ]
+    if extra_args:
+        cmd.extend(extra_args)
     proc = subprocess.run(cmd, cwd=tmp_path, capture_output=True, text=True)
     assert proc.returncode == 0, proc.stderr
     payload = json.loads(proc.stdout.strip())
@@ -90,4 +110,83 @@ def test_pull_prices_pipeline(tmp_path):
     with features_path.open(newline="", encoding="utf-8") as f:
         feature_rows_second = list(csv.DictReader(f))
     assert len(feature_rows_second) == 8
+
+
+def test_pull_prices_gap_detection(tmp_path):
+    payload = _run_pull_prices(tmp_path, csv_text=GAP_SOURCE_CSV)
+    assert payload["rows_raw"] == 3
+    assert payload["rows_validated"] == 3
+    assert payload["rows_featured"] == 3
+    assert payload["gaps_detected"] == 1
+    assert payload["anomalies_logged"] == 1
+
+    anomalies_path = tmp_path / "ops" / "logs" / "ingest_anomalies.jsonl"
+    assert anomalies_path.exists()
+
+    records = [json.loads(line) for line in anomalies_path.read_text().splitlines() if line]
+    assert len(records) == 1
+    gap_entry = records[0]
+    assert gap_entry["type"] == "gap"
+    assert gap_entry["minutes"] == 15.0
+
+
+def test_pull_prices_mismatched_rows_stay_in_raw(tmp_path):
+    base_payload = _run_pull_prices(tmp_path)
+    assert base_payload["rows_validated"] == 8
+
+    raw_path = tmp_path / "raw" / "USDJPY" / "5m.csv"
+    validated_path = tmp_path / "validated" / "USDJPY" / "5m.csv"
+    features_path = tmp_path / "features" / "USDJPY" / "5m.csv"
+    anomalies_path = tmp_path / "ops" / "logs" / "ingest_anomalies.jsonl"
+
+    assert raw_path.exists()
+    assert validated_path.exists()
+    assert features_path.exists()
+    assert not anomalies_path.exists()
+
+    payload = _run_pull_prices(tmp_path, csv_text=MISMATCH_SOURCE_CSV)
+    assert payload["rows_raw"] == 2
+    assert payload["rows_validated"] == 0
+    assert payload["rows_featured"] == 0
+    assert payload["anomalies_logged"] == 2
+    assert payload["gaps_detected"] == 0
+
+    with raw_path.open(newline="", encoding="utf-8") as f:
+        raw_rows = list(csv.DictReader(f))
+    assert len(raw_rows) == 10
+    assert raw_rows[-2]["tf"] == "1m"
+    assert raw_rows[-1]["symbol"] == "EURUSD"
+
+    with validated_path.open(newline="", encoding="utf-8") as f:
+        validated_rows = list(csv.DictReader(f))
+    assert len(validated_rows) == 8
+
+    with features_path.open(newline="", encoding="utf-8") as f:
+        feature_rows = list(csv.DictReader(f))
+    assert len(feature_rows) == 8
+
+    records = [json.loads(line) for line in anomalies_path.read_text().splitlines() if line]
+    types = {entry["type"] for entry in records}
+    assert {"tf_mismatch", "symbol_mismatch"}.issubset(types)
+
+
+def test_pull_prices_dry_run_reports_counts_without_files(tmp_path):
+    payload = _run_pull_prices(tmp_path, extra_args=["--dry-run"])
+    assert payload["rows_raw"] == 8
+    assert payload["rows_validated"] == 8
+    assert payload["rows_featured"] == 8
+    assert payload["gaps_detected"] == 0
+    assert payload["anomalies_logged"] == 0
+
+    raw_path = tmp_path / "raw" / "USDJPY" / "5m.csv"
+    validated_path = tmp_path / "validated" / "USDJPY" / "5m.csv"
+    features_path = tmp_path / "features" / "USDJPY" / "5m.csv"
+    snapshot_path = tmp_path / "snapshot.json"
+    anomalies_path = tmp_path / "ops" / "logs" / "ingest_anomalies.jsonl"
+
+    assert not raw_path.exists()
+    assert not validated_path.exists()
+    assert not features_path.exists()
+    assert not snapshot_path.exists()
+    assert not anomalies_path.exists()
 


### PR DESCRIPTION
## Summary
- extend the pull_prices test helper so fixtures can drive gap, anomaly, and dry-run scenarios
- add regression tests that check gap logging, mismatch rows staying in raw storage, and dry-run count reporting
- record the new ingestion regression coverage in state.md for the ongoing P1-04 effort

## Testing
- python3 -m pytest tests/test_pull_prices.py

------
https://chatgpt.com/codex/tasks/task_e_68db0d1618ec832abf009934a0d43249