### PR TITLE
Respect explicit router scores when present

### DIFF
--- a/router/router_v1.py
+++ b/router/router_v1.py
@@ -192,7 +192,16 @@ def select_candidates(
                 reasons.extend(health_reasons)
 
         signal_ctx = (strategy_signals or {}).get(manifest.id, {})
-        score = float(signal_ctx.get("score") or signal_ctx.get("ev_lcb") or 0.0)
+        score_value: Optional[float] = None
+        if "score" in signal_ctx:
+            raw_score = signal_ctx.get("score")
+            if raw_score is not None:
+                score_value = float(raw_score)
+        if score_value is None:
+            ev_raw = signal_ctx.get("ev_lcb")
+            if ev_raw is not None:
+                score_value = float(ev_raw)
+        score = score_value if score_value is not None else 0.0
         score += manifest.router.priority
 
         # Apply soft penalties (do not flip eligibility) when information exists.

--- a/state.md
+++ b/state.md
@@ -2,6 +2,7 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
+- 2026-01-19: Updated `router/router_v1.select_candidates` so explicit `score` values (including 0.0) are preferred over EV LCB fallbacks and added a regression in `tests/test_router_v1.py` to lock the behaviour. Executed `python3 -m pytest tests/test_router_v1.py` to confirm all 9 cases pass.
 - 2026-01-18: `configs/strategies/templates/base_strategy.yaml` の router ガードを Day テンプレートに揃えて `priority` / `max_gross_exposure_pct` / `max_correlation` / `correlation_tags` / `max_reject_rate` / `max_slippage_bps` をコメント付きで追加し、README へ利用ガイドを追記。`python3 -m pytest tests/test_strategy_manifest.py` を実行してテンプレート読み込み回帰を確認。
 - 2026-01-18: `core/runner.py` に `ev_bypass` デバッグレコードを追加してウォームアップ残量 (`warmup_left` / `warmup_total`) をログ化し、`tests/test_runner.py` と `docs/backtest_runner_logging.md` / `docs/task_backlog.md` を同期。`python3 -m pytest tests/test_runner.py` を実行して 23 件パスを確認。
 - 2026-01-16: ルーター向けポートフォリオ監視を `analysis/portfolio_monitor.py` と `scripts/report_portfolio_summary.py` で整備し、`reports/portfolio_samples/router_demo/` のテレメトリ/メトリクスを用いたフィクスチャを追加。`python3 -m pytest` と `python3 scripts/report_portfolio_summary.py --input reports/portfolio_samples/router_demo --output reports/portfolio_summary.json --indent 2` を実行し、カテゴリ利用率・相関ヒートマップ・合成ドローダウンの算出と JSON 出力を確認。

--- a/tests/test_router_v1.py
+++ b/tests/test_router_v1.py
@@ -60,6 +60,15 @@ def test_scoring_sorting():
     assert any("ev_lcb" in reason for reason in res[0].reasons)
 
 
+def test_zero_score_respected_when_ev_lcb_present():
+    manifest = load_day_manifest()
+    manifest.router.priority = 0.0
+    ctx = {"session": "LDN", "spread_band": "narrow", "rv_band": "mid"}
+    signals = {manifest.id: {"score": 0.0, "ev_lcb": 0.9}}
+    res = select_candidates(ctx, [manifest], strategy_signals=signals)
+    assert res[0].score == 0.0
+
+
 def test_gross_exposure_cap_blocks_candidate():
     manifest = load_day_manifest()
     manifest.router.max_gross_exposure_pct = 60.0


### PR DESCRIPTION
## Summary
- ensure router_v1 prefers explicit signal scores, even when zero, before falling back to EV LCB values
- add regression coverage verifying score 0.0 is preserved when EV LCB is present
- record the routing update and regression test execution in the state log

## Testing
- python3 -m pytest tests/test_router_v1.py

------
https://chatgpt.com/codex/tasks/task_e_68e1caefd238832a9aa37e929f90386e