### PR TITLE
Improve analyze_signal_latency import fallback

### DIFF
--- a/scripts/analyze_signal_latency.py
+++ b/scripts/analyze_signal_latency.py
@@ -4,17 +4,27 @@ from __future__ import annotations
 import argparse
 import csv
 import json
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import List, Dict
 
 
+try:
+    from scripts._ts_utils import _normalize_iso_string
+except ModuleNotFoundError:
+    current_dir = Path(__file__).resolve().parent
+    if str(current_dir) not in sys.path:
+        sys.path.append(str(current_dir))
+    from _ts_utils import _normalize_iso_string
+
+
 def parse_iso(ts: str) -> datetime:
     try:
-        return datetime.fromisoformat(ts)
+        return datetime.fromisoformat(_normalize_iso_string(ts))
     except ValueError:
         # allow space separator
-        return datetime.fromisoformat(ts.replace(" ", "T"))
+        return datetime.fromisoformat(_normalize_iso_string(ts.replace(" ", "T")))
 
 
 def load_latencies(path: Path) -> List[Dict[str, object]]:

--- a/state.md
+++ b/state.md
@@ -36,6 +36,7 @@
   - 2025-10-16: 最新バーの供給が途絶しているため、P1-04 で API インジェスト基盤を設計・整備し、鮮度チェックのブロッカーを解消する計画。
 
 ## Log
+- [Maintenance] 2025-10-17: Added resilient import fallback for `scripts/analyze_signal_latency.py` to prefer package-style resolution before falling back to local modules, and introduced targeted pytest coverage for the timestamp parser.
 - [P1-04] 2025-10-17: Hardened `pull_prices` ingestion tests to cover gap detection, mismatch anomaly retention, and dry-run output. Verified `python3 -m pytest tests/test_pull_prices.py` completes successfully.
 - [P1-01] 2025-10-17: Normalized on-demand workflow docs to reference `run_benchmark_pipeline.py` / `report_benchmark_summary.py`, clarified the `ops/runtime_snapshot.json` snapshot target, and aligned the state runbook linkages.
 - [P1-04] 2025-10-17: Added `--ingest-source` passthrough to `run_daily_workflow.py` ingest calls, documented usage in README/state runbook, and extended pytest coverage for the custom source path.

--- a/tests/test_analyze_signal_latency.py
+++ b/tests/test_analyze_signal_latency.py
@@ -1,0 +1,13 @@
+from datetime import datetime, timezone
+
+from scripts.analyze_signal_latency import parse_iso
+
+
+def test_parse_iso_handles_z_suffix():
+    ts = parse_iso("2024-01-01T12:34:56Z")
+    assert ts == datetime(2024, 1, 1, 12, 34, 56, tzinfo=timezone.utc)
+
+
+def test_parse_iso_handles_space_separator():
+    ts = parse_iso("2024-01-01 12:34:56Z")
+    assert ts == datetime(2024, 1, 1, 12, 34, 56, tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary
- prefer the package-form import for `_normalize_iso_string` and fall back to the local module when needed
- reuse the shared normalizer inside `parse_iso` and add focused tests that lock in Z/space timestamp handling
- document the maintenance change in `state.md`

## Testing
- python3 scripts/analyze_signal_latency.py --help
- python3 /workspace/INVEST4_ORB5M_CODEX_B/scripts/analyze_signal_latency.py --help
- python3 -m pytest tests/test_analyze_signal_latency.py tests/test_run_daily_workflow.py


------
https://chatgpt.com/codex/tasks/task_e_68db4bc219bc832ab19754dd6e5d1c51