### PR TITLE
Add router pipeline builder and surface runtime health metrics

### DIFF
--- a/core/router_pipeline.py
+++ b/core/router_pipeline.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+"""Utilities for assembling router portfolio state from runtime telemetry."""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, Mapping, Optional
+
+from configs.strategies.loader import StrategyManifest
+from router.router_v1 import PortfolioState
+
+
+@dataclass
+class PortfolioTelemetry:
+    """Snapshot of live portfolio data consumed by the router pipeline."""
+
+    active_positions: Dict[str, int] = field(default_factory=dict)
+    category_utilisation_pct: Dict[str, float] = field(default_factory=dict)
+    category_caps_pct: Dict[str, float] = field(default_factory=dict)
+    gross_exposure_pct: Optional[float] = None
+    gross_exposure_cap_pct: Optional[float] = None
+    strategy_correlations: Dict[str, Dict[str, float]] = field(default_factory=dict)
+    execution_health: Dict[str, Dict[str, float]] = field(default_factory=dict)
+
+
+def _to_float(value: Any) -> Optional[float]:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def build_portfolio_state(
+    manifests: Iterable[StrategyManifest],
+    *,
+    telemetry: Optional[PortfolioTelemetry] = None,
+    runtime_metrics: Optional[Mapping[str, Mapping[str, Any]]] = None,
+) -> PortfolioState:
+    """Construct a :class:`PortfolioState` from manifests and live telemetry.
+
+    Parameters
+    ----------
+    manifests:
+        Strategy manifests that contribute to the portfolio. The function will
+        use their risk metadata to infer utilisation and category limits when
+        explicit telemetry is missing.
+    telemetry:
+        Optional snapshot populated with live counts (active positions,
+        category utilisation, correlation matrices, etc.).
+    runtime_metrics:
+        Optional mapping keyed by manifest ID with runtime exports from
+        :class:`core.runner.BacktestRunner`. When provided the execution
+        health block is merged so the router can gate on reject rates and
+        slippage guards.
+    """
+
+    snapshot = telemetry or PortfolioTelemetry()
+    manifest_list = list(manifests)
+
+    active_positions: Dict[str, int] = {
+        str(key): int(value) for key, value in snapshot.active_positions.items()
+    }
+    category_usage: Dict[str, float] = {
+        str(key): float(value) for key, value in snapshot.category_utilisation_pct.items()
+    }
+    category_caps: Dict[str, float] = {
+        str(key): float(value) for key, value in snapshot.category_caps_pct.items()
+    }
+    correlations: Dict[str, Dict[str, float]] = {
+        str(key): {str(inner_k): float(inner_v) for inner_k, inner_v in value.items()}
+        for key, value in snapshot.strategy_correlations.items()
+    }
+    execution_health: Dict[str, Dict[str, float]] = {
+        str(key): {str(inner_k): float(inner_v) for inner_k, inner_v in value.items()}
+        for key, value in snapshot.execution_health.items()
+    }
+
+    exposures: Dict[str, float] = {}
+    for manifest in manifest_list:
+        active = active_positions.get(manifest.id, 0)
+        if active > 0:
+            exposure = active * float(manifest.risk.risk_per_trade_pct)
+            exposures[manifest.id] = exposures.get(manifest.id, 0.0) + exposure
+            category_usage[manifest.category] = (
+                category_usage.get(manifest.category, 0.0) + exposure
+            )
+        cap_value = manifest.router.category_cap_pct
+        if cap_value is not None:
+            cap_float = float(cap_value)
+            prev_cap = category_caps.get(manifest.category)
+            category_caps[manifest.category] = (
+                cap_float if prev_cap is None else min(prev_cap, cap_float)
+            )
+
+    gross_exposure_pct = snapshot.gross_exposure_pct
+    if gross_exposure_pct is None and exposures:
+        gross_exposure_pct = sum(exposures.values())
+
+    gross_cap_pct = snapshot.gross_exposure_cap_pct
+    if gross_cap_pct is None:
+        gross_caps = [
+            _to_float(manifest.router.max_gross_exposure_pct)
+            for manifest in manifest_list
+            if manifest.router.max_gross_exposure_pct is not None
+        ]
+        gross_caps = [cap for cap in gross_caps if cap is not None]
+        if gross_caps:
+            gross_cap_pct = min(gross_caps)
+
+    if runtime_metrics:
+        for manifest in manifest_list:
+            metrics = runtime_metrics.get(manifest.id)
+            if not metrics:
+                continue
+            health = metrics.get("execution_health")
+            if not isinstance(health, Mapping):
+                continue
+            target = execution_health.get(manifest.id, {}).copy()
+            reject_rate = _to_float(health.get("reject_rate"))
+            if reject_rate is not None:
+                target["reject_rate"] = reject_rate
+            slippage = _to_float(health.get("slippage_bps"))
+            if slippage is not None:
+                target["slippage_bps"] = slippage
+            if target:
+                execution_health[manifest.id] = target
+
+    return PortfolioState(
+        category_utilisation_pct=category_usage,
+        active_positions=active_positions,
+        category_caps_pct=category_caps,
+        gross_exposure_pct=gross_exposure_pct,
+        gross_exposure_cap_pct=gross_cap_pct,
+        strategy_correlations=correlations,
+        execution_health=execution_health,
+    )
+
+
+__all__ = [
+    "PortfolioTelemetry",
+    "build_portfolio_state",
+]

