### PR TITLE
Handle emit signal logs without parent directory

### DIFF
--- a/notifications/emit_signal.py
+++ b/notifications/emit_signal.py
@@ -7,6 +7,7 @@ import os
 import sys
 from dataclasses import dataclass, asdict
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Iterable, Optional
 
 try:
@@ -48,8 +49,15 @@ def send_webhook(url: str, payload: SignalPayload, timeout: float = 5.0) -> tupl
         return False, f"unexpected_error={type(e).__name__}:{e}"
 
 
+def _ensure_parent_dir(path: str) -> None:
+    dirpath = Path(path).parent
+    if not dirpath.parts:
+        return
+    dirpath.mkdir(parents=True, exist_ok=True)
+
+
 def log_latency(output_path: str, signal_id: str, ts_emit: str, success: bool, detail: str) -> None:
-    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    _ensure_parent_dir(output_path)
     ts_ack = datetime.now(timezone.utc).isoformat()
     line = ",".join([
         signal_id,
@@ -67,7 +75,7 @@ def log_latency(output_path: str, signal_id: str, ts_emit: str, success: bool, d
 
 
 def log_fallback(path: str, payload: SignalPayload, note: str) -> None:
-    os.makedirs(os.path.dirname(path), exist_ok=True)
+    _ensure_parent_dir(path)
     ts = datetime.now(timezone.utc).isoformat()
     record = {
         "ts": ts,

--- a/state.md
+++ b/state.md
@@ -2,6 +2,7 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
+- 2025-12-24: `notifications/emit_signal.py` の `log_latency` / `log_fallback` で親ディレクトリが存在しない場合でもファイル名のみで書き込めるようガードを追加し、`tests/test_emit_signal.py` に無ディレクトリ指定の回帰テストを実装。`python3 -m pytest tests/test_emit_signal.py` を実行して 5 件パスを確認。
 - 2025-12-20: `scripts/run_daily_workflow.py` の `_run_dukascopy_ingest` をフェッチ処理・yfinance フォールバック・結果永続化ヘルパーへ分離し、`_fetch_dukascopy_records` / `_YFinanceFallbackRunner` / `_finalize_ingest_result` を導入。`_run_yfinance_ingest` と共通ロジックを共有し、`python3 -m pytest tests/test_run_daily_workflow.py` で 27 件パスを確認。
 - 2025-12-22: core/runner._maybe_enter_trade をエントリ条件・EV評価・スリップ/サイズ検証・Fill処理のヘルパーへ分割し、tests/test_runner.py にブレイクアウト成功/EVリジェクト/ウォームアップバイパスのユニットテストを追加。python3 -m pytest tests/test_runner.py で 9 件パスを確認。
 - 2025-12-23: `core/runner._handle_active_position` を `_compute_exit_decision` で共通化し、トレール/同時ヒット/タイムアウトの BUY・SELL 双方向回帰テストを `tests/test_runner.py` に追加。`python3 -m pytest tests/test_runner.py` を実行して 12 件パスを確認。

--- a/tests/test_emit_signal.py
+++ b/tests/test_emit_signal.py
@@ -42,6 +42,28 @@ def test_log_latency_and_fallback(tmp_path):
     assert record["note"] == "error"
 
 
+def test_log_files_without_dir(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    payload = emit.SignalPayload(
+        signal_id="sig2",
+        timestamp_utc="2025-09-21T12:05:00+00:00",
+        side="SELL",
+        entry=120.0,
+        tp=119.5,
+        sl=121.0,
+        trail=0.0,
+        confidence=0.6,
+    )
+
+    emit.log_latency("latency.csv", payload.signal_id, payload.timestamp_utc, True, "ok")
+    emit.log_fallback("fallback.log", payload, "fallback")
+
+    latency_path = tmp_path / "latency.csv"
+    fallback_path = tmp_path / "fallback.log"
+    assert latency_path.exists()
+    assert fallback_path.exists()
+
+
 def test_send_webhook_success(monkeypatch):
     class FakeResponse:
         status = 200


### PR DESCRIPTION
## Summary
- guard the latency and fallback log writers to avoid creating directories when the path has no parent
- cover filename-only logging in the emit_signal tests to prevent regressions
- record the maintenance work in state.md for traceability

## Testing
- python3 -m pytest tests/test_emit_signal.py

------
https://chatgpt.com/codex/tasks/task_e_68e09d2a2a44832abdbe0e0eb8f1d85b