### PR TITLE
Normalize latency analyzer timestamp parsing

### DIFF
--- a/scripts/analyze_signal_latency.py
+++ b/scripts/analyze_signal_latency.py
@@ -8,13 +8,18 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, Dict
 
+from scripts._ts_utils import _normalize_iso_string
+
 
 def parse_iso(ts: str) -> datetime:
+    text = ts.strip()
+    normalized = _normalize_iso_string(text)
     try:
-        return datetime.fromisoformat(ts)
+        return datetime.fromisoformat(normalized)
     except ValueError:
         # allow space separator
-        return datetime.fromisoformat(ts.replace(" ", "T"))
+        normalized = _normalize_iso_string(text.replace(" ", "T"))
+        return datetime.fromisoformat(normalized)
 
 
 def load_latencies(path: Path) -> List[Dict[str, object]]:

--- a/state.md
+++ b/state.md
@@ -36,6 +36,7 @@
   - 2025-10-16: 最新バーの供給が途絶しているため、P1-04 で API インジェスト基盤を設計・整備し、鮮度チェックのブロッカーを解消する計画。
 
 ## Log
+- [P1-01] 2025-10-17: Updated `scripts/analyze_signal_latency.py` to reuse the shared ISO normalizer so Z-suffix timestamps stay parseable, added pytest coverage for `load_latencies` handling of UTC records, and re-ran `python3 -m pytest tests/test_analyze_signal_latency.py tests/test_run_daily_workflow.py` for the CLI regression check.
 - [P1-04] 2025-10-17: Hardened `pull_prices` ingestion tests to cover gap detection, mismatch anomaly retention, and dry-run output. Verified `python3 -m pytest tests/test_pull_prices.py` completes successfully.
 - [P1-01] 2025-10-17: Normalized on-demand workflow docs to reference `run_benchmark_pipeline.py` / `report_benchmark_summary.py`, clarified the `ops/runtime_snapshot.json` snapshot target, and aligned the state runbook linkages.
 - [P1-04] 2025-10-17: Added `--ingest-source` passthrough to `run_daily_workflow.py` ingest calls, documented usage in README/state runbook, and extended pytest coverage for the custom source path.

--- a/tests/test_analyze_signal_latency.py
+++ b/tests/test_analyze_signal_latency.py
@@ -1,0 +1,21 @@
+import pytest
+
+from scripts import analyze_signal_latency
+
+
+def test_load_latencies_handles_z_suffix(tmp_path):
+    csv_path = tmp_path / "latency.csv"
+    csv_path.write_text(
+        "signal_id,status,ts_emit,ts_ack,detail\n"
+        "abc123,success,2024-05-01T00:00:00Z,2024-05-01T00:00:01Z,ok\n",
+        encoding="utf-8",
+    )
+
+    records = analyze_signal_latency.load_latencies(csv_path)
+
+    assert len(records) == 1
+    record = records[0]
+    assert record["signal_id"] == "abc123"
+    assert record["status"] == "success"
+    assert record["detail"] == "ok"
+    assert record["latency"] == pytest.approx(1.0)


### PR DESCRIPTION
## Summary
- reuse the shared timestamp normalizer in `scripts/analyze_signal_latency.parse_iso` so UTC `Z` suffixes and offsets parse consistently
- add regression coverage ensuring `load_latencies` retains records with `Z`-suffixed timestamps
- record the maintenance work in `state.md` for task tracking

## Testing
- python3 -m pytest tests/test_analyze_signal_latency.py tests/test_run_daily_workflow.py

日本語サマリ: シグナル遅延解析のZサフィックス対応と回帰テストを追加し、state.mdを更新しました。

------
https://chatgpt.com/codex/tasks/task_e_68db30b3ab9c832abbba448827ec5fe7