### PR TITLE
Add type hints and guard documentation to feature store indicators

### DIFF
--- a/core/feature_store.py
+++ b/core/feature_store.py
@@ -3,49 +3,95 @@ Feature Store (5m mode) — minimal calculations for ATR, ADX, OR width, RV, ban
 NOTE: Placeholder computations; replace with vetted implementations during integration.
 """
 from __future__ import annotations
+
 import math
-from collections import deque
-from typing import Deque, Dict, Any, Tuple, List
+from typing import Mapping, Sequence, Tuple
 
-def true_range(h, l, pc):
-    return max(h-l, abs(h-pc), abs(l-pc))
 
-def atr(bars: List[Dict[str, float]], period: int = 14) -> float:
-    if len(bars) < period+1: return float("nan")
-    trs = [true_range(bars[i]["h"], bars[i]["l"], bars[i-1]["c"]) for i in range(1, period+1)]
-    return sum(trs)/period
+Bar = Mapping[str, float]
+NAN = math.nan
 
-def adx(bars: List[Dict[str, float]], period: int = 14) -> float:
-    # Simplified ADX (Wilder). For skeleton purposes.
-    if len(bars) < period+1: return float("nan")
-    plus_dm = []; minus_dm = []; tr = []
-    for i in range(1, period+1):
-        up = bars[i]["h"] - bars[i-1]["h"]
-        dn = bars[i-1]["l"] - bars[i]["l"]
+
+def true_range(high: float, low: float, prev_close: float) -> float:
+    """Return the Wilder true range for the provided bar values."""
+
+    return max(high - low, abs(high - prev_close), abs(low - prev_close))
+
+
+def atr(bars: Sequence[Bar], period: int = 14) -> float:
+    """Compute a simplified average true range; NaN if the window is incomplete."""
+
+    if len(bars) < period + 1:
+        # Require a previous close and ``period`` bars to compute ATR.
+        return NAN
+
+    trs = [
+        true_range(bars[i]["h"], bars[i]["l"], bars[i - 1]["c"])
+        for i in range(1, period + 1)
+    ]
+    return sum(trs) / period
+
+
+def adx(bars: Sequence[Bar], period: int = 14) -> float:
+    """Approximate the ADX using Wilder smoothing; NaN when insufficient data."""
+
+    if len(bars) < period + 1:
+        # ADX needs the previous close and ``period`` bars to form directional moves.
+        return NAN
+
+    plus_dm: list[float] = []
+    minus_dm: list[float] = []
+    tr: list[float] = []
+
+    for i in range(1, period + 1):
+        up = bars[i]["h"] - bars[i - 1]["h"]
+        dn = bars[i - 1]["l"] - bars[i]["l"]
         plus_dm.append(max(up, 0.0) if up > dn else 0.0)
         minus_dm.append(max(dn, 0.0) if dn > up else 0.0)
-        tr.append(true_range(bars[i]["h"], bars[i]["l"], bars[i-1]["c"]))
-    atrv = sum(tr)/period
-    if atrv == 0: return 0.0
-    plus_di = (sum(plus_dm)/period)/atrv * 100.0
-    minus_di = (sum(minus_dm)/period)/atrv * 100.0
+        tr.append(true_range(bars[i]["h"], bars[i]["l"], bars[i - 1]["c"]))
+
+    atrv = sum(tr) / period
+    if atrv == 0:
+        # Avoid division by zero when the true range is degenerate.
+        return 0.0
+
+    plus_di = (sum(plus_dm) / period) / atrv * 100.0
+    minus_di = (sum(minus_dm) / period) / atrv * 100.0
     dx = abs(plus_di - minus_di) / max(plus_di + minus_di, 1e-9) * 100.0
     return dx  # This is an approximation of ADX for skeleton
 
-def opening_range(bars: List[Dict[str,float]], n: int = 6) -> Tuple[float,float]:
-    if len(bars) < n: return (float("nan"), float("nan"))
+
+def opening_range(bars: Sequence[Bar], n: int = 6) -> Tuple[float, float]:
+    """Return (high, low) for the opening range; NaNs when the lookback is short."""
+
+    if len(bars) < n:
+        # Need ``n`` bars to form the opening range window.
+        return (NAN, NAN)
+
     window = bars[:n]
-    return (max(b["h"] for b in window), min(b["l"] for b in window))
+    return (max(bar["h"] for bar in window), min(bar["l"] for bar in window))
 
-def realized_vol(bars: List[Dict[str, float]], n: int = 12) -> float:
-    if len(bars) < n+1: return float("nan")
+
+def realized_vol(bars: Sequence[Bar], n: int = 12) -> float:
+    """Compute a realized volatility estimate; NaN when the window is incomplete."""
+
+    if len(bars) < n + 1:
+        # Require the previous close plus ``n`` bars to form log returns.
+        return NAN
+
     rsq = 0.0
-    for i in range(1, n+1):
-        r = math.log(bars[i]["c"]/bars[i-1]["c"])
-        rsq += r*r
-    return math.sqrt(rsq)*math.sqrt(288)  # 5m bars per day ~288; rough annualization proxy
+    for i in range(1, n + 1):
+        r = math.log(bars[i]["c"] / bars[i - 1]["c"])
+        rsq += r * r
 
-def band(value: float, cuts: List[float], labels: List[str]) -> str:
-    for c, lab in zip(cuts, labels):
-        if value <= c: return lab
+    # 5m bars per day ~288; rough annualization proxy
+    return math.sqrt(rsq) * math.sqrt(288)
+
+
+def band(value: float, cuts: Sequence[float], labels: Sequence[str]) -> str:
+    """Return the first label with a threshold greater than the value, else the last."""
+
+    for cutoff, label in zip(cuts, labels):
+        if value <= cutoff:
+            return label
     return labels[-1]

--- a/state.md
+++ b/state.md
@@ -2,6 +2,7 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
+- 2025-12-29: `core/feature_store.py` に型ヒントを追加し、NaN ガードをコメント付きで整理。`python3 -m pytest tests/test_runner.py` を実行して 16 件パスを再確認。
 - 2025-12-26: `core/runner._resolve_calibration_positions` で `_compute_exit_decision` を使ってキャリブレーションポジションを処理し、`tests/test_runner.py` に同時ヒット/セッション切替時の EV 更新回帰テストを追加。`python3 -m pytest tests/test_runner.py` を実行して 16 件パスを確認。
 - 2025-12-27: Dukascopy/yfinance 共通ヘルパー `scripts/ingest_providers.py` を追加し、`run_daily_workflow.py` と `live_ingest_worker.py` を移行。フォールバック鮮度判定・メタデータ付与を共通化するテスト (`tests/test_run_daily_workflow.py` / `tests/test_live_ingest_worker.py`) を拡張し、`python3 -m pytest` を完走してリグレッションを確認。
 - 2025-12-28: `scripts/_time_utils.parse_naive_utc` を追加し、`run_daily_workflow.py` と `live_ingest_worker.py` が同一パーサーを参照するよう統一。`tests/test_run_daily_workflow.py` / `tests/test_live_ingest_worker.py` に共有パスの回帰テストを追加し、`python3 -m pytest` で 150 件パスを確認。


### PR DESCRIPTION
## Summary
- add explicit type hints to the feature store helpers and use a shared NAN constant
- expand guard clauses into multi-line form with comments that document the early return conditions

## Testing
- python3 -m pytest tests/test_runner.py

## 日本語サマリー
- Feature Store 指標に型ヒントと NaN ガードのコメントを追加し、tests/test_runner.py の回帰を確認しました。


------
https://chatgpt.com/codex/tasks/task_e_68e0d1361aec832aa799d33369543c11