### PR TITLE
Document API ingest activation and escalation procedures

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ python3 scripts/run_sim.py --csv data/ohlc5m.csv --symbol USDJPY --json-out out.
 - `scripts/pull_prices.py` はヒストリカルCSV（またはAPIエクスポート）から未処理バーを検出し、`raw/`→`validated/`→`features/` に冪等に追記する。
 - `python3 scripts/run_daily_workflow.py --ingest --use-dukascopy` が現在の標準経路。Dukascopy から最新5mバーを取得し、そのまま `pull_prices.ingest_records` に渡して CSV/特徴量を同期する。Dukascopy が失敗するか、取得した最終バーが `--dukascopy-freshness-threshold-minutes`（既定 90 分）より古い場合は自動で yfinance (`period="7d"`) へ切り替わり、同一の CSV/特徴量更新が継続する。
 - 依存ライブラリ（任意導入）: `pip install dukascopy-python yfinance`。フォールバック経路では Yahoo Finance のシンボル変換（例: USDJPY→JPY=X）が自動適用される。
-- REST API 連携は `scripts/fetch_prices_api.py` を経由して行う設計だが、Alpha Vantage FX_INTRADAY がプレミアム専用であるため 2025-10 時点では **保留**。`--use-api` フラグと `configs/api_ingest.yml` は将来の有料契約/無料代替APIに備えて残している。
+- REST API 連携は `scripts/fetch_prices_api.py` を経由して行う設計だが、Alpha Vantage FX_INTRADAY がプレミアム専用であるため 2025-10 時点では **保留**。再開時は `configs/api_ingest.yml` の `activation_criteria`（ターゲットコスト上限 40 USD/月以内、日次最低無料枠 500 リクエスト以上、リトライ予算 15 回以内 など）を満たすか確認し、`ALPHA_VANTAGE_API_KEY` 等の環境変数をエクスポートした上で `configs/api_keys.yml` にも同値を同期する。`credential_rotation` の `cadence_days` と `next_rotation_at` を更新し、実施ログを `docs/checklists/p1-04_api_ingest.md` に残す。429 や SLA 違反が 2 回連続した場合は `--use-api` を停止し、Dukascopy 経路へフォールバックしつつ #ops へエスカレーションする。
 - 直近の成功時刻は `ops/runtime_snapshot.json` の `ingest` セクションで管理し、異常は `ops/logs/ingest_anomalies.jsonl` に記録。毎回の実行後に `USDJPY_5m` の時刻と差分（目安: 90 分以内）を確認し、必要なら `--dukascopy-freshness-threshold-minutes` を一時的に調整する。
 - タイムスタンプは ISO 8601 (`Z` や `+00:00` 付き)・空白区切りどちらにも対応。
 

--- a/docs/api_ingest_plan.md
+++ b/docs/api_ingest_plan.md
@@ -35,6 +35,8 @@ Dukascopy feed（正式運用） → 正常時は `scripts/dukascopy_fetch.py` �
 - `configs/api_ingest.yml` (new):
   - `base_url`, endpoint paths, required query params。
   - `rate_limit` (requests/min), `batch_size`, `lookback_minutes` (buffer before `last_ts`)。Free-tier defaults should reflect conservative quotas (≤5 req/min, ≤500 req/day) and allow optional overrides。Alpha Vantage 設定は保留ステータスとし、再開時に差し替えやすい YAML を維持。
+  - `activation_criteria` プレースホルダを明示し、REST ルートを有効化する判断指標を管理する: `target_cost_ceiling_usd`（例: 月額 40 USD 以内）、`minimum_free_quota_per_day`（例: 500 リクエスト以上）、`retry_budget_per_run`（例: 15 リトライ以内）。閾値は `docs/state_runbook.md` での運用手順に沿ってレビューし、逸脱時は `--use-api` を停止する。
+  - `credential_rotation` セクションで `cadence_days`（例: 30 日）、`next_rotation_at`、`owner` を記載するプレースホルダを追加し、CI/ローカル双方で参照する。更新後は `docs/checklists/p1-04_api_ingest.md` のローテーション記録項目をチェックする。
 - `configs/api_keys.yml` (new or repurposed): store API key/secret with rotation notes.
 - Local `.env` pattern: for personal use, load keys from environment variables (not committed) and document manual rotation steps.
 - Safety margin: default 60 minutes so gaps around clock shifts or downtime are re-requested。Dukascopy 経路では別途 `--dukascopy-freshness-threshold-minutes`（既定 90 分）を確認し、超過時は自動で yfinance (`pip install dukascopy-python yfinance`) へ切替わる。
