### PR TITLE
Add live ingestion worker daemon and integration tests

### DIFF
--- a/state.md
+++ b/state.md
@@ -21,6 +21,7 @@
   - 2025-11-01: `scripts/yfinance_fetch.py` を実装し、USDJPY→JPY=X のシンボル変換・`period="7d"` 取得・60日制限対応を整備。`run_daily_workflow.py --ingest --use-yfinance` で 2025-10-01T14:10 (UTC) までのバーを取り込めることを確認し、`tests/test_yfinance_fetch.py` / `tests/test_run_daily_workflow.py` に回帰を追加。残課題は自動フォールバックと最新時刻乖離のアラート化。
   - 2025-11-02: `scripts/run_daily_workflow.py --ingest --use-dukascopy` に yfinance 自動フェイルオーバー（7 日再取得・シンボル正規化）と `--dukascopy-freshness-threshold-minutes` を実装。`tests/test_run_daily_workflow.py` に障害復旧の回帰を追加し、README / state runbook / ingest plan / チェックリストへ鮮度確認ステップと依存導入ガイドを追記。
   - 2025-11-03: `docs/api_ingest_plan.md` の `activation_criteria` と `credential_rotation` を明文化し、`docs/state_runbook.md` / `README.md` / チェックリストへ `--use-api` 切替手順・エスカレーションを追記。REST 再開条件と鍵ローテーション記録フローを整理。
+  - 2025-11-04: `scripts/live_ingest_worker.py` を追加し、Dukascopy→yfinance フォールバックと `update_state` 連携の常駐ジョブを実装。pytest 統合テストで重複バーが発生しないことを検証し、README / state runbook へ運用手順とモニタリング項目を追記。
 
 ### 運用メモ
 - バックログから着手するタスクは先にこのリストへ追加し、ID・着手予定日・DoD リンクを明示する。

