### PR TITLE
Fix TP/SL tracking to use filled entry prices

### DIFF
--- a/core/runner.py
+++ b/core/runner.py
@@ -1570,13 +1570,13 @@ class BacktestRunner:
                 },
             )
             return
-        entry_px = result.get("entry_px")
-        tp_px = intent.price + (
-            spec.tp_pips * pip_size_value if intent.side == "BUY" else -spec.tp_pips * pip_size_value
-        )
-        sl_px0 = intent.price - (
-            spec.sl_pips * pip_size_value if intent.side == "BUY" else -spec.sl_pips * pip_size_value
-        )
+        entry_px_result = result.get("entry_px")
+        entry_px = entry_px_result if entry_px_result is not None else intent.price
+        if entry_px is None:
+            raise ValueError("Filled entry price is required to initialise position state")
+        direction = 1.0 if intent.side == "BUY" else -1.0
+        tp_px = entry_px + direction * spec.tp_pips * pip_size_value
+        sl_px0 = entry_px - direction * spec.sl_pips * pip_size_value
         if calibrating:
             self.calib_positions.append(
                 {

--- a/state.md
+++ b/state.md
@@ -2,6 +2,11 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
+- 2026-03-01: Updated `_process_fill_result` so calibration/live TP/SL prices derive from
+  filled entries, ensuring slip-adjusted distances persist in runner state, added
+  regression `tests/test_runner.py::test_entry_slip_preserves_tp_sl_distances_and_pnl`
+  covering realised PnL after non-zero slip, and executed `python3 -m pytest
+  tests/test_runner.py`.
 - 2026-02-28: Updated `BacktestRunner` so `RunnerConfig(ev_mode="off")` bypasses the EV threshold by
   clamping the recorded threshold LCB to negative infinity, keeping debug/context logs consistent,
   and added regression `tests/test_runner.py::test_ev_gate_off_mode_bypasses_threshold_checks` to


### PR DESCRIPTION
## Summary
- compute TP/SL levels from the executed entry price for calibration queues and live positions
- ensure the position snapshot retains slip-adjusted targets and add a regression that exercises non-zero entry slip and verifies realised PnL
- record the change in the session state log

## Testing
- python3 -m pytest tests/test_runner.py

------
https://chatgpt.com/codex/tasks/task_e_68e3606460b8832a8086eced3b1fa0bb