### PR TITLE
Refactor router pipeline helpers and extend regression tests

### DIFF
--- a/state.md
+++ b/state.md
@@ -2,6 +2,12 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
+- 2026-02-22: Refactored `core/router_pipeline.build_portfolio_state` by introducing helper
+  functions for numeric map normalisation, correlation map generation, exposure/headroom
+  aggregation, gross exposure calculation, and runtime metric merging. Added regression
+  tests in `tests/test_router_pipeline.py` to validate the helper outputs (including the
+  existing headroom tolerance) and executed `python3 -m pytest tests/test_router_pipeline.py`
+  to confirm behaviour is unchanged.
 - 2026-02-21: Refactored `router/router_v1.select_candidates` to delegate per-manifest checks to `evaluate_candidate`, introduced
   `CandidateEvaluation` for aggregating eligibility deltas/reasons, added regression coverage in `tests/test_router_v1.py`, and
   executed `python3 -m pytest tests/test_router_v1.py` to confirm the helper matches previous behaviour.


### PR DESCRIPTION
## Summary
- introduce helper functions that normalise telemetry maps, assemble correlation metadata, compute exposures, and merge runtime metrics in `build_portfolio_state`
- add regression tests that exercise the new helpers and lock in the headroom tolerance behaviour
- update the work log to capture the refactor and validation steps

## Testing
- python3 -m pytest tests/test_router_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68e301449f3c832aa302484d15f75849