### PR TITLE
Document sandbox ingest fallback failure and benchmark staleness

### DIFF
--- a/docs/checklists/p1-04_api_ingest.md
+++ b/docs/checklists/p1-04_api_ingest.md
@@ -23,6 +23,7 @@
     - yfinance（0 USD, 約1req/分相当のバッチ取得, 7日分バッチ取得で60日履歴）→ 現行フェイルオーバー経路として継続、REST置換は不要。
 - [ ] (Deferred) `python3 scripts/run_daily_workflow.py --ingest --use-api --symbol USDJPY --mode conservative` が成功し、`ops/runtime_snapshot.json.ingest` が更新される。→ Alpha Vantage FX_INTRADAY はプレミアム専用のため契約後に再開。テストは `tests/test_run_daily_workflow.py::test_api_ingest_updates_snapshot` でモック検証済み。
 - [ ] `python3 scripts/check_benchmark_freshness.py --target USDJPY:conservative --max-age-hours 6` が成功し、鮮度アラートが解消される（Dukascopy 主経路で代替中）。
+  - 2025-11-07 00:45Z: `ops/runtime_snapshot.json.benchmark_pipeline.USDJPY_conservative` が 9.31h / 18.60h 遅延のままで、鮮度アラートが継続。インジェスト再開後に再検証する。
 - [x] モックAPIを用いた単体/統合テストが `python3 -m pytest` で通過し、API失敗時のアノマリーログ出力が検証されている。
 - [x] `docs/state_runbook.md` の `--use-api` 運用手順に沿って環境変数 (`ALPHA_VANTAGE_API_KEY` 等) と `configs/api_keys.yml` の保管先を検証し、権限/暗号化の要件を満たしていることを確認した。
   - 2025-11-06 06:30Z: 暗号化ストレージ（Vault/SOPS/gpg）必須・環境変数注入/同期手順を明文化し、ローテーション記録フローを追記。
@@ -35,5 +36,12 @@
 - [ ] [docs/todo_next.md](../todo_next.md) の該当エントリを Archive へ移動した（保留中は In Progress のまま維持）。
 - [ ] 関連コード/設定ファイル/テストのパスを記録した。
 - [ ] レビュー/承認者を記録した。
+
+### 2025-11-07 サンドボックス実行ログ
+- `python3 scripts/run_daily_workflow.py --ingest --use-dukascopy --symbol USDJPY --mode conservative`
+  - Dukascopy 呼び出しで `dukascopy_python` 未導入のため失敗。
+  - 自動フェイルオーバーで yfinance (`JPY=X`) 取得を試行したが、`yfinance` 未導入のためフォールバックも失敗。`ops/runtime_snapshot.json.ingest.USDJPY_5m` は更新されず、最新バーは 2025-10-01T14:10:00 のまま。
+- `python3 scripts/check_benchmark_freshness.py --target USDJPY:conservative --max-age-hours 6`
+  - ベンチマーク最新バー/サマリーがそれぞれ 18.60h / 9.31h 遅延で鮮度閾値 6h を超過。インジェストが再開するまで 90 分閾値は現状維持しつつ、依存導入後の再実行が必要。
 
 > API供給元や鍵管理ポリシーは `docs/api_ingest_plan.md` の更新と併せて、タスク完了までに最新化してください。現状は Dukascopy 主経路で運用し、REST/API は契約条件が整い次第再開します。

--- a/docs/state_runbook.md
+++ b/docs/state_runbook.md
@@ -26,6 +26,7 @@ python3 scripts/run_daily_workflow.py --ingest --update-state --benchmarks --sta
   - Dukascopy 経由（標準経路）: `python3 -m scripts.run_daily_workflow --ingest --use-dukascopy --symbol USDJPY --mode conservative`
     - 失敗時や取得データが `--dukascopy-freshness-threshold-minutes`（既定 90 分）より古い場合は自動で yfinance (`period="7d"`) へ切替。`pip install dukascopy-python yfinance` を事前に実行して依存を満たす。
     - 実行後は `ops/runtime_snapshot.json.ingest.USDJPY_5m` の更新時刻と `ops/logs/ingest_anomalies.jsonl` を確認し、鮮度が 90 分超で推移する場合は閾値見直しや手動調査を実施する。
