### PR TITLE
Fix router category cap fallback for zero manifest override

### DIFF
--- a/router/router_v1.py
+++ b/router/router_v1.py
@@ -55,7 +55,9 @@ def _band_allowed(allowed: Iterable[str], value: Optional[str]) -> bool:
 def _check_category_cap(manifest: StrategyManifest, portfolio: PortfolioState) -> Optional[str]:
     category = manifest.category
     usage = float(portfolio.category_utilisation_pct.get(category, 0.0))
-    cap = manifest.router.category_cap_pct or portfolio.category_caps_pct.get(category)
+    cap = manifest.router.category_cap_pct
+    if cap is None:
+        cap = portfolio.category_caps_pct.get(category)
     if cap is None:
         return None
     if usage >= cap:

--- a/state.md
+++ b/state.md
@@ -2,6 +2,7 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
+- 2026-01-05: `router/router_v1._check_category_cap` で `category_cap_pct` が `None` の場合のみポートフォリオ定義の上限へフォールバックするよう修正し、`category_cap_pct=0.0` を尊重する回帰テストを追加。`python3 -m pytest tests/test_router_v1.py` を実行して 4 件パスを確認。
 - 2026-01-04: `core/runner._build_ctx` で `pip_value_override` / `base_notional` の float キャストに失敗した場合でも 10.0 へフォールバックするよう調整し、数値文字列を許容するテストを追加。`python3 -m pytest tests/test_runner.py` を実行して 20 件パスを確認。
 - 2026-01-03: `RunnerConfig.build_sizing_cfg` で `risk_per_trade_pct` を `float(...)` キャスト後に >0 判定するよう更新し、`_build_ctx` がヘルパー経由のサイジング設定を利用するよう整備。`tests/test_runner.py` に文字列入力を許容する回帰テストを追加し、`python3 -m pytest tests/test_runner.py` を実行して 18 件パスを再確認。
 - 2026-01-01: `core/runner._extract_pending_fields` ヘルパーを追加して pending シグナルの `side`/`tp_pips`/`sl_pips` 抽出を一元化し、`_evaluate_entry_conditions`・`_evaluate_ev_threshold`・`_check_slip_and_sizing` から重複分岐を排除。`python3 -m pytest tests/test_runner.py` を実行して 17 件パスを再確認。

--- a/tests/test_router_v1.py
+++ b/tests/test_router_v1.py
@@ -38,6 +38,19 @@ def test_category_cap_and_concurrency():
     assert "active positions" in reasons
 
 
+def test_manifest_category_cap_zero_blocks_positive_usage():
+    manifest = load_day_manifest()
+    manifest.router.category_cap_pct = 0.0
+    portfolio = PortfolioState(
+        category_utilisation_pct={manifest.category: 5.0},
+        category_caps_pct={manifest.category: 40.0},
+    )
+    ctx = {"session": "LDN", "spread_band": "narrow", "rv_band": "high"}
+    res = select_candidates(ctx, [manifest], portfolio=portfolio)
+    assert res[0].eligible is False
+    assert any("category utilisation" in reason for reason in res[0].reasons)
+
+
 def test_scoring_sorting():
     manifest = load_day_manifest()
     ctx = {"session": "LDN", "spread_band": "narrow", "rv_band": "mid"}


### PR DESCRIPTION
## Summary
- ensure `router_v1` respects manifest-level category caps even when set to zero instead of falling back to portfolio defaults
- add a regression test that excludes candidates when usage exceeds a zero manifest cap
- record the router update and test execution in `state.md` per the workflow log

## Testing
- python3 -m pytest tests/test_router_v1.py

## JP Summary
- ルーターのカテゴリ上限が 0.0 指定時にポートフォリオ上限へ戻らないよう修正し、回帰テストと state.md のログを更新しました。


------
https://chatgpt.com/codex/tasks/task_e_68e0f191d644832a8c5beafdc3548a3c