### PR TITLE
Track quantity-weighted PnL and validate risk scaling

### DIFF
--- a/state.md
+++ b/state.md
@@ -2,6 +2,7 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
+- 2026-02-27: Weighted trade PnL by executed quantity so pip and currency totals align with risk sizing, stored pip_value in trade snapshots, extended metrics/daily records for currency PnL, added regression `tests/test_runner.py::test_trade_pnl_scales_with_risk_per_trade`, and executed `python3 -m pytest tests/test_runner.py`.
 - 2026-02-25: Tracked live equity inside `BacktestRunner` so trade PnL (in quote
   currency) updates position sizing, recorded the currency PnL on metrics,
   refreshed sizing contexts to use the mutable balance, added a regression in

--- a/tests/data/runner_sample_records.csv
+++ b/tests/data/runner_sample_records.csv
@@ -1,5 +1,5 @@
-stage,pnl_pips
-trade,12.0
-trade,-5.0
-trade,8.0
-trade,-10.0
+stage,pnl_pips,pnl_value,qty
+trade,12.0,12.0,1.0
+trade,-5.0,-5.0,1.0
+trade,8.0,8.0,1.0
+trade,-10.0,-10.0,1.0


### PR DESCRIPTION
## Summary
- compute quantity-weighted pip and currency PnL in `_finalize_trade`, persisting currency totals across metrics, daily aggregates, and debug logs
- ensure trade snapshots carry `pip_value`, add quantity and currency fields to trade records, and expose cumulative currency PnL via `Metrics`
- refresh the runner records fixture and add a regression that varies `risk_per_trade_pct` to confirm PnL and equity scale with position size

## Testing
- python3 -m pytest tests/test_runner.py

------
https://chatgpt.com/codex/tasks/task_e_68e354888c18832ab6dcc5bc515060ed