--- a/docs/checklists/p2_router.md
+++ b/docs/checklists/p2_router.md
@@ -1,0 +1,26 @@
+# DoD チェックリスト — P2 ルーター拡張
+
+- タスク名: ルーター拡張 (カテゴリ配分・相関・キャパ/執行ガード)
+- バックログ ID / アンカー: [P2-ルーター拡張](../task_backlog.md#p2-マルチ戦略ポートフォリオ化)
+- 担当: <!-- operator_name -->
+- チェックリスト保存先: docs/checklists/p2_router.md
+
+## Ready 昇格チェック項目
+- [ ] 高レベルのビジョンガイド（例: [docs/logic_overview.md](../logic_overview.md), [docs/simulation_plan.md](../simulation_plan.md)）を再読し、タスク方針が整合している。
+- [ ] 対象フェーズの進捗ノート（例: `docs/progress_phase*.md`）を確認し、前提条件や未解決の検証ギャップがない。
+- [ ] 関連ランブック（例: [docs/state_runbook.md](../state_runbook.md)）を再読し、必要なオペレーション手順が揃っている。
+- [ ] バックログ該当項目の DoD を最新化し、関係者へ共有済みである。
+
+## バックログ固有の DoD
+- [ ] カテゴリ別利用率と上限（category utilisation / caps）を manifest リスク情報とポートフォリオテレメトリから算出し、`PortfolioState` へ反映した。
+- [ ] コリレーションキャップおよびグロスエクスポージャー上限を取り込み、`router_v1` が期待するフィールド（`strategy_correlations`, `gross_exposure_pct`, `gross_exposure_cap_pct`）を欠損なく提供した。
+- [ ] BacktestRunner のランタイム指標から実行ヘルス（`reject_rate`, `slippage_bps`）を集計し、ルーター判定で利用できることを確認した。
+- [ ] 受け入れテスト（`python3 -m pytest tests/test_router_v1.py tests/test_router_pipeline.py`）を実行し、カテゴリ配分／相関ガード／執行ヘルスが期待通りに機能することを証明した。
+
+## 成果物とログ更新
+- [ ] `state.md` の `## Log` へ完了サマリを追記した。
+- [ ] [docs/todo_next.md](../todo_next.md) の該当エントリを Archive へ移動した。
+- [ ] 関連コード/レポート/Notebook のパスを記録した。
+- [ ] レビュー/承認者を記録した。
+
+> Ready 昇格チェックと固有 DoD を満たしたら、`docs/todo_next.md` から本チェックリストへリンクし、進捗を同期してください。

--- a/state.md
+++ b/state.md
@@ -2,6 +2,7 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
+- 2026-01-14: `core/router_pipeline.py` を新設して manifest リスク/ランナー指標から `PortfolioState` を構築し、`scripts/run_sim.py` が manifest 経由起動時に `router_v1.select_candidates` を呼び出すよう更新。`core/runner.Metrics` に runtime 集計（reject_rate / slippage）を追加し、`tests/test_router_pipeline.py` を新設。`python3 -m pytest tests/test_router_v1.py tests/test_router_pipeline.py` を実行して 9 件パスを確認。
 - 2026-01-13: `core/fill_engine._simulate_bar` を新設して Conservative/Bridge の BUY/SELL 共通処理を集約し、Bridge 固有の `p_tp` 付与をフック関数で調整。`tests/test_fill_engine.py` に SELL ケースを追加して同バー・トレール挙動を確認し、`python3 -m pytest tests/test_fill_engine.py` を実行して 7 件グリーンを確認。
 - 2026-01-12: `scripts/ev_vs_actual_pnl._normalize_path` を新設して CLI/保存系の引数正規化を共通化し、`tests/test_ev_vs_actual_pnl.py` で Path 展開ヘルパー共有をモック検証。`python3 -m pytest tests/test_ev_vs_actual_pnl.py` を実行して 1 件パスを確認。
 - 2026-01-11: `_run_yfinance_ingest` を `compute_yfinance_fallback_start` で共通化し、`last_ts` 欠損/陳腐化時のルックバックをヘルパーと同じクランプに合わせるテストを追加。`python3 -m pytest tests/test_run_daily_workflow.py` を実行して 37 件パスを確認。

--- a/tests/test_router_pipeline.py
+++ b/tests/test_router_pipeline.py
@@ -1,0 +1,53 @@
+from core.router_pipeline import PortfolioTelemetry, build_portfolio_state
+from configs.strategies.loader import load_manifest
+from router.router_v1 import select_candidates
+
+
+def test_router_pipeline_merges_limits_and_execution_health():
+    day_manifest = load_manifest("configs/strategies/day_orb_5m.yaml")
+    mean_manifest = load_manifest("configs/strategies/mean_reversion.yaml")
+
+    # Ensure router guards are active for the test scenario.
+    day_manifest.router.category_cap_pct = 40.0
+    mean_manifest.router.category_cap_pct = 40.0
+    mean_manifest.router.max_reject_rate = 0.05
+    mean_manifest.router.max_correlation = 0.6
+    day_manifest.risk.max_concurrent_positions = 3
+    mean_manifest.risk.max_concurrent_positions = 3
+
+    telemetry = PortfolioTelemetry(
+        active_positions={day_manifest.id: 1},
+        category_utilisation_pct={"day": 39.5},
+        category_caps_pct={"day": 42.0},
+        gross_exposure_cap_pct=60.0,
+        strategy_correlations={
+            mean_manifest.id: {day_manifest.id: 0.4},
+        },
+    )
+    runtime_metrics = {
+        day_manifest.id: {"execution_health": {"reject_rate": 0.01, "slippage_bps": 3.0}},
+        mean_manifest.id: {"execution_health": {"reject_rate": 0.09, "slippage_bps": 6.0}},
+    }
+
+    portfolio = build_portfolio_state(
+        [day_manifest, mean_manifest], telemetry=telemetry, runtime_metrics=runtime_metrics
+    )
+
+    # Telemetry + manifest metadata combine to produce utilisation and caps.
+    assert portfolio.category_utilisation_pct["day"] > 39.5
+    assert portfolio.category_caps_pct["day"] == 40.0
+    assert portfolio.active_positions[day_manifest.id] == 1
+    assert portfolio.gross_exposure_pct == day_manifest.risk.risk_per_trade_pct
+    assert portfolio.gross_exposure_cap_pct == 60.0
+
+    # Execution health is merged from BacktestRunner runtime metrics.
+    assert portfolio.execution_health[day_manifest.id]["reject_rate"] == 0.01
+    assert portfolio.execution_health[mean_manifest.id]["reject_rate"] == 0.09
+
+    market_ctx = {"session": "LDN", "spread_band": "narrow", "rv_band": "mid"}
+    results = select_candidates(market_ctx, [day_manifest, mean_manifest], portfolio=portfolio)
+    result_map = {res.manifest_id: res for res in results}
+
+    assert result_map[day_manifest.id].eligible is True
+    assert result_map[mean_manifest.id].eligible is False
+    assert any("reject_rate" in reason for reason in result_map[mean_manifest.id].reasons)


### PR DESCRIPTION
## Summary
- add a router pipeline module that composes PortfolioState from manifests, telemetry, and BacktestRunner runtime metrics while documenting the P2 router DoD checklist
- expose runtime execution health metrics from BacktestRunner and invoke router_v1 candidate selection in run_sim when manifests are supplied
- cover the router pipeline with an integration pytest alongside existing router_v1 checks

## Testing
- python3 -m pytest tests/test_router_v1.py tests/test_router_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68e1b05445a0832a9afbec3970df2c0d