### PR TITLE
Fix live ingest Dukascopy offer-side metadata propagation

### DIFF
--- a/scripts/live_ingest_worker.py
+++ b/scripts/live_ingest_worker.py
@@ -225,12 +225,16 @@ def _ingest_symbol(symbol: str, config: WorkerConfig, *, now: datetime) -> Optio
         print(f"[live-ingest] ingestion failed for {symbol}: {exc}")
         return None
 
-    if (
-        isinstance(result, dict)
-        and config.offer_side
-        and result.get("source_name") == "dukascopy"
-    ):
-        result.setdefault("dukascopy_offer_side", config.offer_side)
+    if isinstance(result, dict) and config.offer_side:
+        source_hints: List[str] = []
+        if source_name:
+            source_hints.append(str(source_name))
+        source_value = result.get("source")
+        if isinstance(source_value, str):
+            source_hints.append(source_value)
+        normalized = [hint.lower() for hint in source_hints if hint]
+        if any("dukascopy" in hint for hint in normalized):
+            result.setdefault("dukascopy_offer_side", config.offer_side)
 
     print(
         f"[live-ingest] {symbol} {source_name} rows={result['rows_validated']} "

--- a/state.md
+++ b/state.md
@@ -4,6 +4,7 @@
 - Review this file before starting any task to confirm the latest context and checklist.
 - Update this file after completing work to record outcomes, blockers, and next steps.
 
+- 2025-12-14: `scripts/live_ingest_worker.py` の Dukascopy 判定を `ingest_records` が返す `source` に合わせ、成功時のみ `dukascopy_offer_side` を永続化するよう修正。`tests/test_live_ingest_worker.py` と `tests/test_run_daily_workflow.py` を更新し、`python3 -m pytest tests/test_live_ingest_worker.py` を実行して 5 件パスを確認した。
 - 2025-12-13: `scripts/run_daily_workflow.py` に `IngestContext` を導入し、Dukascopy/yfinance/API それぞれのハンドラ関数へ分割。`python3 -m pytest tests/test_run_daily_workflow.py` を実行して 24 件パスを確認し、CLI ディスパッチを簡素化した。
 - 2025-12-12: `scripts/run_daily_workflow.py` のローカルCSVフォールバック合成バー経路をリファクタし、`_tf_to_minutes` ヘルパーを
   追加。`tests/test_run_daily_workflow.py` を実行して 24 件グリーンを確認し、`result.get("last_ts_now")` の有無を問わずバリデー


### PR DESCRIPTION
## Summary
- update `scripts/live_ingest_worker._ingest_symbol` to infer Dukascopy runs from the ingest result `source` field and attach the configured offer side accordingly
- extend live ingest worker regressions to cover Dukascopy success/fallback metadata and add a daily workflow test that verifies snapshot metadata retains the offer side
- record the workflow change in `state.md`

## Testing
- python3 -m pytest tests/test_run_daily_workflow.py::test_dukascopy_success_persists_offer_side_metadata
- python3 -m pytest tests/test_live_ingest_worker.py

------
https://chatgpt.com/codex/tasks/task_e_68dfd07ef7c8832a9f2083dd25c25008