### PR TITLE
Ensure run_daily_workflow subprocess executions run from repo root

### DIFF
--- a/scripts/run_daily_workflow.py
+++ b/scripts/run_daily_workflow.py
@@ -1024,9 +1024,9 @@ def _run_api_ingest(
         empty_message="[wf] API ingestion produced no result",
     )
 
-def run_cmd(cmd):
+def run_cmd(cmd, *, cwd: Path = ROOT):
     print(f"[wf] running: {' '.join(cmd)}")
-    result = subprocess.run(cmd, check=False)
+    result = subprocess.run(cmd, check=False, cwd=cwd)
     if result.returncode != 0:
         print(f"[wf] command failed with exit code {result.returncode}")
     return result.returncode

--- a/state.md
+++ b/state.md
@@ -2,6 +2,7 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
+- 2026-01-10: `scripts/run_daily_workflow.run_cmd` に `cwd=ROOT` 既定を追加し、`tests/test_run_daily_workflow.py::test_run_cmd_executes_with_repo_root` でサブプロセスがリポジトリ直下から起動されることを検証。`python3 -m pytest tests/test_run_daily_workflow.py` を実行して 35 件パスを再確認。
 - 2026-01-09: Day ORB 5m strategy updated so calibration/warmup signals stamp `last_signal_bar` and mark sessions as broken, preventing immediate re-entries. Added regression tests ensuring warmup cooldown is honored, and ran `python3 -m pytest tests/test_runner.py` to verify 23 passing cases.
 - 2026-01-07: `scripts/run_daily_workflow._build_pull_prices_cmd` をシンボル固有の既定 CSV に合わせて修正し、`tests/test_run_daily_workflow.py::test_ingest_pull_prices_uses_symbol_specific_source` を追加。`python3 -m pytest` を実行したところ、`tests/test_fetch_prices_api.py` がサンドボックスのソケット制限でローカル HTTP サーバをバインドできず 8 件エラーとなった（他テストはパス）。
 - 2026-01-06: `core/runner._extract_pending_fields` で `.oco` からの TP/SL も float へ正規化して抽出し、`tests/test_runner.py` に OrderIntent の `.oco` 参照のみで EV リジェクト/サイジングガードが動作する回帰テストを追加。`python3 -m pytest tests/test_runner.py` を実行し 21 件パスを確認。

--- a/tests/test_run_daily_workflow.py
+++ b/tests/test_run_daily_workflow.py
@@ -28,6 +28,25 @@ def _capture_run_cmd(monkeypatch):
     return captured
 
 
+def test_run_cmd_executes_with_repo_root(monkeypatch):
+    called = {}
+
+    def fake_run(cmd, *, check, cwd):
+        called["cmd"] = cmd
+        called["check"] = check
+        called["cwd"] = cwd
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(run_daily_workflow.subprocess, "run", fake_run)
+
+    exit_code = run_daily_workflow.run_cmd(["echo", "hello"])
+
+    assert exit_code == 0
+    assert called["cmd"] == ["echo", "hello"]
+    assert called["check"] is False
+    assert called["cwd"] == run_daily_workflow.ROOT
+
+
 def _assert_path_arg(cmd, flag, expected_path):
     value = cmd[cmd.index(flag) + 1]
     assert Path(value) == Path(expected_path)


### PR DESCRIPTION
## Summary
- default `run_daily_workflow.run_cmd` to execute commands from the repository root
- add a regression test that mocks `subprocess.run` to assert the cwd is set to `ROOT`
- record the workflow update in `state.md`

## Testing
- python3 -m pytest tests/test_run_daily_workflow.py

------
https://chatgpt.com/codex/tasks/task_e_68e1a59d50ec832aa2716f07d1af38b6