### PR TITLE
Reset BacktestRunner EV state between runs

### DIFF
--- a/state.md
+++ b/state.md
@@ -2,6 +2,7 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
+- 2026-02-20: Reset EV and slip-learning state inside `BacktestRunner.run` to avoid cross-run leakage, added a regression that reuses a runner twice with learned slippage, and executed `python3 -m pytest tests/test_runner.py` to confirm the fix.
 - 2026-02-19: Guarded `BacktestRunner._warmup_left` so calibration fills no longer decrement the counter, added a regression test covering the calibration warmup case, and executed `python3 -m pytest tests/test_runner.py` to verify the change.
 - 2026-02-18: Documented how `--doc-section In Progress|Pending Review` controls `docs/todo_next.md` placement across `docs/state_runbook.md` and `docs/codex_workflow.md`, added cross-links, refreshed the Pending Review note in `docs/todo_next.md`, and ran `python3 scripts/manage_task_cycle.py --dry-run start-task --doc-section "Pending Review" ...` to capture the dry-run output.
 - 2026-02-16: Clarified `--skip-record` guidance in `docs/codex_workflow.md` / `docs/state_runbook.md`, captured recommended scenarios, and verified `python3 scripts/manage_task_cycle.py --dry-run start-task --skip-record ...` emits the skip notice plus `sync_task_docs.py promote` preview.


### PR DESCRIPTION
## Summary
- reset BacktestRunner EV managers and slip-learning accumulators on each run before reapplying EV profiles
- document the persistent strategy instance behaviour in BacktestRunner.run
- add a regression proving consecutive runs on a losing fixture behave identically after resetting learning state

## Testing
- python3 -m pytest tests/test_runner.py

------
https://chatgpt.com/codex/tasks/task_e_68e2f4743718832ab55b0ec4189dc989