@@ -62,6 +64,6 @@ Dukascopy feed（正式運用） → 正常時は `scripts/dukascopy_fetch.py` �
 
 ## 8. Open Questions
 - API provider choice (OANDA REST? Alpha Vantage? in-house feed) and associated rate limits/SLA。Alpha Vantage はプレミアム専用となったため、無料枠で使える代替 API or 有償契約を再検討する必要あり。
-- Credential storage: local `.env` vs. secrets manager; rotation cadence.
+- Credential storage: local `.env` vs. secrets manager; rotation cadence。`configs/api_ingest.yml` の `credential_rotation` テンプレに日付・担当・保管場所を反映し、30 日ごとの見直しを既定にするか要検討。`docs/state_runbook.md` とチェックリストでの記録サイクルをどう同期するかも整理する。
 - Streaming/WebSocket rollout timing and relation to current REST-first scope.
 - yfinance フォールバックは `scripts/yfinance_fetch.py` と `--use-yfinance` 経路で実装済み。依存パッケージの導入手順、取得遅延の許容範囲、Dukascopy からの切替判断基準を runbook/チェックリストへ追記する必要がある。Yahoo Finance の intraday 保持期間（≒60 日）に合わせて `period="7d"` で一括取得し、シンボルマッピング（例: USDJPY → JPY=X）や未来日クランプを組み込んだ運用整理も必要。

--- a/docs/checklists/p1-04_api_ingest.md
+++ b/docs/checklists/p1-04_api_ingest.md
@@ -15,9 +15,12 @@
 - [x] `scripts/fetch_prices_api.py` が API から5mバーを取得し、リトライ/レート制限ハンドリングを備えている（**現状は保留**）。
 - [x] `scripts/pull_prices.py` が `ingest_rows` 等のインタフェースを通じて API 取得結果を冪等に `raw/`・`validated/`・`features/` へ反映できる。
 - [x] Dukascopy フェッチ失敗/鮮度低下時に yfinance (`period="7d"`) へ自動フェイルオーバーする実装が `scripts/run_daily_workflow.py` に組み込まれ、回帰テストでカバーされている。
+- [ ] REST プロバイダ候補について `docs/api_ingest_plan.md#4-configuration` の `activation_criteria` を満たすか評価し、ターゲットコスト上限・無料枠・リトライ予算をチェックリストに記録した。
 - [ ] (Deferred) `python3 scripts/run_daily_workflow.py --ingest --use-api --symbol USDJPY --mode conservative` が成功し、`ops/runtime_snapshot.json.ingest` が更新される。→ Alpha Vantage FX_INTRADAY はプレミアム専用のため契約後に再開。テストは `tests/test_run_daily_workflow.py::test_api_ingest_updates_snapshot` でモック検証済み。
 - [ ] `python3 scripts/check_benchmark_freshness.py --target USDJPY:conservative --max-age-hours 6` が成功し、鮮度アラートが解消される（Dukascopy 主経路で代替中）。
 - [x] モックAPIを用いた単体/統合テストが `python3 -m pytest` で通過し、API失敗時のアノマリーログ出力が検証されている。
+- [ ] `docs/state_runbook.md` の `--use-api` 運用手順に沿って環境変数 (`ALPHA_VANTAGE_API_KEY` 等) と `configs/api_keys.yml` の保管先を検証し、権限/暗号化の要件を満たしていることを確認した。
+- [ ] `configs/api_ingest.yml` の `credential_rotation` セクションへ最新情報を反映し、更新履歴を `docs/state_runbook.md` または運用ログへ追記した（ローテーション実施時にチェック）。
 
 ## 成果物とログ更新
 - [x] `docs/state_runbook.md` と `README.md` のインジェスト手順を更新した（yfinance フェイルオーバー・依存導入・鮮度閾値レビューを記載）。

