### PR TITLE
Handle Dukascopy dependency outage via yfinance fallback

### DIFF
--- a/docs/task_backlog.md
+++ b/docs/task_backlog.md
@@ -78,6 +78,7 @@ REST/Streaming API と `scripts/pull_prices.py` を連携させ、手動CSV投�
 
 **進捗メモ**
 - 2025-10-16: API インジェスト設計を起案し、`docs/todo_next.md` / `state.md` にタスク登録。設計ドキュメント (`docs/api_ingest_plan.md`) とチェックリスト (`docs/checklists/p1-04_api_ingest.md`) を整備し、ワークフロー統合を次ステップとする。
+- 2025-11-08: `run_daily_workflow.py --ingest --use-dukascopy` で `dukascopy_python` 未導入時も yfinance フォールバックへ自動切替するよう調整し、回帰テストを追加。
 - 2025-10-21: Added Dukascopy ingestion option to `scripts/run_daily_workflow.py` (`--use-dukascopy`) with shared `ingest_records` helper so fresh 5m bars flow through `raw/`→`validated/`→`features/` without manual CSV staging. Updated progress docs and design notes to capture the workflow and test coverage.
 - 2025-10-21: Created `scripts/merge_dukascopy_monthly.py` and generated `data/usdjpy_5m_2025.csv` from the monthly exports to backfill storage before live refresh. Documented the merge step in phase3 progress notes.
 - 2025-10-21: Cloud deploy flagged "diff too large" during the backfill. Local merge + ingest cleared it, and we need to document how to temporarily relax/re-enable the cloud diff guard (TODO: define guard reset workflow in runbook).

--- a/state.md
+++ b/state.md
@@ -25,6 +25,7 @@
   - 2025-11-05: Alpha Vantage Premium (49.99 USD/月, 75req/min, 1500req/日) は `target_cost_ceiling_usd=40` を超過するため保留継続とし、無料ティアの FX_INTRADAY 制限を再確認。Twelve Data Free (0 USD, 8req/min, 800req/日, 30日履歴) をフォールバック候補に追加し、`configs/api_ingest.yml` へ `activation_criteria` と候補メモを反映。チェックリスト / todo_next を同期。
   - 2025-11-06: API 鍵の暗号化保管・ローテーション記録フローを整理。`configs/api_ingest.yml` へ `credential_rotation` プレースホルダを追加し、`docs/state_runbook.md` / `README.md` / チェックリストで環境変数設定と記録手順を明文化。Reviewers: ops-security（高橋）, ops-runbook（佐藤）。
   - 2025-11-07: サンドボックスで `python3 scripts/run_daily_workflow.py --ingest --use-dukascopy --symbol USDJPY --mode conservative` を実行。`dukascopy_python` 未導入で主経路が失敗し、自動フェイルオーバーの yfinance も未導入のため ImportError。`ops/runtime_snapshot.json.ingest.USDJPY_5m` は 2025-10-01T14:10:00 のまま据え置き。続けて `python3 scripts/check_benchmark_freshness.py --target USDJPY:conservative --max-age-hours 6` を実行したところ、最新バーが 18.60h、サマリーが 9.31h 遅延で閾値超過。依存導入後に再取得→鮮度再確認が必要。
+  - 2025-11-08: `run_daily_workflow.py --ingest --use-dukascopy` 実行時に `dukascopy_python` が未導入でも yfinance フォールバックで継続できるようにし、pytest (`tests/test_run_daily_workflow.py::test_dukascopy_missing_dependency_falls_back_to_yfinance`) で回帰確認。
 
 ### 運用メモ
 - バックログから着手するタスクは先にこのリストへ追加し、ID・着手予定日・DoD リンクを明示する。


### PR DESCRIPTION
## Summary
- load the Dukascopy fetch helper lazily so the daily workflow can fall back to yfinance when the dukascopy_python module is absent
- extend run_daily_workflow regression coverage to mock a missing Dukascopy dependency and verify the fallback path
- document the progress in the ingest backlog and state log for task P1-04

## Testing
- python3 -m pytest tests/test_run_daily_workflow.py
- python3 -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68dda1bdb7e8832aa5ac2d439587b7d4