### PR TITLE
Refactor runner feature pipeline into dedicated module

### DIFF
--- a/core/runner_features.py
+++ b/core/runner_features.py
@@ -1,0 +1,253 @@
+"""Feature computation pipeline for :mod:`core.runner`.
+
+The pipeline encapsulates the per-bar feature calculations and context
+construction that previously lived directly on :class:`BacktestRunner`.
+Keeping these responsibilities in a dedicated module makes it easier to
+share sanitisation helpers and to reason about the state updates that occur
+while processing each bar.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from collections.abc import MutableMapping as MutableMappingABC
+import math
+from typing import Any, Callable, Dict, Iterable, Iterator, List, Mapping, MutableMapping, Optional, Tuple
+
+from core.feature_store import (
+    atr as calc_atr,
+    adx as calc_adx,
+    opening_range,
+    realized_vol,
+    micro_zscore as calc_micro_zscore,
+    micro_trend as calc_micro_trend,
+    mid_price as calc_mid_price,
+    trend_score as calc_trend_score,
+    pullback as calc_pullback,
+)
+
+
+@dataclass
+class RunnerContext(MutableMappingABC[str, Any]):
+    """Dictionary-like container for runner context values."""
+
+    values: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.values = dict(self.values)
+
+    def __getitem__(self, key: str) -> Any:
+        return self.values[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.values[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.values[key]
+
+    def __contains__(self, key: object) -> bool:  # pragma: no cover - simple proxy
+        return key in self.values
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.values)
+
+    def __len__(self) -> int:  # pragma: no cover - simple proxy
+        return len(self.values)
+
+    def items(self) -> Iterable[Tuple[str, Any]]:
+        return self.values.items()
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self.values.get(key, default)
+
+    def update(self, data: Mapping[str, Any]) -> None:
+        self.values.update(data)
+
+    def setdefault(self, key: str, default: Any = None) -> Any:
+        return self.values.setdefault(key, default)
+
+    def keys(self) -> Iterable[str]:
+        return self.values.keys()
+
+    def to_dict(self) -> Dict[str, Any]:
+        return dict(self.values)
+
+
+@dataclass
+class FeatureBundle:
+    bar_input: Dict[str, Any]
+    ctx: RunnerContext
+    atr14: float
+    adx14: float
+    or_high: Optional[float]
+    or_low: Optional[float]
+    realized_vol: float
+    micro_zscore: float = 0.0
+    micro_trend: float = 0.0
+    mid_price: float = 0.0
+    trend_score: float = 0.0
+    pullback: float = 0.0
+
+
+class FeaturePipeline:
+    """Compute feature bundles and runner context for a single bar."""
+
+    WINDOW_LIMIT = 200
+    RV_LOOKBACK = 12
+
+    def __init__(
+        self,
+        *,
+        rcfg: Any,
+        window: List[Dict[str, Any]],
+        session_bars: List[Dict[str, Any]],
+        rv_hist: MutableMapping[str, Any],
+        strategy_cfg: MutableMapping[str, Any],
+        ctx_builder: Callable[..., Dict[str, Any]],
+    ) -> None:
+        self._rcfg = rcfg
+        self._window = window
+        self._session_bars = session_bars
+        self._rv_hist = rv_hist
+        self._strategy_cfg = strategy_cfg
+        self._ctx_builder = ctx_builder
+
+    def compute(
+        self,
+        bar: Mapping[str, Any],
+        *,
+        session: str,
+        new_session: bool,
+        calibrating: bool,
+    ) -> Tuple[FeatureBundle, RunnerContext]:
+        self._ingest_bar(bar, new_session=new_session)
+        realized_vol_value = self._compute_realized_vol(session)
+        atr14, adx14 = self._compute_atr_adx()
+        or_high, or_low = opening_range(self._session_bars, n=self._rcfg.or_n)
+        micro_features = self._compute_micro_features(bar)
+
+        bar_input = self._build_bar_input(
+            bar,
+            new_session=new_session,
+            atr14=atr14,
+            micro_features=micro_features,
+        )
+        ctx_dict = self._ctx_builder(
+            bar=bar,
+            session=session,
+            atr14=bar_input["atr14"],
+            or_h=or_high if self._is_finite(or_high) else None,
+            or_l=or_low if self._is_finite(or_low) else None,
+            realized_vol_value=realized_vol_value,
+        )
+        if calibrating:
+            threshold_override = float("-inf") if ctx_dict.get("ev_mode") == "off" else -1e9
+            ctx_dict["threshold_lcb_pip"] = threshold_override
+            ctx_dict["calibrating"] = True
+        runner_ctx = RunnerContext(ctx_dict)
+        self._strategy_cfg["ctx"] = runner_ctx.to_dict()
+
+        feature_bundle = FeatureBundle(
+            bar_input=bar_input,
+            ctx=runner_ctx,
+            atr14=atr14,
+            adx14=adx14,
+            or_high=or_high if self._is_finite(or_high) else None,
+            or_low=or_low if self._is_finite(or_low) else None,
+            realized_vol=realized_vol_value,
+            micro_zscore=bar_input["micro_zscore"],
+            micro_trend=bar_input["micro_trend"],
+            mid_price=bar_input["mid_price"],
+            trend_score=bar_input["trend_score"],
+            pullback=bar_input["pullback"],
+        )
+        return feature_bundle, runner_ctx
+
+    def _ingest_bar(self, bar: Mapping[str, Any], *, new_session: bool) -> None:
+        self._window.append({key: bar[key] for key in ("o", "h", "l", "c")})
+        if len(self._window) > self.WINDOW_LIMIT:
+            del self._window[0]
+        if new_session:
+            self._session_bars.clear()
+        self._session_bars.append({key: bar[key] for key in ("o", "h", "l", "c")})
+
+    def _compute_realized_vol(self, session: str) -> float:
+        rv_value = 0.0
+        try:
+            if len(self._window) >= self.RV_LOOKBACK + 1:
+                window_slice = self._window[-(self.RV_LOOKBACK + 1) :]
+            else:
+                window_slice = None
+            rv_computed = realized_vol(window_slice, n=self.RV_LOOKBACK)
+        except Exception:
+            rv_computed = None
+        if rv_computed is not None:
+            rv_value = self._sanitize(rv_computed)
+        try:
+            self._rv_hist[session].append(rv_value)
+        except Exception:
+            pass
+        return 0.0 if math.isnan(rv_value) else rv_value
+
+    def _compute_atr_adx(self) -> Tuple[float, float]:
+        if len(self._window) >= 15:
+            atr14 = calc_atr(self._window[-15:])
+            adx14 = calc_adx(self._window[-15:])
+        else:
+            atr14 = float("nan")
+            adx14 = float("nan")
+        return atr14, adx14
+
+    def _compute_micro_features(self, bar: Mapping[str, Any]) -> Dict[str, float]:
+        micro_z = self._sanitize(calc_micro_zscore(self._window))
+        micro_tr = self._sanitize(calc_micro_trend(self._window))
+        mid_px = self._sanitize(calc_mid_price(bar))
+        trend_val = self._sanitize(calc_trend_score(self._window))
+        pullback_val = self._sanitize(calc_pullback(self._session_bars))
+        return {
+            "micro_zscore": micro_z,
+            "micro_trend": micro_tr,
+            "mid_price": mid_px,
+            "trend_score": trend_val,
+            "pullback": pullback_val,
+        }
+
+    def _build_bar_input(
+        self,
+        bar: Mapping[str, Any],
+        *,
+        new_session: bool,
+        atr14: float,
+        micro_features: Mapping[str, float],
+    ) -> Dict[str, Any]:
+        atr_value = atr14 if self._is_finite(atr14) else 0.0
+        bar_input: Dict[str, Any] = {
+            "o": bar["o"],
+            "h": bar["h"],
+            "l": bar["l"],
+            "c": bar["c"],
+            "atr14": atr_value,
+            "window": self._session_bars[: self._rcfg.or_n],
+            "new_session": new_session,
+        }
+        bar_input.update(micro_features)
+        if "zscore" in bar:
+            try:
+                bar_input["zscore"] = float(bar["zscore"])
+            except (TypeError, ValueError):
+                bar_input["zscore"] = bar["zscore"]
+        return bar_input
+
+    @staticmethod
+    def _sanitize(value: Any) -> float:
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError):
+            return 0.0
+        if not math.isfinite(numeric):
+            return 0.0
+        return numeric
+
+    @staticmethod
+    def _is_finite(value: Optional[float]) -> bool:
+        return value is not None and not math.isnan(value)

--- a/docs/task_backlog.md
+++ b/docs/task_backlog.md
@@ -26,6 +26,11 @@ Document the repeatable workflow that lets Codex keep `state.md`, `docs/todo_nex
   the threshold LCB to negative infinity and preserving the disabled state in context/debug logs.
   Added regression `tests/test_runner.py::test_ev_gate_off_mode_bypasses_threshold_checks` and ran
   `python3 -m pytest tests/test_runner.py` to confirm no breakouts are rejected under the override.
+- 2026-03-03: Introduced `FeaturePipeline` to centralise bar ingestion, realised volatility history,
+  and context sanitisation, returning the new `RunnerContext` wrapper so `BacktestRunner._compute_features`
+  delegates to the shared flow. Added `tests/test_runner_features.py` for direct pipeline coverage and
+  refreshed `tests/test_runner.py` to execute via the pipeline path, with `python3 -m pytest`
+  verifying regression parity.
 - ~~**state 更新ワーカー**~~ (完了): `scripts/update_state.py` に部分実行ワークフローを実装し、`BacktestRunner.run_partial` と状態スナップショット/EVアーカイブ連携を整備。`ops/state_archive/<strategy>/<symbol>/<mode>/` へ最新5件を保持し、更新後は `scripts/aggregate_ev.py` を自動起動するようにした。
 - ~~**runs/index 再構築スクリプト整備**~~ (完了): `scripts/rebuild_runs_index.py` が `scripts/run_sim.py` の出力列 (k_tr, gate/EV debug など) と派生指標 (win_rate, pnl_per_trade) を欠損なく復元し、`tests/test_rebuild_runs_index.py` で fixtures 検証を追加。
 - ~~**ベースライン/ローリング run 起動ジョブ**~~ (2024-06-12 完了): `scripts/run_benchmark_pipeline.py` でベースライン/ローリング run → サマリー → スナップショット更新を一括化し、`run_daily_workflow.py --benchmarks` から呼び出せるようにした。`tests/test_run_benchmark_pipeline.py` で順序・引数伝播・失敗処理を回帰テスト化。

--- a/state.md
+++ b/state.md
@@ -2,6 +2,11 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
+- 2026-03-03: Refactored feature computation by introducing `core/runner_features.FeaturePipeline`
+  and `RunnerContext`, ensuring bar ingestion, realised volatility windows, and strategy ctx updates
+  are centralised. Updated `BacktestRunner._compute_features` to delegate to the pipeline, added
+  direct unit tests in `tests/test_runner_features.py`, refreshed runner regressions, and executed
+  `python3 -m pytest tests/test_runner.py tests/test_runner_features.py` for confirmation.
 - 2026-03-02: Introduced `PositionState` for runner position tracking, refactored
   `BacktestRunner` to store active/calibration positions via the dataclass with
   export/load support, refreshed `tests/test_runner.py` to cover the new state

--- a/tests/test_runner_features.py
+++ b/tests/test_runner_features.py
@@ -1,0 +1,84 @@
+from datetime import datetime, timezone, timedelta
+import math
+
+import pytest
+
+from core.runner import BacktestRunner
+from core.runner_features import FeaturePipeline, RunnerContext
+
+
+def make_bar(ts: datetime, price: float) -> dict:
+    return {
+        "timestamp": ts.isoformat().replace("+00:00", "Z"),
+        "symbol": "USDJPY",
+        "tf": "5m",
+        "o": price,
+        "h": price + 0.1,
+        "l": price - 0.1,
+        "c": price,
+        "v": 1000.0,
+        "spread": 0.02,
+    }
+
+
+@pytest.fixture
+def runner() -> BacktestRunner:
+    return BacktestRunner(equity=100_000.0, symbol="USDJPY")
+
+
+def test_pipeline_returns_runner_context_and_updates_strategy_cfg(runner: BacktestRunner) -> None:
+    pipeline = FeaturePipeline(
+        rcfg=runner.rcfg,
+        window=runner.window,
+        session_bars=runner.session_bars,
+        rv_hist=runner.rv_hist,
+        strategy_cfg=runner.stg.cfg,
+        ctx_builder=runner._build_ctx,
+    )
+    ts = datetime(2024, 1, 1, 8, 0, tzinfo=timezone.utc)
+    bar = make_bar(ts, 150.0)
+    features, ctx = pipeline.compute(
+        bar,
+        session="LDN",
+        new_session=True,
+        calibrating=False,
+    )
+
+    assert isinstance(ctx, RunnerContext)
+    assert features.ctx is ctx
+    assert runner.stg.cfg["ctx"] == ctx.to_dict()
+    assert ctx["session"] == "LDN"
+    assert "rv_band" in ctx
+    assert ctx.get("calibrating") is None
+
+
+def test_pipeline_sanitises_invalid_micro_features(runner: BacktestRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("core.runner_features.calc_micro_zscore", lambda bars: math.nan)
+    monkeypatch.setattr("core.runner_features.calc_micro_trend", lambda bars: float("inf"))
+    monkeypatch.setattr("core.runner_features.calc_trend_score", lambda bars: math.nan)
+    monkeypatch.setattr("core.runner_features.calc_pullback", lambda bars: math.nan)
+
+    pipeline = FeaturePipeline(
+        rcfg=runner.rcfg,
+        window=runner.window,
+        session_bars=runner.session_bars,
+        rv_hist=runner.rv_hist,
+        strategy_cfg=runner.stg.cfg,
+        ctx_builder=runner._build_ctx,
+    )
+    ts = datetime(2024, 1, 1, 8, 0, tzinfo=timezone.utc)
+    bar = make_bar(ts, 150.0)
+
+    features, ctx = pipeline.compute(
+        bar,
+        session="LDN",
+        new_session=True,
+        calibrating=True,
+    )
+
+    assert features.micro_zscore == 0.0
+    assert features.micro_trend == 0.0
+    assert features.trend_score == 0.0
+    assert features.pullback == 0.0
+    assert ctx["threshold_lcb_pip"] == -1e9
+    assert ctx["calibrating"] is True


### PR DESCRIPTION
## Summary
- extract feature computation into `core/runner_features.FeaturePipeline` returning the new `RunnerContext`
- update `BacktestRunner._compute_features` to delegate to the pipeline while keeping realised volatility history and strategy context updates centralised
- add direct unit tests for the pipeline and document the refactor in the backlog/state log

## Testing
- python3 -m pytest tests/test_runner.py tests/test_runner_features.py

------
https://chatgpt.com/codex/tasks/task_e_68e375980580832a8f207dd87eea7465