### PR TITLE
Unify timestamp parsing helpers for ingestion workflows

### DIFF
--- a/scripts/_time_utils.py
+++ b/scripts/_time_utils.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 from datetime import datetime as _datetime, timezone
-from typing import Optional
+from typing import Optional, Sequence
+
+from scripts._ts_utils import parse_naive_utc_timestamp
 
 # Allow monkeypatching via ``scripts._time_utils.datetime``
 datetime = _datetime  # type: ignore
@@ -64,3 +66,25 @@ def utcnow_iso(dt_cls=None) -> str:
         .isoformat()
         .replace("+00:00", "Z")
     )
+
+
+def parse_naive_utc(
+    value: str,
+    *,
+    fallback_formats: Sequence[str] | None = None,
+) -> Optional[_datetime]:
+    """Parse ``value`` into a naive UTC ``datetime``.
+
+    The helper wraps :func:`scripts._ts_utils.parse_naive_utc_timestamp` and
+    returns ``None`` for empty or invalid inputs so callers can gracefully
+    handle missing timestamps without raising.
+    """
+
+    text = (value or "").strip()
+    if not text:
+        return None
+
+    try:
+        return parse_naive_utc_timestamp(text, fallback_formats=fallback_formats)
+    except ValueError:
+        return None

--- a/scripts/ingest_providers.py
+++ b/scripts/ingest_providers.py
@@ -6,6 +6,8 @@ from datetime import datetime, timedelta, timezone
 from functools import partial
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
 
