### PR TITLE
Align API ingest finalization with shared helper

### DIFF
--- a/scripts/run_daily_workflow.py
+++ b/scripts/run_daily_workflow.py
@@ -1007,24 +1007,13 @@ def _run_api_ingest(
         ingest_error_prefix="api ingestion failed during ingest",
     )
 
-    if result is None or not source_label:
-        print("[wf] API ingestion produced no result")
-        return None, 1
-
-    _log_ingest_summary(result, source_label)
-
-    finish_now = _utcnow_naive()
-    _persist_ingest_metadata(
-        symbol=ctx.symbol,
-        tf=ctx.tf,
-        snapshot_path=ctx.snapshot_path,
-        result=result,
-        fallback_notes=ctx.fallback_notes,
+    return _finalize_ingest_result(
+        ctx,
+        result,
+        source_label,
         primary_source="api",
-        now=finish_now,
+        empty_message="[wf] API ingestion produced no result",
     )
-
-    return result, 0
 
 def run_cmd(cmd):
     print(f"[wf] running: {' '.join(cmd)}")

--- a/state.md
+++ b/state.md
@@ -2,6 +2,7 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
+- 2025-12-30: `_run_api_ingest` を `_finalize_ingest_result` へ統合し、API 成功/フォールバック時のログ整合性を検証するテストを更新。`python3 -m pytest tests/test_run_daily_workflow.py` を実行して 32 件パスを確認。
 - 2025-12-29: `core/feature_store.py` に型ヒントを追加し、NaN ガードをコメント付きで整理。`python3 -m pytest tests/test_runner.py` を実行して 16 件パスを再確認。
 - 2025-12-26: `core/runner._resolve_calibration_positions` で `_compute_exit_decision` を使ってキャリブレーションポジションを処理し、`tests/test_runner.py` に同時ヒット/セッション切替時の EV 更新回帰テストを追加。`python3 -m pytest tests/test_runner.py` を実行して 16 件パスを確認。
 - 2025-12-27: Dukascopy/yfinance 共通ヘルパー `scripts/ingest_providers.py` を追加し、`run_daily_workflow.py` と `live_ingest_worker.py` を移行。フォールバック鮮度判定・メタデータ付与を共通化するテスト (`tests/test_run_daily_workflow.py` / `tests/test_live_ingest_worker.py`) を拡張し、`python3 -m pytest` を完走してリグレッションを確認。

--- a/tests/test_run_daily_workflow.py
+++ b/tests/test_run_daily_workflow.py
@@ -247,7 +247,7 @@ def test_main_returns_first_failure(failing_run_cmd):
     assert len(captured) == 1
 
 
-def test_api_ingest_updates_snapshot(tmp_path, monkeypatch):
+def test_api_ingest_updates_snapshot(tmp_path, monkeypatch, capsys):
     repo_root = tmp_path / "repo"
     (repo_root / "ops/logs").mkdir(parents=True)
     (repo_root / "configs").mkdir()
@@ -378,6 +378,10 @@ def test_api_ingest_updates_snapshot(tmp_path, monkeypatch):
     )
 
     assert exit_code == 0
+    captured = capsys.readouterr().out
+    assert "[wf] api_ingest" in captured
+    assert "rows=2" in captured
+    assert "last_ts=2025-01-01T00:30:00" in captured
     assert fetch_calls["symbol"] == "USDJPY"
     assert fetch_calls["tf"] == "5m"
     assert fetch_calls["provider"] == "mock"
@@ -409,7 +413,7 @@ def test_api_ingest_updates_snapshot(tmp_path, monkeypatch):
     assert meta["snapshot_path"] == str(snapshot_path)
 
 
-def test_api_ingest_falls_back_to_local_csv(tmp_path, monkeypatch):
+def test_api_ingest_falls_back_to_local_csv(tmp_path, monkeypatch, capsys):
     repo_root = tmp_path / "repo"
     (repo_root / "ops/logs").mkdir(parents=True)
     (repo_root / "configs").mkdir()
@@ -496,6 +500,10 @@ def test_api_ingest_falls_back_to_local_csv(tmp_path, monkeypatch):
     )
 
     assert exit_code == 0
+    fallback_logs = capsys.readouterr().out
+    assert "[wf] local_csv_ingest" in fallback_logs
+    assert "rows=" in fallback_logs
+    assert "last_ts=" in fallback_logs
 
     snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
     meta = snapshot["ingest_meta"]["USDJPY_5m"]


### PR DESCRIPTION
## Summary
- route API ingest completion through `_finalize_ingest_result` to unify logging and metadata persistence
- remove bespoke handling for API empty results and rely on the shared helper messaging
- expand API ingest regression tests to assert summary logging for success and fallback flows

## Testing
- python3 -m pytest tests/test_run_daily_workflow.py

## 概要 (日本語)
- API インジェスト完了処理を `_finalize_ingest_result` に統合し、ログとメタデータの共通フローへ揃えました。
- API 空結果時の分岐を整理し、成功/フォールバック双方のログ整合テストを追加しました。


------
https://chatgpt.com/codex/tasks/task_e_68e0d5484e8c832a83d033bd42ff09e4