--- a/docs/state_runbook.md
+++ b/docs/state_runbook.md
@@ -26,7 +26,11 @@ python3 scripts/run_daily_workflow.py --ingest --update-state --benchmarks --sta
   - Dukascopy 経由（標準経路）: `python3 -m scripts.run_daily_workflow --ingest --use-dukascopy --symbol USDJPY --mode conservative`
     - 失敗時や取得データが `--dukascopy-freshness-threshold-minutes`（既定 90 分）より古い場合は自動で yfinance (`period="7d"`) へ切替。`pip install dukascopy-python yfinance` を事前に実行して依存を満たす。
     - 実行後は `ops/runtime_snapshot.json.ingest.USDJPY_5m` の更新時刻と `ops/logs/ingest_anomalies.jsonl` を確認し、鮮度が 90 分超で推移する場合は閾値見直しや手動調査を実施する。
-  - API 直接取得（保留中）: `python3 -m scripts.run_daily_workflow --ingest --use-api --symbol USDJPY --mode conservative` ※ Alpha Vantage FX_INTRADAY がプレミアム専用のため 2025-10 時点では契約後に再開予定。
+  - API 直接取得（保留中）:
+    1. `configs/api_ingest.yml` の `activation_criteria` が満たされていることを確認し、必要なら `target_cost_ceiling_usd`・`minimum_free_quota_per_day`・`retry_budget_per_run` を最新値へ更新する。
+    2. `ALPHA_VANTAGE_API_KEY`（または利用するプロバイダのキー）を環境変数に設定し、同値を `configs/api_keys.yml`（暗号化ストレージ推奨）へ同期する。ローカルでは `.env` を利用し、CI/cron は Secrets 管理で注入する。
+    3. `configs/api_ingest.yml` の `credential_rotation` に `next_rotation_at`・`cadence_days` を記録した上で、ローテーションログを `docs/checklists/p1-04_api_ingest.md` に反映する。
+    4. `python3 -m scripts.run_daily_workflow --ingest --use-api --symbol USDJPY --mode conservative` を実行する。Alpha Vantage FX_INTRADAY がプレミアム専用のため 2025-10 時点では契約後に再開予定であり、条件を外れた場合は `--use-api` を一時的に停止する。
   - state更新: `python3 scripts/update_state.py --bars validated/USDJPY/5m.csv --chunk-size 20000`
   - 検証・集計: `python3 scripts/run_benchmark_runs.py --bars validated/USDJPY/5m.csv --windows 365,180,90` → `python3 scripts/report_benchmark_summary.py --plot-out reports/benchmark_summary.png`
   - ヘルスチェック: `python3 scripts/check_state_health.py`
@@ -41,6 +45,8 @@ python3 scripts/run_daily_workflow.py --ingest --update-state --benchmarks --sta
 - **履歴保持:** 標準では直近 90 レコードを保持する。上限を変更する場合は `--history-limit` を調整する。履歴の可視化は Notebook or BI で `checked_at` を横軸に `ev_win_lcb` やワーニング件数をプロットする。
 - **タスク同期:** `state.md` と `docs/todo_next.md` の整合を保つ際は `scripts/manage_task_cycle.py` を優先利用する。`start-task` で Ready 登録→In Progress 昇格を一括実行し、既存アンカー検知で重複記録を抑止する。完了時は `finish-task` でまとめてログとアーカイブへ送る。いずれも `--dry-run` でコマンド内容を確認してから本実行する。Codex セッションにおける具体的な開始前チェックや終了処理は [docs/codex_workflow.md](codex_workflow.md) を参照する。
 - **API鍵管理:** REST インジェストを有効化する場合は `configs/api_keys.yml`（もしくは `configs/api_keys.local.yml`）にプレースホルダを用意し、実際の鍵はローカルで上書きする。CI/cron では `ALPHA_VANTAGE_API_KEY` のような環境変数を設定し、`scripts/_secrets.load_api_credentials` が YAML よりも優先して読み込む。鍵のローテーション履歴は別メモに残し、更新したら `docs/checklists/p1-04_api_ingest.md` のチェックボックスに反映する。