+    - 2025-11-07 00:40Z Sandbox: 依存未導入のまま実行すると Dukascopy / yfinance 双方が ImportError で停止し、`ops/runtime_snapshot.json.ingest.USDJPY_5m` は 2025-10-01T14:10:00 のまま。サンドボックスでは先に依存導入を済ませた上で再取得→鮮度確認を行う。
   - API 直接取得（保留中）:
     1. `configs/api_ingest.yml` の `activation_criteria` が満たされていることを確認し、必要なら `target_cost_ceiling_usd`・`minimum_free_quota_per_day`・`retry_budget_per_run` を最新値へ更新する。
     2. 認証情報を投入する前に暗号化ストレージ（Vault / SOPS / gpg など）へ保存先を作成し、`credential_rotation.storage_reference` に URI を記録する。平文ファイルを一時的に扱う場合は、コミット対象から除外されていることを `.gitignore` と CI ルールで再確認する。

--- a/docs/todo_next.md
+++ b/docs/todo_next.md
@@ -38,6 +38,7 @@
   - Deliverables (EN): API ingestion design doc (`docs/api_ingest_plan.md`), CLI integration plan, retry/test matrix.
   - 2025-11-05: Alpha Vantage（Premium 49.99 USD/月）と Twelve Data Free（0 USD, 8req/min, 800req/日）を `activation_criteria` で比較し、Alpha Vantage は保留継続・Twelve Data はフォールバック候補として記録。`configs/api_ingest.yml` に閾値・候補ノートを追記済み。
   - 2025-11-06: 暗号化ストレージ運用と鍵ローテーション記録フローを `docs/state_runbook.md` / README / チェックリストへ反映し、`credential_rotation` プレースホルダを定義。Reviewers: ops-security（高橋）, ops-runbook（佐藤）。
+  - 2025-11-07: サンドボックスで `run_daily_workflow --ingest --use-dukascopy` を実行したが、`dukascopy_python` / `yfinance` 未導入で双方失敗しスナップショット未更新。`check_benchmark_freshness --max-age-hours 6` では最新バー 18.60h / サマリー 9.31h 遅延で閾値超過を確認。依存導入→再取得→鮮度確認を次アクションに設定。
   - Next step: Twelve Data のレスポンス差異（UTC/ボリューム欠損時の扱い）をモック API テストへ反映し、フォールバック手順を `docs/state_runbook.md` へ追記する。
   - Backlog Anchor: [価格インジェストAPI基盤整備 (P1-04)](docs/task_backlog.md#p1-04-価格インジェストapi基盤整備)
   - Vision / Runbook References:

--- a/state.md
+++ b/state.md
@@ -24,6 +24,7 @@
   - 2025-11-04: `scripts/live_ingest_worker.py` を追加し、Dukascopy→yfinance フォールバックと `update_state` 連携の常駐ジョブを実装。pytest 統合テストで重複バーが発生しないことを検証し、README / state runbook へ運用手順とモニタリング項目を追記。
   - 2025-11-05: Alpha Vantage Premium (49.99 USD/月, 75req/min, 1500req/日) は `target_cost_ceiling_usd=40` を超過するため保留継続とし、無料ティアの FX_INTRADAY 制限を再確認。Twelve Data Free (0 USD, 8req/min, 800req/日, 30日履歴) をフォールバック候補に追加し、`configs/api_ingest.yml` へ `activation_criteria` と候補メモを反映。チェックリスト / todo_next を同期。
   - 2025-11-06: API 鍵の暗号化保管・ローテーション記録フローを整理。`configs/api_ingest.yml` へ `credential_rotation` プレースホルダを追加し、`docs/state_runbook.md` / `README.md` / チェックリストで環境変数設定と記録手順を明文化。Reviewers: ops-security（高橋）, ops-runbook（佐藤）。
+  - 2025-11-07: サンドボックスで `python3 scripts/run_daily_workflow.py --ingest --use-dukascopy --symbol USDJPY --mode conservative` を実行。`dukascopy_python` 未導入で主経路が失敗し、自動フェイルオーバーの yfinance も未導入のため ImportError。`ops/runtime_snapshot.json.ingest.USDJPY_5m` は 2025-10-01T14:10:00 のまま据え置き。続けて `python3 scripts/check_benchmark_freshness.py --target USDJPY:conservative --max-age-hours 6` を実行したところ、最新バーが 18.60h、サマリーが 9.31h 遅延で閾値超過。依存導入後に再取得→鮮度再確認が必要。
 
 ### 運用メモ
 - バックログから着手するタスクは先にこのリストへ追加し、ID・着手予定日・DoD リンクを明示する。


### PR DESCRIPTION
## Summary
- record the November 7 sandbox ingest attempt and resulting Dukascopy/yfinance import failures in the P1-04 checklist
- capture the same sandbox dependency gap and freshness delay guidance inside the state runbook and active task tracker
- sync state.md and todo_next.md with the outstanding actions required to restore ingest freshness

## Testing
- not run (documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68dd9fd0f29c832a8b3e98976a8ba3bd