### PR TITLE
Refine execution health scoring with structured penalties

### DIFF
--- a/docs/checklists/p2_router.md
+++ b/docs/checklists/p2_router.md
@@ -16,7 +16,7 @@
 - [ ] カテゴリ別利用率と上限（category utilisation / caps）を manifest リスク情報とポートフォリオテレメトリから算出し、`PortfolioState` へ反映した。
 - [ ] コリレーションキャップおよびグロスエクスポージャー上限を取り込み、`router_v1` が期待するフィールド（`strategy_correlations`, `gross_exposure_pct`, `gross_exposure_cap_pct`）を欠損なく提供した。
 - [ ] カテゴリ/グロスヘッドルームとカテゴリ予算 (`category_budget_pct` / `category_budget_headroom_pct`) を `PortfolioState` へ保持し、テレメトリ起点の headroom がある場合でも再計算で失われないことを確認した上で `router_v1.select_candidates` のスコアリングと理由ログに反映した。
-- [ ] BacktestRunner のランタイム指標から実行ヘルス（`reject_rate`, `slippage_bps`）を集計し、`_check_execution_health` の段階的なボーナス/ペナルティと理由ログ（値・ガード・比率・スコア差分）が `select_candidates` へ反映されることを確認した。
+- [ ] BacktestRunner のランタイム指標から実行ヘルス（`reject_rate`, `slippage_bps`）を集計し、`_check_execution_health` の段階的なボーナス/ペナルティ、ペナルティマップ（`ExecutionHealthStatus.penalties`）、理由ログ（値・ガード・比率・スコア差分）が `select_candidates` へ反映されることを確認した。
 - [ ] v2 拡張で参照する予算・相関・ヘルス項目を [docs/router_architecture.md](../router_architecture.md) の計画に沿って記録し、必要なテレメトリ項目を `PortfolioState` 経由で公開した。
 - [ ] ルーターサマリー出力前に `scripts/build_router_snapshot.py` で最新 run を `runs/router_pipeline/latest` へ集約した（`--manifest-run` で対象 run を明示、または `runs/index.csv` の `manifest_id` 列から自動検出）。`--category-budget` などの CLI 上書きがある場合でも、新しいテレメトリフィールドが `telemetry.json` に保持されることを確認した。
 - [ ] 受け入れテスト（`python3 -m pytest tests/test_router_v1.py tests/test_router_pipeline.py`）を実行し、カテゴリ配分／カテゴリ予算ペナルティ／相関ガード／執行ヘルスが期待通りに機能することを証明した。

--- a/state.md
+++ b/state.md
@@ -2,6 +2,7 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
+- 2026-02-04: Refined `router_v1._check_execution_health` to emit per-metric penalty maps and structured messages, updated `select_candidates` to deduplicate logs while applying the aggregated penalty, refreshed router docs/checklists with the new telemetry contract, extended `tests/test_router_v1.py` for bonus/penalty/disqualification assertions, and executed `python3 -m pytest tests/test_router_v1.py`.
 - 2026-02-03: Introduced tiered execution-health scoring in `router_v1._check_execution_health`, plumbed the structured status into `select_candidates`, refreshed router docs/checklist guidance, expanded `tests/test_router_v1.py` with bonus/penalty/disqualification coverage, and ran `python3 -m pytest tests/test_router_v1.py`.
 - 2026-02-02: Preserved telemetry-supplied `category_budget_headroom_pct` values when building `PortfolioState`, added regression coverage to `tests/test_router_pipeline.py`, refreshed router docs/checklist guidance, and executed `python3 -m pytest tests/test_router_pipeline.py tests/test_router_v1.py`.
 - 2026-02-01: Portfolio telemetry/state now preserves category budgets and headroom. `router_v1.select_candidates` applies soft


### PR DESCRIPTION
## Summary
- extend `router_v1._check_execution_health` to emit per-metric penalty maps, structured messages, and reuse them when adjusting candidate scores
- teach `select_candidates` to apply the aggregated penalties while deduplicating reason logs and refresh router documentation/checklists for the new contract
- broaden execution-health regression coverage and update `state.md` to capture the refined workflow

## Testing
- python3 -m pytest tests/test_router_v1.py

## サマリ
- 実行ヘルス評価でメトリクス別ペナルティマップと詳細ログを出力し、スコア調整へ反映できるよう整備しました。
- 理由ログの重複を抑えつつペナルティを適用するよう`select_candidates`を更新し、関連ドキュメントとチェックリストを追記しました。
- 実行ヘルスのボーナス・ペナルティ・失格ケースを回帰テストで網羅し、`state.md`に作業内容を記録しました。


------
https://chatgpt.com/codex/tasks/task_e_68e22c4e2ad0832abbcdd92d2a864562