### PR TITLE
Refactor pending signal field extraction

### DIFF
--- a/core/runner.py
+++ b/core/runner.py
@@ -465,6 +465,20 @@ class BacktestRunner:
             return allowed, reason
         return allowed, None
 
+    @staticmethod
+    def _extract_pending_fields(
+        pending: Any,
+    ) -> Tuple[Optional[str], Optional[float], Optional[float]]:
+        if isinstance(pending, Mapping):
+            pending_side = pending.get("side")
+            tp_pips = pending.get("tp_pips")
+            sl_pips = pending.get("sl_pips")
+        else:
+            pending_side = getattr(pending, "side", None)
+            tp_pips = getattr(pending, "tp_pips", None)
+            sl_pips = getattr(pending, "sl_pips", None)
+        return pending_side, tp_pips, sl_pips
+
     def _call_ev_threshold(
         self,
         ctx_dbg: Dict[str, Any],
@@ -1053,10 +1067,7 @@ class BacktestRunner:
         features: FeatureBundle,
     ) -> Optional[Dict[str, Any]]:
         ctx_dbg = dict(features.ctx)
-        if isinstance(pending, Mapping):
-            pending_side = pending.get("side")
-        else:
-            pending_side = getattr(pending, "side", None)
+        pending_side, _, _ = self._extract_pending_fields(pending)
         gate_allowed, gate_reason = self._call_strategy_gate(
             ctx_dbg,
             pending,
@@ -1110,14 +1121,7 @@ class BacktestRunner:
         calibrating: bool,
         timestamp: Optional[str],
     ) -> Optional[Tuple[Any, float, float, bool]]:
-        if isinstance(pending, Mapping):
-            pending_side = pending.get("side")
-            tp_pips = pending.get("tp_pips")
-            sl_pips = pending.get("sl_pips")
-        else:
-            pending_side = getattr(pending, "side", None)
-            tp_pips = getattr(pending, "tp_pips", None)
-            sl_pips = getattr(pending, "sl_pips", None)
+        pending_side, tp_pips, sl_pips = self._extract_pending_fields(pending)
         ev_key = ctx_dbg.get(
             "ev_key",
             (
@@ -1180,14 +1184,7 @@ class BacktestRunner:
         ev_bypass: bool,
         timestamp: Optional[str],
     ) -> bool:
-        if isinstance(pending, Mapping):
-            pending_side = pending.get("side")
-            tp_pips = pending.get("tp_pips")
-            sl_pips = pending.get("sl_pips")
-        else:
-            pending_side = getattr(pending, "side", None)
-            tp_pips = getattr(pending, "tp_pips", None)
-            sl_pips = getattr(pending, "sl_pips", None)
+        pending_side, tp_pips, sl_pips = self._extract_pending_fields(pending)
         slip_cap = ctx_dbg.get("slip_cap_pip", self.rcfg.slip_cap_pip)
         expected_slip = ctx_dbg.get("expected_slip_pip", 0.0)
         if expected_slip > slip_cap:

--- a/state.md
+++ b/state.md
@@ -2,6 +2,7 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
+- 2026-01-01: `core/runner._extract_pending_fields` ヘルパーを追加して pending シグナルの `side`/`tp_pips`/`sl_pips` 抽出を一元化し、`_evaluate_entry_conditions`・`_evaluate_ev_threshold`・`_check_slip_and_sizing` から重複分岐を排除。`python3 -m pytest tests/test_runner.py` を実行して 17 件パスを再確認。
 - 2025-12-31: `core/runner._compute_features` を `FeatureBundle` へ拡張し、`_maybe_enter_trade` 系のヘルパーが事前組立てコンテキストを共有するようリファクタ。`tests/test_runner.py` に校正モード閾値/期待スリップの単体テストを追加し、`python3 -m pytest` を実行して 151 件パスを確認。
 - 2025-12-30: `_run_api_ingest` を `_finalize_ingest_result` へ統合し、API 成功/フォールバック時のログ整合性を検証するテストを更新。`python3 -m pytest tests/test_run_daily_workflow.py` を実行して 32 件パスを確認。
 - 2025-12-29: `core/feature_store.py` に型ヒントを追加し、NaN ガードをコメント付きで整理。`python3 -m pytest tests/test_runner.py` を実行して 16 件パスを再確認。


### PR DESCRIPTION
## Summary
- add a BacktestRunner helper to extract pending signal side/take-profit/stop-loss data consistently
- refactor entry, EV threshold, and slip sizing checks to rely on the helper so logging semantics stay identical
- update state.md with the refactor and regression test run

## Testing
- python3 -m pytest tests/test_runner.py

------
https://chatgpt.com/codex/tasks/task_e_68e0dd41b8fc832ab7d57de7bd132f1c