### PR TITLE
Propagate optimize workflow parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,8 @@ python3 scripts/report_benchmark_summary.py --symbol USDJPY --mode conservative 
   --min-win-rate 0.55 --min-sharpe 0.5 --max-drawdown 200
 ```
 
+`--optimize` フラグを付けると `scripts/auto_optimize.py` を呼び出し、指定した `--symbol` / `--mode` をそのまま最適化コマンドへ渡します。デフォルトでは `data/<symbol_lower>_5m_2018-2024_utc.csv`（例: `data/gbpjpy_5m_2018-2024_utc.csv`）を参照し、別データセットを使いたい場合は `--bars validated/GBPJPY/5m.csv` のように明示してください。
+
 開発時は、実行側で以下のような`ctx`辞書を戦略へ提供してください（例）:
 
 ```python

--- a/state.md
+++ b/state.md
@@ -47,6 +47,7 @@
 - 2025-11-26: `scripts/check_benchmark_freshness.py` で `ingest_meta.fallbacks` のステージ名を正規化し、CLI 出力からフォールバック連鎖を直接確認できるようにした。`tests/test_check_benchmark_freshness.py` に回帰を追加し、Sandbox の advisory ダウングレード仕様が維持されることを確認。
 - 2025-11-27: `scripts/run_daily_workflow.py` でベンチマーク鮮度チェックのパイプライン既定値を `pipeline_max_age_hours` に切り出し、`--benchmark-freshness-max-age-hours` を独立引数として `check_benchmark_freshness.py` へ伝播するよう更新。`tests/test_run_daily_workflow.py::test_check_benchmark_freshness_passes_pipeline_and_override` を追加し、両方のフラグがコマンドに含まれることを検証。
 - 2025-11-28: `run_daily_workflow.py --check-benchmark-freshness` に `--benchmark-freshness-base-max-age-hours` を追加し、`check_benchmark_freshness.py` へ渡す `--max-age-hours` を CLI から制御可能にした。README / docs/benchmark_runbook.md / docs/logic_overview.md / docs/checklists/p1-01.md / docs/task_backlog.md を更新し、`python3 -m pytest` で回帰テストを通過させた。
+- 2025-11-29: `run_daily_workflow.py --optimize` で `--symbol` / `--mode` / `--bars` の指定が `auto_optimize.py` へ伝播するよう更新し、`tests/test_run_daily_workflow.py` にシンボル・モード伝播の回帰を追加。README へ `--optimize` フローのデータセット差し替え手順を追記し、`python3 -m pytest tests/test_run_daily_workflow.py` を実行してパスを確認。
   - 2025-11-08: `run_daily_workflow.py --ingest --use-dukascopy` 実行時に `dukascopy_python` が未導入でも yfinance フォールバックで継続できるようにし、pytest (`tests/test_run_daily_workflow.py::test_dukascopy_missing_dependency_falls_back_to_yfinance`) で回帰確認。
   - 2025-11-09: yfinance フォールバック時に `--yfinance-lookback-minutes` を参照して再取得ウィンドウを決定するよう更新。冗長な再処理を抑えつつ長期停止後に手動調整できるよう、README / state runbook / 回帰テスト / backlog メモを同期。
 

--- a/tests/test_run_daily_workflow.py
+++ b/tests/test_run_daily_workflow.py
@@ -186,6 +186,24 @@ def test_optimize_uses_absolute_paths(monkeypatch):
     _assert_path_arg(cmd, "--report", root / "reports/auto_optimize.json")
 
 
+def test_optimize_propagates_symbol_mode_and_csv(monkeypatch):
+    captured = _capture_run_cmd(monkeypatch)
+
+    exit_code = run_daily_workflow.main([
+        "--optimize",
+        "--symbol", "GBPJPY",
+        "--mode", "bridge",
+    ])
+
+    assert exit_code == 0
+    assert captured, "run_cmd should be invoked"
+    cmd = captured[0]
+    assert cmd[cmd.index("--symbol") + 1] == "GBPJPY"
+    assert cmd[cmd.index("--mode") + 1] == "bridge"
+    root = run_daily_workflow.ROOT
+    _assert_path_arg(cmd, "--csv", root / "data/gbpjpy_5m_2018-2024_utc.csv")
+
+
 def test_analyze_latency_uses_absolute_paths(monkeypatch):
     captured = _capture_run_cmd(monkeypatch)
 


### PR DESCRIPTION
## Summary
- update the optimize branch of the daily workflow to honor the caller-provided symbol, mode, and bars CSV while keeping the historical fallback derived from the symbol
- add regression coverage to ensure the optimize command forwards symbol/mode overrides and continues to use absolute paths
- document how the optimize flow respects CLI overrides and how to swap datasets in the README, and log the update in state.md

## Testing
- python3 -m pytest tests/test_run_daily_workflow.py

## 日本語サマリ
- 日次ワークフローの最適化呼び出しでシンボル・モード・CSV指定が反映されるよう調整し、既定履歴パスも維持
- 最適化コマンドへ引数が伝播することを検証するpytestを追加
- READMEとstate.mdに`--optimize`フローのデータセット差し替え手順と更新履歴を追記


------
https://chatgpt.com/codex/tasks/task_e_68dfa1ef74ac832ab7b33d646f783dbe