### PR TITLE
Refine calibration exit handling

### DIFF
--- a/state.md
+++ b/state.md
@@ -2,6 +2,7 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
+- 2025-12-26: `core/runner._resolve_calibration_positions` で `_compute_exit_decision` を使ってキャリブレーションポジションを処理し、`tests/test_runner.py` に同時ヒット/セッション切替時の EV 更新回帰テストを追加。`python3 -m pytest tests/test_runner.py` を実行して 16 件パスを確認。
 - 2025-12-25: `core/runner._check_slip_and_sizing` で `core.sizing` のヘルパーを用いたサイズ算出に置き換え、ゼロサイズ/スリップガードのユニットテストを `tests/test_runner.py` に追加。`python3 -m pytest tests/test_runner.py` を実行して 14 件パスを確認。
 - 2025-12-24: `notifications/emit_signal.py` の `log_latency` / `log_fallback` で親ディレクトリが存在しない場合でもファイル名のみで書き込めるようガードを追加し、`tests/test_emit_signal.py` に無ディレクトリ指定の回帰テストを実装。`python3 -m pytest tests/test_emit_signal.py` を実行して 5 件パスを確認。
 - 2025-12-20: `scripts/run_daily_workflow.py` の `_run_dukascopy_ingest` をフェッチ処理・yfinance フォールバック・結果永続化ヘルパーへ分離し、`_fetch_dukascopy_records` / `_YFinanceFallbackRunner` / `_finalize_ingest_result` を導入。`_run_yfinance_ingest` と共通ロジックを共有し、`python3 -m pytest tests/test_run_daily_workflow.py` で 27 件パスを確認。


### PR DESCRIPTION
## Summary
- reuse the shared exit decision helper for calibration positions by normalizing stored state and preserving trailing data
- record trailing metadata when enqueueing calibration fills and keep the state log in sync
- add regression tests ensuring calibration EV updates remain stable for simultaneous hits and session transitions

## Testing
- python3 -m pytest tests/test_runner.py

------
https://chatgpt.com/codex/tasks/task_e_68e09fa786a4832a8e5a149f78c06feb