--- a/tests/test_live_ingest_worker.py
+++ b/tests/test_live_ingest_worker.py
@@ -1,0 +1,191 @@
+import csv
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from scripts import live_ingest_worker as worker
+
+
+@pytest.fixture(autouse=True)
+def _patch_anomaly_log(monkeypatch, tmp_path):
+    anomaly_log = tmp_path / "ops/logs/ingest_anomalies.jsonl"
+    monkeypatch.setattr("scripts.pull_prices.ANOMALY_LOG", anomaly_log)
+    return anomaly_log
+
+
+def _read_validated(path: Path) -> List[dict]:
+    if not path.exists():
+        return []
+    with path.open(newline="", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        return list(reader)
+
+
+def test_live_worker_ingests_without_duplicates(monkeypatch, tmp_path):
+    records_seq = [
+        [
+            {
+                "timestamp": "2024-01-01T00:00:00",
+                "symbol": "USDJPY",
+                "tf": "5m",
+                "o": 150.0,
+                "h": 150.2,
+                "l": 149.9,
+                "c": 150.1,
+                "v": 1200.0,
+                "spread": 0.1,
+            },
+            {
+                "timestamp": "2024-01-01T00:05:00",
+                "symbol": "USDJPY",
+                "tf": "5m",
+                "o": 150.1,
+                "h": 150.4,
+                "l": 150.0,
+                "c": 150.3,
+                "v": 900.0,
+                "spread": 0.1,
+            },
+        ],
+        [
+            {
+                "timestamp": "2024-01-01T00:05:00",
+                "symbol": "USDJPY",
+                "tf": "5m",
+                "o": 150.1,
+                "h": 150.4,
+                "l": 150.0,
+                "c": 150.3,
+                "v": 900.0,
+                "spread": 0.1,
+            },
+            {
+                "timestamp": "2024-01-01T00:10:00",
+                "symbol": "USDJPY",
+                "tf": "5m",
+                "o": 150.3,
+                "h": 150.6,
+                "l": 150.2,
+                "c": 150.5,
+                "v": 800.0,
+                "spread": 0.1,
+            },
+        ],
+    ]
+    duk_calls = []
+
+    def fake_dukascopy(symbol, tf, start, end):
+        idx = min(len(duk_calls), len(records_seq) - 1)
+        duk_calls.append((symbol, start, end))
+        return list(records_seq[idx])
+
+    monkeypatch.setattr(worker, "_load_dukascopy_records", fake_dukascopy)
+    monkeypatch.setattr(worker, "_load_yfinance_records", lambda *a, **k: [])
+
+    updates = []
+
+    def fake_update(symbol, mode, *, bars_path):
+        updates.append((symbol, mode, Path(bars_path)))
+
+    monkeypatch.setattr(worker, "_run_update_state", fake_update)
+
+    args = [
+        "--symbols",
+        "USDJPY",
+        "--modes",
+        "conservative",
+        "--interval",
+        "0",
+        "--max-iterations",
+        "2",
+        "--raw-root",
+        str(tmp_path / "raw"),
+        "--validated-root",
+        str(tmp_path / "validated"),
+        "--features-root",
+        str(tmp_path / "features"),
+        "--snapshot",
+        str(tmp_path / "ops/runtime_snapshot.json"),
+        "--shutdown-file",
+        "",
+        "--freshness-threshold-minutes",
+        "0",
+        "--lookback-minutes",
+        "5",
+    ]
+
+    exit_code = worker.main(args)
+    assert exit_code == 0
+
+    validated_path = tmp_path / "validated" / "USDJPY" / "5m.csv"
+    rows = _read_validated(validated_path)
+    timestamps = [row["timestamp"] for row in rows]
+    assert timestamps == [
+        "2024-01-01T00:00:00",
+        "2024-01-01T00:05:00",
+        "2024-01-01T00:10:00",
+    ]
+    assert len(updates) == 2
+
+
+def test_live_worker_fallback_to_yfinance(monkeypatch, tmp_path):
+    monkeypatch.setattr(worker, "_load_dukascopy_records", lambda *a, **k: [])
+
+    def fake_yfinance(symbol, tf, start, end):
+        ts = (end - worker.timedelta(minutes=5)).replace(microsecond=0)
+        return [
+            {
+                "timestamp": ts.strftime("%Y-%m-%dT%H:%M:%S"),
+                "symbol": symbol,
+                "tf": tf,
+                "o": 151.0,
+                "h": 151.2,
+                "l": 150.8,
+                "c": 151.1,
+                "v": 700.0,
+                "spread": 0.1,
+            }
+        ]
+
+    monkeypatch.setattr(worker, "_load_yfinance_records", fake_yfinance)
+
+    updates = []
+
+    def fake_update(symbol, mode, *, bars_path):
+        updates.append((symbol, mode, Path(bars_path)))
+
+    monkeypatch.setattr(worker, "_run_update_state", fake_update)
+
+    args = [
+        "--symbols",
+        "USDJPY",
+        "--modes",
+        "conservative",
+        "--interval",
+        "0",
+        "--max-iterations",
+        "1",
+        "--raw-root",
+        str(tmp_path / "raw"),
+        "--validated-root",
+        str(tmp_path / "validated"),
+        "--features-root",
+        str(tmp_path / "features"),
+        "--snapshot",
+        str(tmp_path / "ops/runtime_snapshot.json"),
+        "--shutdown-file",
+        "",
+        "--freshness-threshold-minutes",
+        "90",
+        "--lookback-minutes",
+        "5",
+    ]
+
+    exit_code = worker.main(args)
+    assert exit_code == 0
+
+    validated_path = tmp_path / "validated" / "USDJPY" / "5m.csv"
+    rows = _read_validated(validated_path)
+    assert len(rows) == 1
+    assert updates == [("USDJPY", "CONSERVATIVE", validated_path)]


### PR DESCRIPTION
## Summary
- add a live ingestion worker that polls Dukascopy, falls back to yfinance when needed, writes anomalies, and refreshes state per configured mode
- document the continuous ingestion workflow and monitoring steps in the README and state runbook
- cover the worker with pytest integration tests to ensure successive runs avoid duplicate bars and exercise the fallback path

## Testing
- python3 -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd492f77e4832a818246222ce5b2d6