### PR TITLE
Refactor local CSV fallback handling

### DIFF
--- a/state.md
+++ b/state.md
@@ -4,6 +4,9 @@
 - Review this file before starting any task to confirm the latest context and checklist.
 - Update this file after completing work to record outcomes, blockers, and next steps.
 
+- 2025-12-11: `scripts/run_daily_workflow.py` のローカルCSVフォールバック処理を `_execute_local_csv_fallback` ヘルパーへ集約し、
+  Dukascopy/yfinance/API 経路のラッパー関数を共通化。フォールバックノートの `stage`/`reason` を呼び出し側で指定できるように
+  整理し、`python3 -m pytest tests/test_run_daily_workflow.py` を実行して回帰が通ることを確認。
 - 2025-12-10: live ingest worker `_ingest_symbol` で `result.source_name` を確認して `ingest_meta.dukascopy_offer_side` を保存する条件を
   Dukascopy 経路のみに限定。`tests/test_live_ingest_worker.py` に yfinance フォールバックでフィールドが追加されないことを検証
   するケースを追加し、`python3 -m pytest` を実行して全件パスを確認。


### PR DESCRIPTION
## Summary
- add a shared `_execute_local_csv_fallback` helper and parameter bundle to centralize local CSV ingestion and fallback note handling
- update the Dukascopy, yfinance, and API ingestion branches to rely on a thin wrapper that passes explicit stage and reason values
- document the refactor in `state.md`

## Testing
- python3 -m pytest tests/test_run_daily_workflow.py


------
https://chatgpt.com/codex/tasks/task_e_68dfc1c952b8832a817d003a2a18fe36