### PR TITLE
Refactor sizing helper usage across strategies

### DIFF
--- a/core/runner.py
+++ b/core/runner.py
@@ -22,7 +22,7 @@ from core.feature_store import atr as calc_atr, adx as calc_adx, opening_range, 
 from core.fill_engine import ConservativeFill, BridgeFill, OrderSpec
 from core.ev_gate import BetaBinomialEV, TLowerEV
 from core.pips import pip_size, price_to_pips
-from core.sizing import SizingConfig, base_units, kelly_multiplier_oco, apply_guards
+from core.sizing import compute_qty_from_ctx
 from router.router_v0 import pass_gates
 
 
@@ -1199,32 +1199,15 @@ class BacktestRunner:
             )
             return False
         if not ev_bypass and not calibrating and tp_pips is not None and sl_pips is not None:
-            sizing_cfg_data = ctx_dbg.get("sizing_cfg")
-            sizing_cfg = SizingConfig()
-            if isinstance(sizing_cfg_data, Mapping):
-                risk_pct = sizing_cfg_data.get("risk_per_trade_pct")
-                if risk_pct is not None:
-                    sizing_cfg.risk_per_trade_pct = float(risk_pct)
-                kelly_fraction = sizing_cfg_data.get("kelly_fraction")
-                if kelly_fraction is not None:
-                    sizing_cfg.kelly_fraction = float(kelly_fraction)
-                units_cap = sizing_cfg_data.get("units_cap")
-                if units_cap is not None:
-                    sizing_cfg.units_cap = float(units_cap)
-                max_trade_loss_pct = sizing_cfg_data.get("max_trade_loss_pct")
-                if max_trade_loss_pct is not None:
-                    sizing_cfg.max_trade_loss_pct = float(max_trade_loss_pct)
-            pip_value_raw = ctx_dbg.get("pip_value", 0.0)
-            try:
-                pip_value = float(pip_value_raw)
-            except (TypeError, ValueError):
-                pip_value = 0.0
-            tp_val = float(tp_pips)
-            sl_val = float(sl_pips)
-            p_lcb = ev_mgr.p_lcb()
-            base = base_units(self.equity, pip_value, sl_val, sizing_cfg)
-            mult = kelly_multiplier_oco(p_lcb, tp_val, sl_val, sizing_cfg)
-            qty_dbg = apply_guards(base * mult, self.equity, pip_value, sl_val, sizing_cfg)
+            ctx_for_sizing: Dict[str, Any] = dict(ctx_dbg)
+            ctx_for_sizing.setdefault("equity", self.equity)
+            qty_dbg = compute_qty_from_ctx(
+                ctx_for_sizing,
+                float(sl_pips),
+                mode="production",
+                tp_pips=float(tp_pips),
+                p_lcb=ev_mgr.p_lcb(),
+            )
             if qty_dbg <= 0:
                 self.debug_counts["zero_qty"] += 1
                 return False

