### PR TITLE
Refactor trade entry flow in core runner

### DIFF
--- a/state.md
+++ b/state.md
@@ -3,6 +3,7 @@
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
 - 2025-12-20: `scripts/run_daily_workflow.py` の `_run_dukascopy_ingest` をフェッチ処理・yfinance フォールバック・結果永続化ヘルパーへ分離し、`_fetch_dukascopy_records` / `_YFinanceFallbackRunner` / `_finalize_ingest_result` を導入。`_run_yfinance_ingest` と共通ロジックを共有し、`python3 -m pytest tests/test_run_daily_workflow.py` で 27 件パスを確認。
+- 2025-12-22: core/runner._maybe_enter_trade をエントリ条件・EV評価・スリップ/サイズ検証・Fill処理のヘルパーへ分割し、tests/test_runner.py にブレイクアウト成功/EVリジェクト/ウォームアップバイパスのユニットテストを追加。python3 -m pytest tests/test_runner.py で 9 件パスを確認。
 - 2025-12-21: `scripts/run_daily_workflow.py` のローカル CSV フォールバック ingest を `_resolve_local_backup_path` / `_ingest_csv_source` / `_extend_with_synthetic_bars` へ分割し、`_execute_local_csv_fallback` から `IngestContext.fallback_kwargs()` をそのまま渡せるよう整理。`tests/test_run_daily_workflow.py` に合成バー有無の分岐を検証するユニットテストを追加し、`python3 -m pytest tests/test_run_daily_workflow.py` で 29 件パスを確認。
 - 2025-12-19: `core/runner.py` の `run_partial` をヘルパー関数へ分解し、日次状態更新・特徴量計算・ポジション決済・トレードエントリー処理を整理。`_finalize_trade` でスリップ/決済共通処理を集約し、`tests/test_runner.py` を実行して回帰を確認。
 - Update this file after completing work to record outcomes, blockers, and next steps.

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -22,6 +22,86 @@ def make_bar(ts, symbol, o, h, l, c, spread):
 
 
 class TestRunner(unittest.TestCase):
+
+    class DummyEV:
+        def __init__(self, ev_lcb: float, p_lcb: float) -> None:
+            self._ev_lcb = ev_lcb
+            self._p_lcb = p_lcb
+
+        def ev_lcb_oco(self, tp_pips: float, sl_pips: float, cost_pips: float) -> float:
+            return self._ev_lcb
+
+        def p_lcb(self) -> float:
+            return self._p_lcb
+
+        def update(self, hit: bool) -> None:
+            self.last_update = hit
+
+    def _prepare_breakout_environment(self, *, warmup_left: int = 0):
+        import core.runner as runner_module
+
+        symbol = "USDJPY"
+        runner = BacktestRunner(equity=100_000.0, symbol=symbol)
+        runner._strategy_gate_hook = None
+        runner._ev_threshold_hook = None
+        t0 = datetime(2024, 1, 5, 8, 0, tzinfo=timezone.utc)
+        bars = []
+        price = 150.0
+        for i in range(6):
+            bars.append(
+                make_bar(
+                    t0 + timedelta(minutes=5 * i),
+                    symbol,
+                    price,
+                    price + 0.10,
+                    price - 0.10,
+                    price + 0.02,
+                    spread=0.02,
+                )
+            )
+            price += 0.01
+        or_high = max(b["h"] for b in bars)
+        breakout = make_bar(
+            t0 + timedelta(minutes=5 * 6),
+            symbol,
+            price,
+            or_high + 0.12,
+            price - 0.05,
+            price,
+            spread=0.02,
+        )
+        for bar in bars:
+            new_session, session, calibrating = runner._update_daily_state(bar)
+            runner._compute_features(
+                bar,
+                session=session,
+                new_session=new_session,
+                calibrating=calibrating,
+            )
+        new_session, session, calibrating = runner._update_daily_state(breakout)
+        bar_input, ctx, atr14, adx14, or_h, or_l = runner._compute_features(
+            breakout,
+            session=session,
+            new_session=new_session,
+            calibrating=calibrating,
+        )
+        pending = {
+            "side": "BUY",
+            "tp_pips": 2.0,
+            "sl_pips": 1.0,
+            "trail_pips": 0.0,
+            "entry": breakout["c"],
+        }
+        original_pass_gates = runner_module.pass_gates
+        runner_module.pass_gates = lambda ctx: True
+        self.addCleanup(lambda: setattr(runner_module, "pass_gates", original_pass_gates))
+        runner._last_timestamp = breakout["timestamp"]
+        runner._warmup_left = warmup_left
+        runner.rcfg.min_or_atr_ratio = 0.0
+        runner.rcfg.allow_low_rv = True
+        runner.rcfg.allowed_sessions = ()
+        return runner, pending, breakout, bar_input, ctx, atr14, adx14, or_h, or_l, calibrating
+
     def test_minimal_flow_produces_metrics(self):
         # create simple opening range then breakout
         symbol = "USDJPY"
@@ -179,6 +259,134 @@ class TestRunner(unittest.TestCase):
         self.assertAlmostEqual(slip_off, expected_slip)
         self.assertEqual(runner_off.slip_a["normal"], prev_a_off)
         self.assertEqual(runner_off.qty_ewma["normal"], prev_qty_off)
