### PR TITLE
Add headroom metrics to router portfolio state

### DIFF
--- a/router/router_v1.py
+++ b/router/router_v1.py
@@ -17,8 +17,10 @@ class PortfolioState:
     category_utilisation_pct: Dict[str, float] = field(default_factory=dict)
     active_positions: Dict[str, int] = field(default_factory=dict)
     category_caps_pct: Dict[str, float] = field(default_factory=dict)
+    category_headroom_pct: Dict[str, float] = field(default_factory=dict)
     gross_exposure_pct: Optional[float] = None
     gross_exposure_cap_pct: Optional[float] = None
+    gross_exposure_headroom_pct: Optional[float] = None
     strategy_correlations: Dict[str, Dict[str, float]] = field(default_factory=dict)
     execution_health: Dict[str, Dict[str, float]] = field(default_factory=dict)
 

--- a/state.md
+++ b/state.md
@@ -2,6 +2,11 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
+- 2026-01-26: `router/router_v1.PortfolioState` にカテゴリ/グロスエクスポージャーのヘッドルームを保持するフィールドを追加し、
+  `core/router_pipeline.build_portfolio_state` で利用率・上限からヘッドルームを算出するロジックを実装。
+  `analysis/portfolio_monitor` がポートフォリオヘッドルームを参照するよう揃え、対応テスト
+  (`tests/test_router_pipeline.py` / `tests/test_portfolio_monitor.py`) を更新。
+  `python3 -m pytest tests/test_router_pipeline.py tests/test_portfolio_monitor.py` を実行して 8 件パスを確認。
 - 2026-01-25: `analysis/portfolio_monitor._load_strategy_series` で manifest の相対パスをメトリクス所在ディレクトリ基準で解決するよう更新し、
   `scripts/report_portfolio_summary.py` の CLI 実行でも同ロジックを共有。
   マニフェスト名を書き換えたフィクスチャを一時ディレクトリへ複製する回帰テスト（`tests/test_portfolio_monitor.py`）を追加し、


### PR DESCRIPTION
## Summary
- add category and gross exposure headroom fields to `PortfolioState` and compute them from telemetry in the router pipeline
- reuse the shared headroom telemetry in the portfolio monitor summary instead of duplicating calculations
- extend router pipeline and portfolio monitor tests to assert the new headroom metrics

## Testing
- python3 -m pytest tests/test_router_pipeline.py tests/test_portfolio_monitor.py

## 要約 (JP)
- ルーターのポートフォリオ状態にカテゴリ/グロスのヘッドルームを追加し、テレメトリから算出する処理を導入
- ポートフォリオモニターを共通ヘッドルーム指標利用へ切り替え、重複計算を排除
- 新フィールドの想定値を確認するテストを拡充し、関連 pytest を実行

------
https://chatgpt.com/codex/tasks/task_e_68e1f062e150832aac8bd73694496879