### PR TITLE
Guard warmup decrement during calibration fills

### DIFF
--- a/core/runner.py
+++ b/core/runner.py
@@ -1255,7 +1255,7 @@ class BacktestRunner:
             calibrating=calibrating,
             pip_size_value=pip_size_value,
         )
-        if self._warmup_left > 0:
+        if not calibrating and self._warmup_left > 0:
             self._warmup_left -= 1
 
 

--- a/state.md
+++ b/state.md
@@ -2,6 +2,7 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
+- 2026-02-19: Guarded `BacktestRunner._warmup_left` so calibration fills no longer decrement the counter, added a regression test covering the calibration warmup case, and executed `python3 -m pytest tests/test_runner.py` to verify the change.
 - 2026-02-18: Documented how `--doc-section In Progress|Pending Review` controls `docs/todo_next.md` placement across `docs/state_runbook.md` and `docs/codex_workflow.md`, added cross-links, refreshed the Pending Review note in `docs/todo_next.md`, and ran `python3 scripts/manage_task_cycle.py --dry-run start-task --doc-section "Pending Review" ...` to capture the dry-run output.
 - 2026-02-16: Clarified `--skip-record` guidance in `docs/codex_workflow.md` / `docs/state_runbook.md`, captured recommended scenarios, and verified `python3 scripts/manage_task_cycle.py --dry-run start-task --skip-record ...` emits the skip notice plus `sync_task_docs.py promote` preview.
 - 2026-02-17: Captured the `finish-task` dry-run preview for `docs/codex_workflow.md` and `docs/state_runbook.md`, documented the lack of side effects when using `--dry-run`, and executed `npx markdownlint-cli docs/codex_workflow.md docs/state_runbook.md` to review Markdown formatting warnings.

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -663,6 +663,54 @@ class TestRunner(unittest.TestCase):
         self.assertEqual(runner._warmup_left, initial_warmup - 1)
         mock_process.assert_called_once()
 
+    def test_calibration_warmup_counter_remains_unchanged(self):
+        runner, pending, breakout, features, calibrating = self._prepare_breakout_environment(
+            warmup_left=3,
+            calibrate_days=2,
+        )
+        self.assertTrue(calibrating)
+        stub_ev = self.DummyEV(ev_lcb=1.1, p_lcb=0.7)
+        runner._get_ev_manager = lambda key: stub_ev
+        fill_entry = breakout["c"]
+        pending["entry"] = fill_entry
+        runner.stg._pending_signal = pending
+        features.ctx["ev_oco"] = stub_ev
+        features.ctx.setdefault("slip_cap_pip", runner.rcfg.slip_cap_pip)
+        features.ctx.setdefault("expected_slip_pip", 0.0)
+        pip_value = pip_size(runner.symbol)
+        initial_warmup = runner._warmup_left
+        intent = OrderIntent(
+            pending["side"],
+            qty=1.0,
+            price=fill_entry,
+            tif="IOC",
+            tag="day_orb5m#test",
+            oco={
+                "tp_pips": pending["tp_pips"],
+                "sl_pips": pending["sl_pips"],
+                "trail_pips": pending["trail_pips"],
+            },
+        )
+
+        runner.fill_engine_c.default_policy = SameBarPolicy.SL_FIRST
+
+        with patch.object(runner, "_check_slip_and_sizing", return_value=True):
+            with patch.object(runner.stg, "signals", return_value=[intent]):
+                with patch.object(
+                    runner,
+                    "_process_fill_result",
+                    wraps=runner._process_fill_result,
+                ) as mock_process:
+                    runner._maybe_enter_trade(
+                        bar=breakout,
+                        features=features,
+                        mode="conservative",
+                        pip_size_value=pip_value,
+                        calibrating=calibrating,
+                    )
+        self.assertEqual(runner._warmup_left, initial_warmup)
+        mock_process.assert_called_once()
+
     @patch("strategies.day_orb_5m.pass_gates", return_value=True)
     def test_calibration_signal_updates_cooldown_state(self, _mock_pass_gates):
         stg = DayORB5m()


### PR DESCRIPTION
## Summary
- guard the BacktestRunner warmup counter so calibration trades no longer consume the allowance
- add a regression test to verify warmup_left is unchanged when executing calibration fills
- record the change in the state log for session tracking

## Testing
- python3 -m pytest tests/test_runner.py

------
https://chatgpt.com/codex/tasks/task_e_68e2f3505288832a889288f4df991fe0