### PR TITLE
Add shared path normalization helper to EV vs PnL CLI

### DIFF
--- a/state.md
+++ b/state.md
@@ -2,6 +2,7 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
+- 2026-01-12: `scripts/ev_vs_actual_pnl._normalize_path` を新設して CLI/保存系の引数正規化を共通化し、`tests/test_ev_vs_actual_pnl.py` で Path 展開ヘルパー共有をモック検証。`python3 -m pytest tests/test_ev_vs_actual_pnl.py` を実行して 1 件パスを確認。
 - 2026-01-11: `_run_yfinance_ingest` を `compute_yfinance_fallback_start` で共通化し、`last_ts` 欠損/陳腐化時のルックバックをヘルパーと同じクランプに合わせるテストを追加。`python3 -m pytest tests/test_run_daily_workflow.py` を実行して 37 件パスを確認。
 - 2026-01-10: `scripts/run_daily_workflow.run_cmd` に `cwd=ROOT` 既定を追加し、`tests/test_run_daily_workflow.py::test_run_cmd_executes_with_repo_root` でサブプロセスがリポジトリ直下から起動されることを検証。`python3 -m pytest tests/test_run_daily_workflow.py` を実行して 35 件パスを再確認。
 - 2026-01-09: Day ORB 5m strategy updated so calibration/warmup signals stamp `last_signal_bar` and mark sessions as broken, preventing immediate re-entries. Added regression tests ensuring warmup cooldown is honored, and ran `python3 -m pytest tests/test_runner.py` to verify 23 passing cases.

--- a/tests/test_ev_vs_actual_pnl.py
+++ b/tests/test_ev_vs_actual_pnl.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import sys
+import types
+from datetime import datetime
+from pathlib import Path
+
+
+class _DummyFrame:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def to_dict(self, *args, **kwargs):
+        return {}
+
+    def to_csv(self, *args, **kwargs):
+        return None
+
+
+pd_stub = types.ModuleType("pandas")
+pd_stub.DataFrame = _DummyFrame
+pd_stub.Series = _DummyFrame
+pd_stub.Timestamp = datetime
+pd_stub.read_csv = lambda *args, **kwargs: _DummyFrame()
+pd_stub.to_datetime = lambda *args, **kwargs: None
+pd_stub.concat = lambda *args, **kwargs: _DummyFrame()
+pd_stub.isna = lambda value: value is None
+
+sys.modules.setdefault("pandas", pd_stub)
+
+import scripts.ev_vs_actual_pnl as module
+
+
+def test_entrypoints_use_shared_normalizer(monkeypatch):
+    expand_calls = []
+
+    def fake_expanduser(self):
+        expand_calls.append(("expanduser", self))
+        return self
+
+    def fake_resolve(self):
+        expand_calls.append(("resolve", self))
+        return self
+
+    monkeypatch.setattr(Path, "expanduser", fake_expanduser, raising=False)
+    monkeypatch.setattr(Path, "resolve", fake_resolve, raising=False)
+
+    original_normalize = module._normalize_path
+    normalized_inputs = []
+
+    def spy_normalize(value):
+        normalized_inputs.append(value)
+        return original_normalize(value)
+
+    monkeypatch.setattr(module, "_normalize_path", spy_normalize)
+
+    dummy_record = Path("/runs/dummy/records.csv")
+    collect_inputs = []
+
+    def fake_collect(runs_dir):
+        collect_inputs.append(runs_dir)
+        return [dummy_record]
+
+    monkeypatch.setattr(module, "_collect_record_paths", fake_collect)
+    monkeypatch.setattr(module, "_select_run", lambda paths, run_id: dummy_record)
+    monkeypatch.setattr(module, "process_single_run", lambda *a, **k: {"run_id": "dummy"})
+    monkeypatch.setattr(module, "_store_single_run", lambda *a, **k: None)
+    monkeypatch.setattr(module, "process_all_runs", lambda *a, **k: {"runs": []})
+    monkeypatch.setattr(module, "_store_all_runs", lambda *a, **k: None)
+
+    module.store_run_summary("~/.runs", None, "~/out", store_daily=False)
+    module.store_all_runs("~/.runs", "~/out")
+
+    args = types.SimpleNamespace(
+        runs_dir="~/runs",
+        list_runs=False,
+        all_runs=False,
+        run_id=None,
+        top_n=3,
+        show_daily=False,
+        store_daily=False,
+        store_dir="~/store",
+        quiet=True,
+        output_json=None,
+    )
+
+    monkeypatch.setattr(module, "parse_args", lambda: args)
+
+    module.main()
+
+    assert normalized_inputs == [
+        "~/.runs",
+        "~/out",
+        "~/.runs",
+        "~/out",
+        "~/runs",
+        "~/store",
+        None,
+    ]
+
+    assert len(expand_calls) == 12
+    assert all(isinstance(value, Path) for _, value in expand_calls)
+    assert collect_inputs == [
+        Path("~/.runs"),
+        Path("~/.runs"),
+        Path("~/runs"),
+    ]


### PR DESCRIPTION
## Summary
- add a `_normalize_path` helper to `scripts/ev_vs_actual_pnl.py`
- reuse the helper throughout the CLI entry points to remove duplicated path handling
- add a focused unit test that patches `Path` expansion to confirm the shared helper is used

## Testing
- python3 -m pytest tests/test_ev_vs_actual_pnl.py

------
https://chatgpt.com/codex/tasks/task_e_68e1ab468e40832a956090cff73a352d