### PR TITLE
Document doc-section options for task sync

### DIFF
--- a/docs/codex_workflow.md
+++ b/docs/codex_workflow.md
@@ -14,8 +14,8 @@ This guide summarizes the routine Codex agents should follow to keep tasks movin
 ## Pre-session Routine
 1. **Review the current situation**  
    Read `state.md`, focusing on the `Next Task` entry, open questions, and linked checklists. Confirm that the `Backlog Anchor` and `Pending Questions` slots match the intended work.
-2. **Confirm the backlog anchor**  
-   Locate the task in `docs/task_backlog.md`, reread its DoD, and check `docs/todo_next.md` to ensure the task sits in the correct section (`Ready`, `In Progress`, or `Pending Review`). Adjust the target section via `--doc-section` when running automation.
+2. **Confirm the backlog anchor**
+   Locate the task in `docs/task_backlog.md`, reread its DoD, and check `docs/todo_next.md` to ensure the task sits in the correct section (`Ready`, `In Progress`, or `Pending Review`). Adjust the target section via `--doc-section` when running automation. For a quick refresher on how the placement synchronizes with `state.md`, see [docs/state_runbook.md#task-sync](state_runbook.md#task-sync).
 3. **Prepare templates**  
    When adding a new `Next Task`, start from `docs/templates/next_task_entry.md`. For Ready tasks, duplicate `docs/templates/dod_checklist.md` into `docs/checklists/<task-slug>.md` so progress can be tracked with checkboxes.
 4. **Sandbox & approval check**  
@@ -24,7 +24,7 @@ This guide summarizes the routine Codex agents should follow to keep tasks movin
    - Network: `restricted`
    - Approvals: `on-request`
    Request approval when you need to rerun commands unsandboxed (e.g., external network access, privileged filesystem writes, destructive git operations). For routine read/pytest commands, approvals are unnecessary.
-5. **Dry-run the start command**
+5. **Dry-run the start command** <a id="doc-section-options"></a>
    Execute the following command with `--dry-run` to validate anchors and dates before making real changes.
    ```bash
    python3 scripts/manage_task_cycle.py --dry-run start-task \
@@ -35,11 +35,11 @@ This guide summarizes the routine Codex agents should follow to keep tasks movin
        --title "<Task Title>" \
        --state-note "<State entry memo>" \
        --doc-note "<docs/todo_next.md memo>" \
-       --doc-section <Ready|In Progress> \
+       --doc-section <Ready|In Progress|Pending Review> \
        [--runbook-links "<Markdown links for runbooks>"] \
        [--pending-questions "<Key questions to track>"]
    ```
-   During the preview the automation cross-checks the anchor to avoid creating duplicate records. If the session still needs to reuse the existing anchor—for example when only the memos must be refreshed—add `--skip-record` so the tool intentionally bypasses the record creation step.
+   During the preview the automation cross-checks the anchor to avoid creating duplicate records. If the session still needs to reuse the existing anchor—for example when only the memos must be refreshed—add `--skip-record` so the tool intentionally bypasses the record creation step. Use `--doc-section Pending Review` when resuming a task that remains under review but requires additional iteration; the command keeps the memo in the Pending Review block of `docs/todo_next.md` while restoring the templates in `state.md`.
    ```bash
    python3 scripts/manage_task_cycle.py --dry-run start-task --skip-record \
        --anchor docs/task_backlog.md#codex-session-operations-guide \

--- a/docs/state_runbook.md
+++ b/docs/state_runbook.md
@@ -102,7 +102,21 @@ python3 scripts/run_daily_workflow.py --ingest --update-state --benchmarks --sta
 - **アーカイブの整理（任意）:** `ops/state_archive/` は運用で増えていきます。最新 N 件のみ残す場合は `scripts/prune_state_archive.py --base ops/state_archive --keep 5` を実行してください。`--dry-run` で削除予定を確認できます。
 - **ヘルスチェック:** `scripts/check_state_health.py` を日次（`run_daily_workflow.py --state-health`）で実行し、結果を `ops/health/state_checks.json` に追記する。勝率 LCB・バケット別サンプル・滑り係数を監視し、警告が出た場合は `--webhook` で Slack 等へ通知。`--fail-on-warning` を CI/バッチに組み込むと異常時にジョブを停止できる。
 - **履歴保持:** 標準では直近 90 レコードを保持する。上限を変更する場合は `--history-limit` を調整する。履歴の可視化は Notebook or BI で `checked_at` を横軸に `ev_win_lcb` やワーニング件数をプロットする。
-- **タスク同期:** `state.md` と `docs/todo_next.md` の整合を保つ際は `scripts/manage_task_cycle.py` を優先利用する。`start-task` で Ready 登録→In Progress 昇格を一括実行し、既存アンカー検知で重複記録を抑止する。既存アンカーを維持したままメモだけ更新したい場合は `--skip-record` を付与して記録工程を明示的にスキップする（Codex セッション再開時など）。完了時は `finish-task` でまとめてログとアーカイブへ送る。いずれも `--dry-run` でコマンド内容を確認してから本実行する。Codex セッションにおける具体的な開始前チェックや終了処理、`--skip-record` 利用例は [docs/codex_workflow.md#pre-session-routine](codex_workflow.md#pre-session-routine) を参照する。`finish-task` ドライランの出力例は以下の通りで、プレビューのみが表示され（`--dry-run` のため副作用なし）、本番実行時に呼び出される `sync_task_docs.py complete` の引数を確認できる。
+- **タスク同期:** <a id="task-sync"></a> `state.md` と `docs/todo_next.md` の整合を保つ際は `scripts/manage_task_cycle.py` を優先利用する。`start-task` で Ready 登録→In Progress 昇格を一括実行し、既存アンカー検知で重複記録を抑止する。既存アンカーを維持したままメモだけ更新したい場合は `--skip-record` を付与して記録工程を明示的にスキップする（Codex セッション再開時など）。完了時は `finish-task` でまとめてログとアーカイブへ送る。いずれも `--dry-run` でコマンド内容を確認してから本実行する。`docs/todo_next.md` への挿入先は `--doc-section In Progress|Pending Review` で制御でき、Ready 以外から着手する場合でも配置を保ったまま同期できる。`--doc-section` の選択手順とテンプレ適用フローは [docs/codex_workflow.md#doc-section-options](codex_workflow.md#doc-section-options) で詳述しているので併せて確認する。Ready 以外でタスクを再開する例:
+
+  ```bash
+  python3 scripts/manage_task_cycle.py --dry-run start-task \
+      --anchor docs/task_backlog.md#codex-session-operations-guide \
+      --record-date 2026-02-17 \
+      --promote-date 2026-02-17 \
+      --task-id OPS-CODEX-GUIDE \
+      --title "Codex Session Operations Guide" \
+      --state-note "Resume review from Pending Review" \
+      --doc-note "Picking up reviewer feedback" \
+      --doc-section "Pending Review"
+  ```
+
+  Codex セッションにおける具体的な開始前チェックや終了処理、`--skip-record` 利用例は [docs/codex_workflow.md#pre-session-routine](codex_workflow.md#pre-session-routine) を参照する。`finish-task` ドライランの出力例は以下の通りで、プレビューのみが表示され（`--dry-run` のため副作用なし）、本番実行時に呼び出される `sync_task_docs.py complete` の引数を確認できる。
 
   ```bash
   [dry-run] /root/.pyenv/versions/3.12.10/bin/python3 /workspace/INVEST4_ORB5M_CODEX_B/scripts/sync_task_docs.py complete --anchor 'docs/task_backlog.md#codex-session-operations-guide' --date 2026-02-14 --note 'Captured finish-task dry-run sample for documentation' --task-id OPS-CODEX-GUIDE

--- a/docs/todo_next.md
+++ b/docs/todo_next.md
@@ -26,6 +26,8 @@
 
 ### Pending Review
 
+- レビュー中のタスクを再開する際は `scripts/manage_task_cycle.py --doc-section Pending Review` を用いると、`docs/todo_next.md` の配置を維持したまま `state.md` のテンプレートを再適用できる。
+
 ## Archive（達成済み）
 
 - **ルーター拡張** (Backlog: `docs/task_backlog.md` → [P2-マルチ戦略ポートフォリオ化](docs/task_backlog.md#p2-マルチ戦略ポートフォリオ化)) — 2026-02-13 完了 <!-- anchor: docs/task_backlog.md#p2-マルチ戦略ポートフォリオ化 -->

--- a/state.md
+++ b/state.md
@@ -2,6 +2,7 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
+- 2026-02-18: Documented how `--doc-section In Progress|Pending Review` controls `docs/todo_next.md` placement across `docs/state_runbook.md` and `docs/codex_workflow.md`, added cross-links, refreshed the Pending Review note in `docs/todo_next.md`, and ran `python3 scripts/manage_task_cycle.py --dry-run start-task --doc-section "Pending Review" ...` to capture the dry-run output.
 - 2026-02-16: Clarified `--skip-record` guidance in `docs/codex_workflow.md` / `docs/state_runbook.md`, captured recommended scenarios, and verified `python3 scripts/manage_task_cycle.py --dry-run start-task --skip-record ...` emits the skip notice plus `sync_task_docs.py promote` preview.
 - 2026-02-17: Captured the `finish-task` dry-run preview for `docs/codex_workflow.md` and `docs/state_runbook.md`, documented the lack of side effects when using `--dry-run`, and executed `npx markdownlint-cli docs/codex_workflow.md docs/state_runbook.md` to review Markdown formatting warnings.
 - 2026-02-15: Shifted the warmup decrement in `core/runner._maybe_enter_trade` to occur after processing fill results so only confirmed fills reduce the counter, updated `tests/test_runner.py` to exercise the conservative fill engine for both filled and unfilled scenarios, and executed `python3 -m pytest tests/test_runner.py` to verify the behaviour.


### PR DESCRIPTION
## Summary
- document how `--doc-section In Progress|Pending Review` controls placement in the task sync flow and cross-link the guidance between docs
- add a Pending Review resume example in the state runbook and update the Codex workflow guide to reference the new section
- note in docs/todo_next.md how to keep review items in place when resuming work

## Testing
- `python3 scripts/manage_task_cycle.py --dry-run start-task --anchor docs/task_backlog.md#codex-session-operations-guide --record-date 2026-02-17 --promote-date 2026-02-17 --task-id OPS-CODEX-GUIDE --title "Codex Session Operations Guide" --state-note "Resume review from Pending Review" --doc-note "Picking up reviewer feedback" --doc-section "Pending Review"`


------
https://chatgpt.com/codex/tasks/task_e_68e2eaae5b94832ab6bfff61b5d3e91f