### PR TITLE
Refactor daily workflow ingest dispatch

### DIFF
--- a/state.md
+++ b/state.md
@@ -4,6 +4,7 @@
 - Review this file before starting any task to confirm the latest context and checklist.
 - Update this file after completing work to record outcomes, blockers, and next steps.
 
+- 2025-12-13: `scripts/run_daily_workflow.py` に `IngestContext` を導入し、Dukascopy/yfinance/API それぞれのハンドラ関数へ分割。`python3 -m pytest tests/test_run_daily_workflow.py` を実行して 24 件パスを確認し、CLI ディスパッチを簡素化した。
 - 2025-12-12: `scripts/run_daily_workflow.py` のローカルCSVフォールバック合成バー経路をリファクタし、`_tf_to_minutes` ヘルパーを
   追加。`tests/test_run_daily_workflow.py` を実行して 24 件グリーンを確認し、`result.get("last_ts_now")` の有無を問わずバリデー
   ション済み最新行を単回ロードするよう整理。


### PR DESCRIPTION
## Summary
- introduce an IngestContext helper to centralize shared ingest paths and fallback bookkeeping
- split Dukascopy, yfinance, and API ingestion flows into dedicated helpers and route through them from main()
- update the state log with the refactor details

## Testing
- python3 -m pytest tests/test_run_daily_workflow.py

------
https://chatgpt.com/codex/tasks/task_e_68dfcab24838832a82ef46a4c1f8bdfe