### PR TITLE
Document correlation window metadata handling

### DIFF
--- a/docs/router_architecture.md
+++ b/docs/router_architecture.md
@@ -21,7 +21,7 @@ This note captures how the portfolio router evolves from the legacy v0 gate to t
    - `category_budget_pct[category]` / `category_budget_headroom_pct[category]` → governance budgets and optional pre-computed headroom. When budgets are missing from telemetry the pipeline falls back to manifest defaults (budget → `router.category_budget_pct` or the cap when unset).
    - `gross_exposure_pct` / `gross_exposure_cap_pct` → overall gross usage and cap.
    - `strategy_correlations[key][peer]` → pairwise correlations keyed by strategy ID or correlation tag.
-   - `correlation_window_minutes` → rolling window (in minutes) used when building `strategy_correlations`.
+   - `correlation_window_minutes` → rolling window (in minutes) used when building `strategy_correlations`; set via `scripts/build_router_snapshot.py --correlation-window-minutes` so reviewers know which lookback produced the heatmap.
    - `execution_health[strategy_id]` → runtime health aggregates (see below for field names).
 3. **Runtime metrics**: optional runner exports keyed by manifest ID. When present, the function pulls `execution_health.reject_rate` and `execution_health.slippage_bps` into the aggregated telemetry so the router can gate/score on current execution quality.【F:core/router_pipeline.py†L99-L126】
 

--- a/scripts/build_router_snapshot.py
+++ b/scripts/build_router_snapshot.py
@@ -16,7 +16,10 @@ snapshot layout compatible with ``scripts/report_portfolio_summary.py``:
 Pairwise strategy correlations are derived from the equity curves embedded in
 the metrics files. Active position counts are merged with manifest risk data
 via :func:`core.router_pipeline.build_portfolio_state` so the resulting
-``telemetry.json`` matches the contract used by the router pipeline.
+``telemetry.json`` matches the contract used by the router pipeline. Pass
+``--correlation-window-minutes`` to persist the rolling lookback window used to
+compute the correlation matrix so downstream monitors can display the correct
+context.
 """
 
 from __future__ import annotations

--- a/state.md
+++ b/state.md
@@ -2,6 +2,8 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
+- 2026-02-06: `scripts/build_router_snapshot.py` のドキュメントとヘルプ文に窓幅フラグの利用手順を追記し、`tests/test_router_pipeline.py` へ `correlation_window_minutes` 伝播の回帰テストを追加。
+  `docs/router_architecture.md` で CLI 引数の指定箇所を明記し、`python3 -m pytest`（192 件）を完走してスイートの健全性を再確認。
 - 2026-02-05: `scripts/build_router_snapshot.py` に `--correlation-window-minutes` を追加して相関行列と窓幅メタデータをテレメトリへ保存し、`PortfolioTelemetry` / `PortfolioState` / ポートフォリオサマリー / ルーター文書を同期。`tests/test_report_portfolio_summary.py` に CLI 回帰（ヘルプ出力含む）を追加し、`python3 -m pytest` を実行して 191 件パスを確認。
 - 2026-02-04: Refined `router_v1._check_execution_health` to emit per-metric penalty maps and structured messages, updated `select_candidates` to deduplicate logs while applying the aggregated penalty, refreshed router docs/checklists with the new telemetry contract, extended `tests/test_router_v1.py` for bonus/penalty/disqualification assertions, and executed `python3 -m pytest tests/test_router_v1.py`.
 - 2026-02-03: Introduced tiered execution-health scoring in `router_v1._check_execution_health`, plumbed the structured status into `select_candidates`, refreshed router docs/checklist guidance, expanded `tests/test_router_v1.py` with bonus/penalty/disqualification coverage, and ran `python3 -m pytest tests/test_router_v1.py`.

--- a/tests/test_router_pipeline.py
+++ b/tests/test_router_pipeline.py
@@ -72,6 +72,18 @@ def test_router_pipeline_merges_limits_and_execution_health():
     assert any("reject_rate" in reason for reason in result_map[mean_manifest.id].reasons)
 
 
+def test_router_pipeline_preserves_correlation_window_metadata():
+    manifest = load_manifest("configs/strategies/day_orb_5m.yaml")
+    telemetry = PortfolioTelemetry(
+        strategy_correlations={manifest.id: {}},
+        correlation_window_minutes=180.0,
+    )
+
+    portfolio = build_portfolio_state([manifest], telemetry=telemetry)
+
+    assert portfolio.correlation_window_minutes == approx(180.0)
+
+
 def test_router_pipeline_skips_invalid_telemetry_values():
     day_manifest = load_manifest("configs/strategies/day_orb_5m.yaml")
     day_manifest.router.category_cap_pct = 50.0


### PR DESCRIPTION
## Summary
- remind router snapshot help/docstring about the --correlation-window-minutes flag so operators capture the correlation lookback metadata
- document the CLI flag in docs/router_architecture.md and record the update in state.md for the workflow log
- add a regression in tests/test_router_pipeline.py to ensure correlation_window_minutes propagates through build_portfolio_state

## Testing
- python3 -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2355ae404832a9bc34c55ad3bd5b4