### PR TITLE
Ensure tightened category budgets refresh headroom

### DIFF
--- a/state.md
+++ b/state.md
@@ -2,6 +2,7 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
+- 2026-02-09: `core/router_pipeline.build_portfolio_state` でテレメトリ予算のベースラインを保持し、manifest や CSV が予算を引き締めた際にカテゴリ予算ヘッドルームを再計算するロジックを追加。`tests/test_router_pipeline.py` に回帰テストを追加し、`python3 -m pytest tests/test_router_pipeline.py tests/test_router_v1.py` を実行して breach ペナルティの適用を確認。
 - 2026-02-08: `core/router_pipeline.build_portfolio_state` が `execution_health` の数値メトリクス（`reject_rate` / `slippage_bps` / `fill_latency_ms` など）を包括的に取り込み、`router_v1.select_candidates` で各ガード (`max_reject_rate` / `max_slippage_bps` / `max_fill_latency_ms` or `max_latency_ms`) までのマージンを算出・理由ログへ記録。閾値接近時の減点と逸脱時の詳細失格理由をテスト（`python3 -m pytest tests/test_router_v1.py tests/test_router_pipeline.py tests/test_strategy_manifest.py`）で確認し、manifest ローダー・テンプレート・ドキュメント（`docs/router_architecture.md`, `docs/checklists/p2_router.md`, `docs/task_backlog.md`）を同期。
 - 2026-02-07: manifest `governance.category_budget_pct` を `core/router_pipeline.manifest_category_budget` で吸い上げ、`scripts/build_router_snapshot.py` が `--category-budget-csv` で外部 CSV を統合できるようにした。`router_v1.select_candidates` はカテゴリ予算ヘッドルームに応じて `status=ok|warning|breach` を理由ログへ付与し、超過率に比例したソフトペナルティを適用。`tests/test_router_pipeline.py` / `tests/test_router_v1.py` を実行し、新しいカテゴリ予算ロジックの回帰を確認。
 - 2026-02-06: `scripts/build_router_snapshot.py` のドキュメントとヘルプ文に窓幅フラグの利用手順を追記し、`tests/test_router_pipeline.py` へ `correlation_window_minutes` 伝播の回帰テストを追加。


### PR DESCRIPTION
## Summary
- capture telemetry-derived category budget baselines before applying manifest or CSV minima and recompute headroom when tightened budgets or stale values are detected
- add a regression covering stricter manifest budgets triggering a breach penalty in router_v1 and verifying recalculated headroom
- record the workflow note in state.md for the budget headroom tightening update

## Testing
- python3 -m pytest tests/test_router_pipeline.py tests/test_router_v1.py

------
https://chatgpt.com/codex/tasks/task_e_68e24d21f304832a98a6cf8a861450d0