+from scripts._time_utils import parse_naive_utc as _shared_parse_naive_utc
+
 
 __all__ = [
     "ProviderError",
@@ -33,25 +35,7 @@ class ProviderError(RuntimeError):
 def parse_naive_utc(timestamp: str) -> Optional[datetime]:
     """Parse ISO 8601 timestamps into naive UTC datetimes."""
 
-    if not timestamp:
-        return None
-
-    value = timestamp.strip()
-    if not value:
-        return None
-
-    if value.endswith("Z"):
-        value = value[:-1] + "+00:00"
-
-    try:
-        parsed = datetime.fromisoformat(value)
-    except ValueError:
-        return None
-
-    if parsed.tzinfo is not None:
-        parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
-
-    return parsed
+    return _shared_parse_naive_utc(timestamp)
 
 
 def load_dukascopy_fetch() -> Callable[..., Iterable[Dict[str, object]]]:

--- a/scripts/live_ingest_worker.py
+++ b/scripts/live_ingest_worker.py
@@ -7,7 +7,7 @@ import signal
 import sys
 import time
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Iterable, List, Optional, Sequence
 
@@ -17,7 +17,10 @@ if str(ROOT) not in sys.path:
 
 
 from scripts import ingest_providers  # noqa: E402  # isort:skip
-from scripts._time_utils import utcnow_naive  # noqa: E402  # isort:skip
+from scripts._time_utils import (  # noqa: E402  # isort:skip
+    parse_naive_utc,
+    utcnow_naive,
+)
 from scripts.pull_prices import (  # noqa: E402  # isort:skip
     FEATURES_ROOT,
     RAW_ROOT,
@@ -81,16 +84,7 @@ def _parse_csv_list(
     return _apply_case(items)
 
 
-def _parse_timestamp(value: str) -> Optional[datetime]:
-    if not value:
-        return None
-    try:
-        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
-    except ValueError:
-        return None
-    if dt.tzinfo is not None:
-        dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
-    return dt
+_parse_timestamp = parse_naive_utc
 
 
 def _load_dukascopy_records(

--- a/scripts/run_daily_workflow.py
+++ b/scripts/run_daily_workflow.py
@@ -18,11 +18,14 @@ if str(ROOT) not in sys.path:
 
 from core.utils import yaml_compat as yaml
 from scripts import ingest_providers
-from scripts._time_utils import utcnow_naive as _shared_utcnow_naive
+from scripts._time_utils import (
+    parse_naive_utc as _shared_parse_naive_utc,
+    utcnow_naive as _shared_utcnow_naive,
+)
 
 
 ProviderError = ingest_providers.ProviderError
-_parse_naive_utc = ingest_providers.parse_naive_utc
+_parse_naive_utc = _shared_parse_naive_utc
 _fetch_dukascopy_records = ingest_providers.fetch_dukascopy_records
 _compute_yfinance_fallback_start = ingest_providers.compute_yfinance_fallback_start
 _fetch_yfinance_records = ingest_providers.fetch_yfinance_records

--- a/state.md
+++ b/state.md
@@ -4,6 +4,7 @@
 - Review this file before starting any task to confirm the latest context and checklist.
 - 2025-12-26: `core/runner._resolve_calibration_positions` で `_compute_exit_decision` を使ってキャリブレーションポジションを処理し、`tests/test_runner.py` に同時ヒット/セッション切替時の EV 更新回帰テストを追加。`python3 -m pytest tests/test_runner.py` を実行して 16 件パスを確認。
 - 2025-12-27: Dukascopy/yfinance 共通ヘルパー `scripts/ingest_providers.py` を追加し、`run_daily_workflow.py` と `live_ingest_worker.py` を移行。フォールバック鮮度判定・メタデータ付与を共通化するテスト (`tests/test_run_daily_workflow.py` / `tests/test_live_ingest_worker.py`) を拡張し、`python3 -m pytest` を完走してリグレッションを確認。
+- 2025-12-28: `scripts/_time_utils.parse_naive_utc` を追加し、`run_daily_workflow.py` と `live_ingest_worker.py` が同一パーサーを参照するよう統一。`tests/test_run_daily_workflow.py` / `tests/test_live_ingest_worker.py` に共有パスの回帰テストを追加し、`python3 -m pytest` で 150 件パスを確認。
 - 2025-12-25: `core/runner._check_slip_and_sizing` で `core.sizing` のヘルパーを用いたサイズ算出に置き換え、ゼロサイズ/スリップガードのユニットテストを `tests/test_runner.py` に追加。`python3 -m pytest tests/test_runner.py` を実行して 14 件パスを確認。
 - 2025-12-24: `notifications/emit_signal.py` の `log_latency` / `log_fallback` で親ディレクトリが存在しない場合でもファイル名のみで書き込めるようガードを追加し、`tests/test_emit_signal.py` に無ディレクトリ指定の回帰テストを実装。`python3 -m pytest tests/test_emit_signal.py` を実行して 5 件パスを確認。
 - 2025-12-20: `scripts/run_daily_workflow.py` の `_run_dukascopy_ingest` をフェッチ処理・yfinance フォールバック・結果永続化ヘルパーへ分離し、`_fetch_dukascopy_records` / `_YFinanceFallbackRunner` / `_finalize_ingest_result` を導入。`_run_yfinance_ingest` と共通ロジックを共有し、`python3 -m pytest tests/test_run_daily_workflow.py` で 27 件パスを確認。

--- a/tests/test_live_ingest_worker.py
+++ b/tests/test_live_ingest_worker.py
@@ -444,3 +444,18 @@ def test_run_update_state_passes_lowercase_mode(monkeypatch, tmp_path):
             "conservative",
         ]
     ]
+
+
+def test_live_worker_uses_shared_timestamp_parser():
+    from scripts import _time_utils
+
+    parser = worker._parse_timestamp
+
+    assert parser is _time_utils.parse_naive_utc
+    assert parser("2024-01-01T00:00:00Z") == datetime(2024, 1, 1, 0, 0)
+    assert parser("2024-01-01 00:00:00", fallback_formats=("%Y-%m-%d %H:%M:%S",)) == datetime(
+        2024, 1, 1, 0, 0
+    )
+    assert parser("") is None
+    assert parser("invalid") is None
+

--- a/tests/test_run_daily_workflow.py
+++ b/tests/test_run_daily_workflow.py
@@ -2126,3 +2126,23 @@ def test_ingest_providers_yfinance_fallback_runner_handles_import_error():
     call = ingest_calls[0]
     assert call["stage"] == "yfinance"
     assert call["source_label"] == "yfinance"
+
+
+def test_run_daily_workflow_uses_shared_timestamp_parser():
+    from scripts import _time_utils
+
+    parser = run_daily_workflow._parse_naive_utc
+
+    assert parser is _time_utils.parse_naive_utc
+
+    dt_z = parser("2024-01-01T00:00:00Z")
+    assert dt_z == datetime(2024, 1, 1, 0, 0)
+    assert dt_z.tzinfo is None
+
+    dt_offset = parser("2024-01-01T09:00:00+09:00")
+    assert dt_offset == datetime(2024, 1, 1, 0, 0)
+    assert dt_offset.tzinfo is None
+
+    assert parser("   ") is None
+    assert parser("not-a-timestamp") is None
+


### PR DESCRIPTION
## Summary
- add a shared `parse_naive_utc` helper to `scripts/_time_utils.py` and reuse it from the ingest providers module
- switch `run_daily_workflow.py` and `live_ingest_worker.py` to import the shared parser instead of local implementations
- extend the workflow and live worker tests to assert the shared helper semantics and update `state.md` with the change

## Testing
- python3 -m pytest


------
https://chatgpt.com/codex/tasks/task_e_68e0c9694b6c832aabf2f4acc21b1b15