### PR TITLE
Handle invalid telemetry values in router pipeline

### DIFF
--- a/core/router_pipeline.py
+++ b/core/router_pipeline.py
@@ -59,20 +59,41 @@ def build_portfolio_state(
     active_positions: Dict[str, int] = {
         str(key): int(value) for key, value in snapshot.active_positions.items()
     }
-    category_usage: Dict[str, float] = {
-        str(key): float(value) for key, value in snapshot.category_utilisation_pct.items()
-    }
-    category_caps: Dict[str, float] = {
-        str(key): float(value) for key, value in snapshot.category_caps_pct.items()
-    }
-    correlations: Dict[str, Dict[str, float]] = {
-        str(key): {str(inner_k): float(inner_v) for inner_k, inner_v in value.items()}
-        for key, value in snapshot.strategy_correlations.items()
-    }
-    execution_health: Dict[str, Dict[str, float]] = {
-        str(key): {str(inner_k): float(inner_v) for inner_k, inner_v in value.items()}
-        for key, value in snapshot.execution_health.items()
-    }
+    category_usage: Dict[str, float] = {}
+    for key, value in snapshot.category_utilisation_pct.items():
+        value_float = _to_float(value)
+        if value_float is None:
+            continue
+        category_usage[str(key)] = value_float
+
+    category_caps: Dict[str, float] = {}
+    for key, value in snapshot.category_caps_pct.items():
+        value_float = _to_float(value)
+        if value_float is None:
+            continue
+        category_caps[str(key)] = value_float
+
+    correlations: Dict[str, Dict[str, float]] = {}
+    for key, value in snapshot.strategy_correlations.items():
+        inner: Dict[str, float] = {}
+        for inner_k, inner_v in value.items():
+            inner_float = _to_float(inner_v)
+            if inner_float is None:
+                continue
+            inner[str(inner_k)] = inner_float
+        if inner:
+            correlations[str(key)] = inner
+
+    execution_health: Dict[str, Dict[str, float]] = {}
+    for key, value in snapshot.execution_health.items():
+        inner: Dict[str, float] = {}
+        for inner_k, inner_v in value.items():
+            inner_float = _to_float(inner_v)
+            if inner_float is None:
+                continue
+            inner[str(inner_k)] = inner_float
+        if inner:
+            execution_health[str(key)] = inner
 
     exposures: Dict[str, float] = {}
     for manifest in manifest_list:

--- a/state.md
+++ b/state.md
@@ -2,6 +2,7 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
+- 2026-01-20: `core/router_pipeline.build_portfolio_state` のテレメトリ取り込みで `_to_float` を利用するよう更新し、非数値のカテゴリ利用率や `None` の拒否率を無視する回帰テストを `tests/test_router_pipeline.py` に追加。`python3 -m pytest tests/test_router_pipeline.py` を実行して 2 件パスを確認。
 - 2026-01-19: Updated `router/router_v1.select_candidates` so explicit `score` values (including 0.0) are preferred over EV LCB fallbacks and added a regression in `tests/test_router_v1.py` to lock the behaviour. Executed `python3 -m pytest tests/test_router_v1.py` to confirm all 9 cases pass.
 - 2026-01-18: `configs/strategies/templates/base_strategy.yaml` の router ガードを Day テンプレートに揃えて `priority` / `max_gross_exposure_pct` / `max_correlation` / `correlation_tags` / `max_reject_rate` / `max_slippage_bps` をコメント付きで追加し、README へ利用ガイドを追記。`python3 -m pytest tests/test_strategy_manifest.py` を実行してテンプレート読み込み回帰を確認。
 - 2026-01-18: `core/runner.py` に `ev_bypass` デバッグレコードを追加してウォームアップ残量 (`warmup_left` / `warmup_total`) をログ化し、`tests/test_runner.py` と `docs/backtest_runner_logging.md` / `docs/task_backlog.md` を同期。`python3 -m pytest tests/test_runner.py` を実行して 23 件パスを確認。


### PR DESCRIPTION
## Summary
- guard portfolio telemetry ingestion in build_portfolio_state by using the existing _to_float helper and skipping non-numeric values
- cover the None reject_rate and blank category utilisation cases with a regression test to ensure the router pipeline remains resilient
- record the change in state.md for operational tracking

## Testing
- python3 -m pytest tests/test_router_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68e1cbcc99dc832ab804b8d61d4216a5