### PR TITLE
Add dedicated pipeline benchmark freshness threshold

### DIFF
--- a/scripts/run_daily_workflow.py
+++ b/scripts/run_daily_workflow.py
@@ -1324,18 +1324,20 @@ def main(argv=None) -> int:
             return exit_code
 
     if args.check_benchmark_freshness:
+        pipeline_max_age_hours = 6.0
         cmd = [
             sys.executable,
             str(ROOT / "scripts/check_benchmark_freshness.py"),
             "--snapshot",
             str(ROOT / "ops/runtime_snapshot.json"),
             "--max-age-hours",
-            str(
-                args.benchmark_freshness_max_age_hours
-                if args.benchmark_freshness_max_age_hours is not None
-                else 6.0
-            ),
+            str(pipeline_max_age_hours),
         ]
+        if args.benchmark_freshness_max_age_hours is not None:
+            cmd += [
+                "--benchmark-freshness-max-age-hours",
+                str(args.benchmark_freshness_max_age_hours),
+            ]
         if args.benchmark_freshness_targets:
             for raw_target in args.benchmark_freshness_targets.split(","):
                 target = raw_target.strip()

--- a/state.md
+++ b/state.md
@@ -45,6 +45,7 @@
 - 2025-11-24: ローカル CSV フォールバック時に `synthetic_local` 合成バーを挿入しないオプション（`--disable-synthetic-extension`）を追加。`tests/test_run_daily_workflow.py::test_local_csv_fallback_can_disable_synthetic_extension` で回帰を整備し、README / runbook / ingest plan / checklist を更新して鮮度アラートが `errors` 扱いになるケースを明記。
 - 2025-11-25: `run_daily_workflow.py --ingest --use-api` で API 障害や空レスポンスが発生した際にローカル CSV → `synthetic_local` へ自動フォールバックし、`ingest_meta` に `api` → `local_csv` → `synthetic_local` の `fallbacks` / `source_chain` / `local_backup_path` を記録するよう更新。`tests/test_run_daily_workflow.py::test_api_ingest_falls_back_to_local_csv` を追加し、README / state runbook / ingest plan を同期。
 - 2025-11-26: `scripts/check_benchmark_freshness.py` で `ingest_meta.fallbacks` のステージ名を正規化し、CLI 出力からフォールバック連鎖を直接確認できるようにした。`tests/test_check_benchmark_freshness.py` に回帰を追加し、Sandbox の advisory ダウングレード仕様が維持されることを確認。
+- 2025-11-27: `scripts/run_daily_workflow.py` でベンチマーク鮮度チェックのパイプライン既定値を `pipeline_max_age_hours` に切り出し、`--benchmark-freshness-max-age-hours` を独立引数として `check_benchmark_freshness.py` へ伝播するよう更新。`tests/test_run_daily_workflow.py::test_check_benchmark_freshness_passes_pipeline_and_override` を追加し、両方のフラグがコマンドに含まれることを検証。
   - 2025-11-08: `run_daily_workflow.py --ingest --use-dukascopy` 実行時に `dukascopy_python` が未導入でも yfinance フォールバックで継続できるようにし、pytest (`tests/test_run_daily_workflow.py::test_dukascopy_missing_dependency_falls_back_to_yfinance`) で回帰確認。
   - 2025-11-09: yfinance フォールバック時に `--yfinance-lookback-minutes` を参照して再取得ウィンドウを決定するよう更新。冗長な再処理を抑えつつ長期停止後に手動調整できるよう、README / state runbook / 回帰テスト / backlog メモを同期。
 

--- a/tests/test_run_daily_workflow.py
+++ b/tests/test_run_daily_workflow.py
@@ -96,6 +96,26 @@ def test_benchmark_summary_with_webhook(monkeypatch):
     assert cmd[cmd.index("--windows") + 1] == "120,30"
 
 
+def test_check_benchmark_freshness_passes_pipeline_and_override(monkeypatch):
+    captured = _capture_run_cmd(monkeypatch)
+
+    exit_code = run_daily_workflow.main([
+        "--check-benchmark-freshness",
+        "--benchmark-freshness-max-age-hours",
+        "8.5",
+        "--benchmark-freshness-targets",
+        "USDJPY:conservative",
+    ])
+
+    assert exit_code == 0
+    assert captured, "run_cmd should be invoked"
+    cmd = captured[0]
+    assert "--max-age-hours" in cmd
+    assert float(cmd[cmd.index("--max-age-hours") + 1]) == pytest.approx(6.0)
+    assert "--benchmark-freshness-max-age-hours" in cmd
+    assert cmd[cmd.index("--benchmark-freshness-max-age-hours") + 1] == "8.5"
+
+
 def test_benchmarks_pipeline_arguments(monkeypatch):
     captured = _capture_run_cmd(monkeypatch)
 


### PR DESCRIPTION
## Summary
- keep the pipeline benchmark freshness threshold in a dedicated variable before building the freshness check command
- forward the optional benchmark freshness override as its own CLI flag while preserving the pipeline default
- extend the daily workflow regression suite to assert that both flags are passed when an override is provided

## Testing
- python3 -m pytest tests/test_run_daily_workflow.py

## 備考
- ベンチマーク鮮度チェックの既定値と上書き用フラグが両方とも CLI コマンドに含まれることを確認しました。

------
https://chatgpt.com/codex/tasks/task_e_68df8b3f2244832a905b07d6595130cb