+    def test_evaluate_entry_conditions_and_ev_pass_on_breakout(self):
+        (
+            runner,
+            pending,
+            breakout,
+            bar_input,
+            ctx,
+            atr14,
+            adx14,
+            or_h,
+            or_l,
+            calibrating,
+        ) = self._prepare_breakout_environment(warmup_left=0)
+        stub_ev = self.DummyEV(ev_lcb=1.2, p_lcb=0.65)
+        runner._get_ev_manager = lambda key: stub_ev
+        ctx_dbg = runner._evaluate_entry_conditions(
+            pending=pending,
+            bar=breakout,
+            bar_input=bar_input,
+            atr14=atr14,
+            adx14=adx14,
+            or_h=or_h,
+            or_l=or_l,
+        )
+        self.assertIsNotNone(ctx_dbg)
+        ev_eval = runner._evaluate_ev_threshold(
+            ctx_dbg=ctx_dbg,
+            pending=pending,
+            calibrating=calibrating,
+            timestamp=runner._last_timestamp,
+        )
+        self.assertIsNotNone(ev_eval)
+        ev_mgr, ev_lcb, threshold_lcb, ev_bypass = ev_eval
+        self.assertIs(ev_mgr, stub_ev)
+        self.assertGreater(ev_lcb, threshold_lcb)
+        self.assertFalse(ev_bypass)
+        self.assertTrue(ctx_dbg.get("ev_pass"))
+        slip_ok = runner._check_slip_and_sizing(
+            ctx_dbg=ctx_dbg,
+            pending=pending,
+            ev_mgr=stub_ev,
+            calibrating=calibrating,
+            ev_bypass=ev_bypass,
+            timestamp=runner._last_timestamp,
+        )
+        self.assertTrue(slip_ok)
+
+    def test_evaluate_ev_threshold_rejects_when_ev_below_threshold(self):
+        (
+            runner,
+            pending,
+            breakout,
+            bar_input,
+            ctx,
+            atr14,
+            adx14,
+            or_h,
+            or_l,
+            calibrating,
+        ) = self._prepare_breakout_environment(warmup_left=0)
+        stub_ev = self.DummyEV(ev_lcb=0.05, p_lcb=0.55)
+        runner._get_ev_manager = lambda key: stub_ev
+        ctx_dbg = runner._evaluate_entry_conditions(
+            pending=pending,
+            bar=breakout,
+            bar_input=bar_input,
+            atr14=atr14,
+            adx14=adx14,
+            or_h=or_h,
+            or_l=or_l,
+        )
+        self.assertIsNotNone(ctx_dbg)
+        ev_eval = runner._evaluate_ev_threshold(
+            ctx_dbg=ctx_dbg,
+            pending=pending,
+            calibrating=calibrating,
+            timestamp=runner._last_timestamp,
+        )
+        self.assertIsNone(ev_eval)
+        self.assertEqual(runner.debug_counts["ev_reject"], 1)
+
+    def test_warmup_bypass_allows_low_ev_signal(self):
+        (
+            runner,
+            pending,
+            breakout,
+            bar_input,
+            ctx,
+            atr14,
+            adx14,
+            or_h,
+            or_l,
+            calibrating,
+        ) = self._prepare_breakout_environment(warmup_left=5)
+        stub_ev = self.DummyEV(ev_lcb=0.05, p_lcb=0.55)
+        runner._get_ev_manager = lambda key: stub_ev
+        ctx_dbg = runner._evaluate_entry_conditions(
+            pending=pending,
+            bar=breakout,
+            bar_input=bar_input,
+            atr14=atr14,
+            adx14=adx14,
+            or_h=or_h,
+            or_l=or_l,
+        )
+        self.assertIsNotNone(ctx_dbg)
+        ev_eval = runner._evaluate_ev_threshold(
+            ctx_dbg=ctx_dbg,
+            pending=pending,
+            calibrating=calibrating,
+            timestamp=runner._last_timestamp,
+        )
+        self.assertIsNotNone(ev_eval)
+        ev_mgr, ev_lcb, threshold_lcb, ev_bypass = ev_eval
+        self.assertTrue(ev_bypass)
+        self.assertFalse(ctx_dbg.get("ev_pass"))
+        slip_ok = runner._check_slip_and_sizing(
+            ctx_dbg=ctx_dbg,
+            pending=pending,
+            ev_mgr=ev_mgr,
+            calibrating=calibrating,
+            ev_bypass=ev_bypass,
+            timestamp=runner._last_timestamp,
+        )
+        self.assertTrue(slip_ok)
+        self.assertEqual(runner.debug_counts["ev_bypass"], 1)
+
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extract BacktestRunner._maybe_enter_trade into helper methods covering entry condition evaluation, EV threshold handling, slip and sizing checks, and fill processing for clearer control flow
- add unit tests that exercise the new helper methods for breakout success, EV rejection, and warmup bypass scenarios and update the workflow state log

## Testing
- python3 -m pytest tests/test_runner.py

------
https://chatgpt.com/codex/tasks/task_e_68e0778488d0832aa2229c873fd893f8