### PR TITLE
Guard Dukascopy offer side metadata on live fallback

### DIFF
--- a/scripts/live_ingest_worker.py
+++ b/scripts/live_ingest_worker.py
@@ -225,7 +225,11 @@ def _ingest_symbol(symbol: str, config: WorkerConfig, *, now: datetime) -> Optio
         print(f"[live-ingest] ingestion failed for {symbol}: {exc}")
         return None
 
-    if isinstance(result, dict) and config.offer_side:
+    if (
+        isinstance(result, dict)
+        and config.offer_side
+        and result.get("source_name") == "dukascopy"
+    ):
         result.setdefault("dukascopy_offer_side", config.offer_side)
 
     print(

--- a/state.md
+++ b/state.md
@@ -4,6 +4,9 @@
 - Review this file before starting any task to confirm the latest context and checklist.
 - Update this file after completing work to record outcomes, blockers, and next steps.
 
+- 2025-12-10: live ingest worker `_ingest_symbol` で `result.source_name` を確認して `ingest_meta.dukascopy_offer_side` を保存する条件を
+  Dukascopy 経路のみに限定。`tests/test_live_ingest_worker.py` に yfinance フォールバックでフィールドが追加されないことを検証
+  するケースを追加し、`python3 -m pytest` を実行して全件パスを確認。
 - 2025-12-09: Dukascopy 経路のフォールバック結果で `ingest_meta.dukascopy_offer_side` が誤って残らないように、`scripts/run_daily_workflow.py`
   でソース判定ガードを追加。`tests/test_run_daily_workflow.py` にフォールバック時のメタデータ検証ケースを追加し、`python3 -m pytest`
   を完走して既存回帰を確認。

--- a/tests/test_live_ingest_worker.py
+++ b/tests/test_live_ingest_worker.py
@@ -1,4 +1,5 @@
 import csv
+from datetime import datetime
 from pathlib import Path
 from typing import List
 
@@ -190,6 +191,68 @@ def test_live_worker_fallback_to_yfinance(monkeypatch, tmp_path):
     rows = _read_validated(validated_path)
     assert len(rows) == 1
     assert updates == [("USDJPY", "conservative", validated_path)]
+
+
+def test_ingest_symbol_yfinance_fallback_excludes_offer_side(monkeypatch, tmp_path):
+    monkeypatch.setattr(worker, "_load_dukascopy_records", lambda *a, **k: [])
+    fallback_rows = [
+        {
+            "timestamp": "2024-01-01T00:10:00",
+            "symbol": "USDJPY",
+            "tf": "5m",
+            "o": 151.0,
+            "h": 151.2,
+            "l": 150.8,
+            "c": 151.1,
+            "v": 700.0,
+            "spread": 0.1,
+        }
+    ]
+    monkeypatch.setattr(worker, "_load_yfinance_records", lambda *a, **k: list(fallback_rows))
+    monkeypatch.setattr(worker, "get_last_processed_ts", lambda *a, **k: None)
+
+    ingests = []
+
+    def fake_ingest(records, *, symbol, tf, snapshot_path, raw_path, validated_path, features_path, or_n, source_name):
+        records_list = list(records)
+        ingests.append({
+            "symbol": symbol,
+            "tf": tf,
+            "records": records_list,
+            "source_name": source_name,
+        })
+        return {
+            "rows_validated": len(records_list),
+            "anomalies_logged": 0,
+            "last_ts_now": "2024-01-01T00:10:00",
+            "source_name": source_name,
+        }
+
+    monkeypatch.setattr(worker, "ingest_records", fake_ingest)
+
+    config = worker.WorkerConfig(
+        symbols=["USDJPY"],
+        modes=["conservative"],
+        tf="5m",
+        interval=0.0,
+        lookback_minutes=5,
+        freshness_threshold=90,
+        offer_side="bid",
+        snapshot_path=tmp_path / "ops/runtime_snapshot.json",
+        raw_root=tmp_path / "raw",
+        validated_root=tmp_path / "validated",
+        features_root=tmp_path / "features",
+        shutdown_file=None,
+        max_iterations=None,
+        or_n=6,
+    )
+
+    result = worker._ingest_symbol("USDJPY", config, now=datetime(2024, 1, 1, 0, 15, 0))
+
+    assert result is not None
+    assert result.get("source_name") == "yfinance"
+    assert "dukascopy_offer_side" not in result
+    assert ingests and ingests[0]["source_name"] == "yfinance"
 
 
 def test_run_update_state_passes_lowercase_mode(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- guard the live ingestion worker so dukascopy_offer_side is only set when the ingest result reports a Dukascopy source
- add a regression test covering the yfinance fallback path to ensure the Dukascopy metadata is omitted
- record the live ingest guard and regression coverage update in the state log

## Testing
- python3 -m pytest


------
https://chatgpt.com/codex/tasks/task_e_68dfc020a6bc832abfa04ffe59082e2e