### PR TITLE
Handle NaN realized volatility during runner context build

### DIFF
--- a/core/runner.py
+++ b/core/runner.py
@@ -690,10 +690,22 @@ class BacktestRunner:
             or_ratio = (or_h - or_l) / (atr14)
 
         sess = self._session_of_ts(bar.get("timestamp", ""))
+        rv_val = realized_vol(self.window, n=12)
+        if rv_val is None:
+            rv_val = 0.0
+        else:
+            try:
+                rv_val = float(rv_val)
+            except (TypeError, ValueError):
+                rv_val = 0.0
+            else:
+                if math.isnan(rv_val):
+                    rv_val = 0.0
+
         ctx = {
             "session": sess,
             "spread_band": self._band_spread(spread_pips),
-            "rv_band": self._band_rv(realized_vol(self.window, n=12) or 0.0, sess),
+            "rv_band": self._band_rv(rv_val, sess),
             "slip_cap_pip": self.rcfg.slip_cap_pip,
             "threshold_lcb_pip": self.rcfg.threshold_lcb_pip,
             "or_atr_ratio": or_ratio,

--- a/state.md
+++ b/state.md
@@ -4,6 +4,7 @@
 - Review this file before starting any task to confirm the latest context and checklist.
 - Update this file after completing work to record outcomes, blockers, and next steps.
 
+- 2025-12-05: `core/runner._build_ctx` で `realized_vol` が `NaN` を返しても RV バンド計算が破綻しないようにガードを追加。`python3 -m pytest tests/test_runner.py tests/test_run_daily_workflow.py` を実行して回帰が維持されることを確認。
 - [P1-04] 2025-10-16 価格インジェストAPI基盤整備 — DoD: [docs/task_backlog.md#p1-04-価格インジェストapi基盤整備](docs/task_backlog.md#p1-04-価格インジェストapi基盤整備) — Dukascopy ベースの自動インジェストを正式経路として仕上げ、REST/API ルートは保留ステータスで再開条件を整理する。
   - Backlog Anchor: [価格インジェストAPI基盤整備 (P1-04)](docs/task_backlog.md#p1-04-価格インジェストapi基盤整備)
   - Vision / Runbook References:


### PR DESCRIPTION
## Summary
- guard the realized volatility reading used for rv_band so NaN values fall back to zero before band selection
- log the runner safeguard and pytest verification in `state.md`

## Testing
- python3 -m pytest tests/test_runner.py tests/test_run_daily_workflow.py

## Japanese Summary
- runner の RV バンド計算で `realized_vol` が NaN を返す際に 0.0 へフォールバックするガードを追加し、state.md に実行ログを追記しました


------
https://chatgpt.com/codex/tasks/task_e_68dfb52d44f4832ab83a86a0210a7764