+- **API 運用切替:** `--use-api` を有効化する際は上記「API 直接取得」手順を踏み、初回はドライラン (`--dry-run`) でレスポンス整合性・レートリミットヘッダを確認する。`configs/api_ingest.yml` の `activation_criteria` 逸脱や `retry_budget_per_run` 超過を検知した場合は直ちに `--use-api` を無効化し、Dukascopy 経路へ戻す。
+- **レート制限/ SLA エスカレーション:** 429 や SLA 違反が 2 回連続で発生した場合は `ops/logs/ingest_anomalies.jsonl` を添えて #ops チャネルへ報告し、契約窓口への連絡可否を確認する。それまでは `retry_budget_per_run` を超えない範囲で 15 分間隔の再試行にとどめ、`docs/api_ingest_plan.md#4-configuration` のコスト上限を再チェックする。
 - **テンプレ適用:** `state.md` の `## Next Task` へ手動で項目を追加する場合は、必ず [docs/templates/next_task_entry.md](templates/next_task_entry.md) を貼り付けてアンカー・参照リンク・疑問点スロットを埋める。`scripts/manage_task_cycle.py start-task` を使うとテンプレが自動挿入されるため、手動調整より優先する。
 - **DoD チェックリスト:** Ready へ昇格する際は [docs/templates/dod_checklist.md](templates/dod_checklist.md) をコピーし、`docs/checklists/<task-slug>.md` として保存する。テンプレート内の Ready チェック項目は昇格時点で状態を更新し、バックログ固有の DoD 箇条書きをチェックボックスへ転記する。進行中は該当タスクの `docs/todo_next.md` エントリからリンクし、完了後も `docs/checklists/` に履歴として保管する。
 

--- a/state.md
+++ b/state.md
@@ -20,6 +20,7 @@
   - 2025-10-24: Alpha Vantage FX_INTRADAY がプレミアム専用であることを確認。REST ルートは backlog へ「保留」として移し、Dukascopy を主経路に昇格。万一の障害時は yfinance 変換レイヤーで復旧できるよう要件整理を次イテレーションへ設定。
   - 2025-11-01: `scripts/yfinance_fetch.py` を実装し、USDJPY→JPY=X のシンボル変換・`period="7d"` 取得・60日制限対応を整備。`run_daily_workflow.py --ingest --use-yfinance` で 2025-10-01T14:10 (UTC) までのバーを取り込めることを確認し、`tests/test_yfinance_fetch.py` / `tests/test_run_daily_workflow.py` に回帰を追加。残課題は自動フォールバックと最新時刻乖離のアラート化。
   - 2025-11-02: `scripts/run_daily_workflow.py --ingest --use-dukascopy` に yfinance 自動フェイルオーバー（7 日再取得・シンボル正規化）と `--dukascopy-freshness-threshold-minutes` を実装。`tests/test_run_daily_workflow.py` に障害復旧の回帰を追加し、README / state runbook / ingest plan / チェックリストへ鮮度確認ステップと依存導入ガイドを追記。
+  - 2025-11-03: `docs/api_ingest_plan.md` の `activation_criteria` と `credential_rotation` を明文化し、`docs/state_runbook.md` / `README.md` / チェックリストへ `--use-api` 切替手順・エスカレーションを追記。REST 再開条件と鍵ローテーション記録フローを整理。
 
 ### 運用メモ
 - バックログから着手するタスクは先にこのリストへ追加し、ID・着手予定日・DoD リンクを明示する。


### PR DESCRIPTION
## Summary
- add activation criteria and credential rotation placeholders to the API ingest plan
- extend the P1-04 checklist with provider evaluation, credential storage, and rotation logging steps
- outline API enablement, environment variable requirements, and escalation guidance in the state runbook and README

## Testing
- not run (documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68dd46741334832a98e5f4be35a6f312