### PR TITLE
Align yfinance ingest start with shared helper

### DIFF
--- a/scripts/run_daily_workflow.py
+++ b/scripts/run_daily_workflow.py
@@ -903,8 +903,11 @@ def _run_yfinance_ingest(
             f"yfinance module unavailable: {exc}",
         )
     else:
-        lookback = max(5, args.yfinance_lookback_minutes)
-        start = last_ts - timedelta(minutes=lookback) if last_ts else now - timedelta(minutes=lookback)
+        start = _compute_yfinance_fallback_start(
+            last_ts=last_ts,
+            lookback_minutes=args.yfinance_lookback_minutes,
+            now=now,
+        )
 
         fetch_symbol = resolve_ticker(ctx.symbol)
         print(

--- a/state.md
+++ b/state.md
@@ -2,6 +2,7 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
+- 2026-01-11: `_run_yfinance_ingest` を `compute_yfinance_fallback_start` で共通化し、`last_ts` 欠損/陳腐化時のルックバックをヘルパーと同じクランプに合わせるテストを追加。`python3 -m pytest tests/test_run_daily_workflow.py` を実行して 37 件パスを確認。
 - 2026-01-10: `scripts/run_daily_workflow.run_cmd` に `cwd=ROOT` 既定を追加し、`tests/test_run_daily_workflow.py::test_run_cmd_executes_with_repo_root` でサブプロセスがリポジトリ直下から起動されることを検証。`python3 -m pytest tests/test_run_daily_workflow.py` を実行して 35 件パスを再確認。
 - 2026-01-09: Day ORB 5m strategy updated so calibration/warmup signals stamp `last_signal_bar` and mark sessions as broken, preventing immediate re-entries. Added regression tests ensuring warmup cooldown is honored, and ran `python3 -m pytest tests/test_runner.py` to verify 23 passing cases.
 - 2026-01-07: `scripts/run_daily_workflow._build_pull_prices_cmd` をシンボル固有の既定 CSV に合わせて修正し、`tests/test_run_daily_workflow.py::test_ingest_pull_prices_uses_symbol_specific_source` を追加。`python3 -m pytest` を実行したところ、`tests/test_fetch_prices_api.py` がサンドボックスのソケット制限でローカル HTTP サーバをバインドできず 8 件エラーとなった（他テストはパス）。


### PR DESCRIPTION
## Summary
- replace manual yfinance lookback math with the shared compute_yfinance_fallback_start helper
- log the helper-derived start timestamp when invoking the yfinance ingest path
- cover missing and stale last_ts scenarios with regression tests for the yfinance start window

## Testing
- python3 -m pytest tests/test_run_daily_workflow.py

## 概要
- yfinance インジェスト開始時刻の算出をヘルパーに統一し、ログと回帰テストを更新しました。


------
https://chatgpt.com/codex/tasks/task_e_68e1a7fdade0832ab6263d5cbfd794f2