### PR TITLE
Refactor local CSV fallback helpers for the daily workflow

### DIFF
--- a/state.md
+++ b/state.md
@@ -3,6 +3,7 @@
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
 - 2025-12-20: `scripts/run_daily_workflow.py` の `_run_dukascopy_ingest` をフェッチ処理・yfinance フォールバック・結果永続化ヘルパーへ分離し、`_fetch_dukascopy_records` / `_YFinanceFallbackRunner` / `_finalize_ingest_result` を導入。`_run_yfinance_ingest` と共通ロジックを共有し、`python3 -m pytest tests/test_run_daily_workflow.py` で 27 件パスを確認。
+- 2025-12-21: `scripts/run_daily_workflow.py` のローカル CSV フォールバック ingest を `_resolve_local_backup_path` / `_ingest_csv_source` / `_extend_with_synthetic_bars` へ分割し、`_execute_local_csv_fallback` から `IngestContext.fallback_kwargs()` をそのまま渡せるよう整理。`tests/test_run_daily_workflow.py` に合成バー有無の分岐を検証するユニットテストを追加し、`python3 -m pytest tests/test_run_daily_workflow.py` で 29 件パスを確認。
 - 2025-12-19: `core/runner.py` の `run_partial` をヘルパー関数へ分解し、日次状態更新・特徴量計算・ポジション決済・トレードエントリー処理を整理。`_finalize_trade` でスリップ/決済共通処理を集約し、`tests/test_runner.py` を実行して回帰を確認。
 - Update this file after completing work to record outcomes, blockers, and next steps.
 


### PR DESCRIPTION
## Summary
- split the local CSV ingest routine into `_resolve_local_backup_path`, `_ingest_csv_source`, and `_extend_with_synthetic_bars`
- align `_execute_local_csv_fallback` with `IngestContext.fallback_kwargs()` so the helper is reusable without reshaping arguments
- add unit tests that cover the synthetic extension threshold logic using deterministic timestamps

## Testing
- python3 -m pytest tests/test_run_daily_workflow.py

## 日本語サマリ
- ローカルCSV取り込み処理を3つのヘルパーへ分割し責務を明確化しました
- `_execute_local_csv_fallback` が `IngestContext.fallback_kwargs()` をそのまま活用できるように整理しました
- 合成バー生成の閾値分岐を検証するユニットテストを追加しました


------
https://chatgpt.com/codex/tasks/task_e_68e06dde8260832aab2781a9498260c8