--- a/core/sizing.py
+++ b/core/sizing.py
@@ -2,7 +2,10 @@
 Position sizing: fractional Kelly (safe) + guard rails
 """
 from __future__ import annotations
+
 from dataclasses import dataclass
+from typing import Any, Literal, Mapping, Optional
+
 
 @dataclass
 class SizingConfig:
@@ -11,16 +14,110 @@ class SizingConfig:
     units_cap: float = 5.0
     max_trade_loss_pct: float = 0.5
 
+
 def base_units(equity: float, pip_value: float, sl_pips: float, cfg: SizingConfig) -> float:
-    risk_amt = equity * (cfg.risk_per_trade_pct/100.0)
-    return max(0.0, risk_amt / max(pip_value*sl_pips, 1e-9))
+    risk_amt = equity * (cfg.risk_per_trade_pct / 100.0)
+    return max(0.0, risk_amt / max(pip_value * sl_pips, 1e-9))
+
 
 def kelly_multiplier_oco(p_lcb: float, tp_pips: float, sl_pips: float, cfg: SizingConfig) -> float:
     b = tp_pips / max(sl_pips, 1e-9)
-    f_star = max(0.0, p_lcb - (1.0 - p_lcb)/b)
+    f_star = max(0.0, p_lcb - (1.0 - p_lcb) / b)
     return min(cfg.units_cap, cfg.kelly_fraction * f_star)
+
 
 def apply_guards(units: float, equity: float, pip_value: float, sl_pips: float, cfg: SizingConfig) -> float:
     # Ensure 1-trade loss <= max_trade_loss_pct
-    max_units = (equity * (cfg.max_trade_loss_pct/100.0)) / max(pip_value*sl_pips, 1e-9)
+    max_units = (equity * (cfg.max_trade_loss_pct / 100.0)) / max(pip_value * sl_pips, 1e-9)
     return max(0.0, min(units, max_units, cfg.units_cap))
+
+
+def _extract_sizing_config(ctx: Mapping[str, Any]) -> SizingConfig:
+    cfg = SizingConfig()
+    data = ctx.get("sizing_cfg")
+    if isinstance(data, Mapping):
+        risk_pct = data.get("risk_per_trade_pct")
+        if risk_pct is not None:
+            try:
+                cfg.risk_per_trade_pct = float(risk_pct)
+            except (TypeError, ValueError):
+                pass
+        kelly_fraction = data.get("kelly_fraction")
+        if kelly_fraction is not None:
+            try:
+                cfg.kelly_fraction = float(kelly_fraction)
+            except (TypeError, ValueError):
+                pass
+        units_cap = data.get("units_cap")
+        if units_cap is not None:
+            try:
+                cfg.units_cap = float(units_cap)
+            except (TypeError, ValueError):
+                pass
+        max_trade_loss_pct = data.get("max_trade_loss_pct")
+        if max_trade_loss_pct is not None:
+            try:
+                cfg.max_trade_loss_pct = float(max_trade_loss_pct)
+            except (TypeError, ValueError):
+                pass
+    return cfg
+
+
+def _to_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def compute_qty_from_ctx(
+    ctx: Mapping[str, Any],
+    sl_pips: float,
+    *,
+    mode: Literal["calibration", "warmup", "production"],
+    tp_pips: Optional[float] = None,
+    p_lcb: Optional[float] = None,
+    multiplier: Optional[float] = None,
+) -> float:
+    """Derive guarded position size using ``ctx`` sizing configuration.
+
+    Parameters
+    ----------
+    ctx:
+        Strategy/runner context containing equity, pip value, and sizing_cfg.
+    sl_pips:
+        Stop-loss distance in pips for the signal.
+    mode:
+        Controls how quantity is derived:
+        - ``"calibration"`` returns the unit qty (or size floor when EV is disabled).
+        - ``"warmup"`` applies the warmup multiplier from ``ctx``.
+        - ``"production"`` applies Kelly sizing using ``p_lcb`` and ``tp_pips``.
+    tp_pips / p_lcb:
+        Required when ``mode == "production"`` to derive Kelly multiplier.
+    multiplier:
+        Optional explicit multiplier override (for warmup/calibration floor).
+    """
+
+    cfg = _extract_sizing_config(ctx)
+    equity = _to_float(ctx.get("equity"))
+    pip_value = _to_float(ctx.get("pip_value"))
+    sl_val = _to_float(sl_pips)
+    base = base_units(equity, pip_value, sl_val, cfg)
+
+    if mode == "calibration":
+        if str(ctx.get("ev_mode")) == "off":
+            mult = multiplier if multiplier is not None else _to_float(ctx.get("size_floor_mult"), 0.01)
+            return apply_guards(base * max(0.0, mult), equity, pip_value, sl_val, cfg)
+        return 1.0
+
+    if mode == "warmup":
+        mult = multiplier if multiplier is not None else _to_float(ctx.get("warmup_mult"), 0.05)
+        return apply_guards(base * max(0.0, mult), equity, pip_value, sl_val, cfg)
+
+    if mode == "production":
+        tp_val = _to_float(tp_pips)
+        p_val = _to_float(p_lcb)
+        mult = kelly_multiplier_oco(p_val, tp_val, sl_val, cfg)
+        return apply_guards(base * mult, equity, pip_value, sl_val, cfg)
+
+    raise ValueError(f"Unsupported sizing mode: {mode}")

--- a/state.md
+++ b/state.md
@@ -3,6 +3,7 @@
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
 - 2026-01-01: `core/runner._extract_pending_fields` ヘルパーを追加して pending シグナルの `side`/`tp_pips`/`sl_pips` 抽出を一元化し、`_evaluate_entry_conditions`・`_evaluate_ev_threshold`・`_check_slip_and_sizing` から重複分岐を排除。`python3 -m pytest tests/test_runner.py` を実行して 17 件パスを再確認。
+- 2026-01-02: `core/sizing.compute_qty_from_ctx` を新設して校正/ウォームアップ/本番サイズ算出を共通化し、Day ORB・Mean Reversion 戦略とランナーの重複ロジックを移行。関連テスト (`tests/test_runner.py`, `tests/test_run_sim_cli.py` など) を更新して数量一致を検証し、`python3 -m pytest` を完走。
 - 2025-12-31: `core/runner._compute_features` を `FeatureBundle` へ拡張し、`_maybe_enter_trade` 系のヘルパーが事前組立てコンテキストを共有するようリファクタ。`tests/test_runner.py` に校正モード閾値/期待スリップの単体テストを追加し、`python3 -m pytest` を実行して 151 件パスを確認。
 - 2025-12-30: `_run_api_ingest` を `_finalize_ingest_result` へ統合し、API 成功/フォールバック時のログ整合性を検証するテストを更新。`python3 -m pytest tests/test_run_daily_workflow.py` を実行して 32 件パスを確認。
 - 2025-12-29: `core/feature_store.py` に型ヒントを追加し、NaN ガードをコメント付きで整理。`python3 -m pytest tests/test_runner.py` を実行して 16 件パスを再確認。

--- a/strategies/mean_reversion.py
+++ b/strategies/mean_reversion.py
@@ -5,12 +5,7 @@ import math
 from typing import Any, Dict, Iterable, List, Optional
 
 from core.pips import pip_size
-from core.sizing import (
-    SizingConfig,
-    apply_guards,
-    base_units,
-    kelly_multiplier_oco,
-)
+from core.sizing import compute_qty_from_ctx
 from core.strategy_api import OrderIntent, Strategy
 from router.router_v0 import pass_gates
 
@@ -162,21 +157,9 @@ class MeanReversionStrategy(Strategy):
             return []
 
         if ctx.get("calibrating") or ctx.get("ev_mode") == "off":
-            qty = 1.0
-            if ctx.get("ev_mode") == "off":
-                equity = float(ctx.get("equity", 0.0))
-                pip_value = float(ctx.get("pip_value", 0.0))
-                sizing_cfg_dict = ctx.get("sizing_cfg", {})
-                sz_cfg = SizingConfig(
-                    risk_per_trade_pct=sizing_cfg_dict.get("risk_per_trade_pct", 0.25),
-                    kelly_fraction=sizing_cfg_dict.get("kelly_fraction", 0.25),
-                    units_cap=sizing_cfg_dict.get("units_cap", 5.0),
-                    max_trade_loss_pct=sizing_cfg_dict.get("max_trade_loss_pct", 0.5),
-                )
-                base = base_units(equity, pip_value, sig["sl_pips"], sz_cfg)
-                qty = apply_guards(base * float(ctx.get("size_floor_mult", 0.01)), equity, pip_value, sig["sl_pips"], sz_cfg)
-                if qty <= 0:
-                    return []
+            qty = compute_qty_from_ctx(ctx, sig["sl_pips"], mode="calibration")
+            if ctx.get("ev_mode") == "off" and qty <= 0:
+                return []
             tag = f"mean_reversion#{sig['side']}#calib"
             self.state["last_signal_bar"] = self.state["bar_idx"]
             return [
@@ -192,18 +175,7 @@ class MeanReversionStrategy(Strategy):
 
         warmup_left = int(ctx.get("warmup_left", 0))
         if warmup_left > 0:
-            equity = float(ctx.get("equity", 0.0))
-            pip_value = float(ctx.get("pip_value", 0.0))
-            sizing_cfg_dict = ctx.get("sizing_cfg", {})
-            sz_cfg = SizingConfig(
-                risk_per_trade_pct=sizing_cfg_dict.get("risk_per_trade_pct", 0.25),
-                kelly_fraction=sizing_cfg_dict.get("kelly_fraction", 0.25),
-                units_cap=sizing_cfg_dict.get("units_cap", 5.0),
-                max_trade_loss_pct=sizing_cfg_dict.get("max_trade_loss_pct", 0.5),
-            )
-            base = base_units(equity, pip_value, sig["sl_pips"], sz_cfg)
-            warm_mult = float(ctx.get("warmup_mult", 0.05))
-            qty = apply_guards(base * max(0.0, warm_mult), equity, pip_value, sig["sl_pips"], sz_cfg)
+            qty = compute_qty_from_ctx(ctx, sig["sl_pips"], mode="warmup")
             if qty <= 0:
                 return []
             tag = f"mean_reversion#{sig['side']}#warmup"
@@ -223,18 +195,13 @@ class MeanReversionStrategy(Strategy):
         if ev is None:
             return []
         p_lcb = ev.p_lcb()
-        equity = float(ctx.get("equity", 0.0))
-        pip_value = float(ctx.get("pip_value", 0.0))
-        sizing_cfg_dict = ctx.get("sizing_cfg", {})
-        sz_cfg = SizingConfig(
-            risk_per_trade_pct=sizing_cfg_dict.get("risk_per_trade_pct", 0.25),
-            kelly_fraction=sizing_cfg_dict.get("kelly_fraction", 0.25),
-            units_cap=sizing_cfg_dict.get("units_cap", 5.0),
-            max_trade_loss_pct=sizing_cfg_dict.get("max_trade_loss_pct", 0.5),
+        qty = compute_qty_from_ctx(
+            ctx,
+            sig["sl_pips"],
+            mode="production",
+            tp_pips=sig["tp_pips"],
+            p_lcb=p_lcb,
         )
-        base = base_units(equity, pip_value, sig["sl_pips"], sz_cfg)
-        mult = kelly_multiplier_oco(p_lcb, sig["tp_pips"], sig["sl_pips"], sz_cfg)
-        qty = apply_guards(base * mult, equity, pip_value, sig["sl_pips"], sz_cfg)
         if qty <= 0:
             return []
 

--- a/tests/test_mean_reversion_strategy.py
+++ b/tests/test_mean_reversion_strategy.py
@@ -1,5 +1,6 @@
 import unittest
 
+from core.sizing import compute_qty_from_ctx
 from strategies.mean_reversion import MeanReversionStrategy
 
 
@@ -61,6 +62,15 @@ class MeanReversionStrategyTest(unittest.TestCase):
         self.assertGreater(intent.oco["tp_pips"], 0.0)
         self.assertGreater(intent.oco["sl_pips"], intent.oco["tp_pips"])
         self.assertEqual(self.strategy.state["last_signal_bar"], self.strategy.state["bar_idx"])
+
+        expected_qty = compute_qty_from_ctx(
+            ctx,
+            intent.oco["sl_pips"],
+            mode="production",
+            tp_pips=intent.oco["tp_pips"],
+            p_lcb=ctx["ev_oco"].p_lcb(),
+        )
+        self.assertAlmostEqual(intent.qty, expected_qty)
 
     def test_strategy_gate_blocks_high_rv_and_adx(self) -> None:
         bar = {"c": 150.0, "atr14": 0.15, "zscore": -2.0}


### PR DESCRIPTION
## Summary
- add `compute_qty_from_ctx` helper to core sizing utilities and reuse it for calibration, warmup, and production flows
- update Day ORB and Mean Reversion strategies plus the runner to rely on the new helper and remove duplicated sizing code
- extend strategy and runner test suites to assert quantities computed via the helper and validate CLI manifest coverage

## Testing
- python3 -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0e2b71348832aa98946ef09082d7f