### PR TITLE
Introduce strategy context update hook and adjust runner integration

### DIFF
--- a/core/runner.py
+++ b/core/runner.py
@@ -953,8 +953,8 @@ class BacktestRunner:
             window=self.window,
             session_bars=self.session_bars,
             rv_hist=self.rv_hist,
-            strategy_cfg=self.stg.cfg,
             ctx_builder=self._build_ctx,
+            context_consumer=self.stg.update_context,
         )
         features, _ = pipeline.compute(
             bar,

--- a/core/runner_features.py
+++ b/core/runner_features.py
@@ -102,15 +102,15 @@ class FeaturePipeline:
         window: List[Dict[str, Any]],
         session_bars: List[Dict[str, Any]],
         rv_hist: MutableMapping[str, Any],
-        strategy_cfg: MutableMapping[str, Any],
         ctx_builder: Callable[..., Dict[str, Any]],
+        context_consumer: Optional[Callable[[Dict[str, Any]], None]] = None,
     ) -> None:
         self._rcfg = rcfg
         self._window = window
         self._session_bars = session_bars
         self._rv_hist = rv_hist
-        self._strategy_cfg = strategy_cfg
         self._ctx_builder = ctx_builder
+        self._context_consumer = context_consumer
 
     def compute(
         self,
@@ -145,7 +145,8 @@ class FeaturePipeline:
             ctx_dict["threshold_lcb_pip"] = threshold_override
             ctx_dict["calibrating"] = True
         runner_ctx = RunnerContext(ctx_dict)
-        self._strategy_cfg["ctx"] = runner_ctx.to_dict()
+        if self._context_consumer is not None:
+            self._context_consumer(runner_ctx.to_dict())
 
         feature_bundle = FeatureBundle(
             bar_input=bar_input,

--- a/core/strategy_api.py
+++ b/core/strategy_api.py
@@ -18,6 +18,9 @@ class OrderIntent:
 class Strategy(ABC):
     api_version = "1.0"
 
+    def __init__(self) -> None:
+        self._runtime_ctx: Dict[str, Any] = {}
+
     @abstractmethod
     def on_start(self, cfg: Dict[str,Any], instruments: List[str], state_store: Dict[str,Any]) -> None:
         ...
@@ -31,6 +34,16 @@ class Strategy(ABC):
     @abstractmethod
     def signals(self) -> Iterable[OrderIntent]:
         ...
+
+    def update_context(self, ctx: Dict[str, Any]) -> None:
+        self._runtime_ctx = dict(ctx)
+
+    @property
+    def runtime_ctx(self) -> Dict[str, Any]:
+        return self._runtime_ctx
+
+    def get_context(self) -> Dict[str, Any]:
+        return dict(self._runtime_ctx)
 
     def eligibility(self, ctx: Dict[str,Any]) -> float:
         return 1.0

--- a/state.md
+++ b/state.md
@@ -7,6 +7,12 @@
   are centralised. Updated `BacktestRunner._compute_features` to delegate to the pipeline, added
   direct unit tests in `tests/test_runner_features.py`, refreshed runner regressions, and executed
   `python3 -m pytest tests/test_runner.py tests/test_runner_features.py` for confirmation.
+- 2026-03-05: Decoupled strategy runtime context from configuration by adding
+  `Strategy.update_context`, routing BacktestRunner and FeaturePipeline updates through the new API,
+  and updating DayORB5m/templated strategies plus runner/CLI regressions. Ran
+  `python3 -m pytest tests/test_runner.py tests/test_runner_features.py tests/test_run_sim_cli.py
+  tests/test_ev_and_sizing.py tests/test_mean_reversion_strategy.py tests/test_strategy_feature_integration.py`
+  to confirm behaviour.
 - 2026-03-04: Introduced `core/runner_entry` with structured gate/EV/sizing dataclasses, refactored
   `BacktestRunner._maybe_enter_trade` to compose `EntryGate`/`EVGate`/`SizingGate`, removed ad-hoc
   `None` checks, and expanded `tests/test_runner.py` with pipeline success/failure coverage.

--- a/strategies/day_orb_5m.py
+++ b/strategies/day_orb_5m.py
@@ -138,7 +138,7 @@ class DayORB5m(Strategy):
         if not self._pending_signal:
             return []
         # Context should include router gates + EV + sizing related configs
-        ctx = self.cfg.get("ctx", {}).copy()
+        ctx = self.get_context()
         # Simple cooldown by bars
         cooldown = int(ctx.get("cooldown_bars", self.cfg.get("cooldown_bars", 0)))
         if cooldown > 0 and (self.state["bar_idx"] - self.state["last_signal_bar"] < cooldown):

--- a/strategies/day_template.py
+++ b/strategies/day_template.py
@@ -62,7 +62,7 @@ class DayStrategyTemplate(Strategy):
     def signals(self) -> Iterable[OrderIntent]:
         if not self._pending_signal:
             return []
-        ctx = dict(self.cfg.get("ctx", {}))
+        ctx = self.get_context()
         if not pass_gates(ctx):
             return []
 

--- a/strategies/mean_reversion.py
+++ b/strategies/mean_reversion.py
@@ -147,7 +147,7 @@ class MeanReversionStrategy(Strategy):
     def signals(self) -> Iterable[OrderIntent]:
         if not self._pending_signal:
             return []
-        ctx = dict(self.cfg.get("ctx", {}))
+        ctx = self.get_context()
         if not pass_gates(ctx):
             return []
 

--- a/strategies/scalping_template.py
+++ b/strategies/scalping_template.py
@@ -76,7 +76,7 @@ class ScalpingTemplate(Strategy):
     def signals(self) -> Iterable[OrderIntent]:
         if not self._pending_signal:
             return []
-        ctx = dict(self.cfg.get("ctx", {}))
+        ctx = self.get_context()
         if not pass_gates(ctx):
             return []
 

--- a/tests/fixtures/strategies/forced_failure.py
+++ b/tests/fixtures/strategies/forced_failure.py
@@ -15,6 +15,7 @@ class DeterministicFailureStrategy(Strategy):
     """
 
     def __init__(self) -> None:
+        super().__init__()
         self.cfg: Dict[str, Any] = {}
         self._pending_signal: Dict[str, Any] | None = None
 

--- a/tests/test_ev_and_sizing.py
+++ b/tests/test_ev_and_sizing.py
@@ -96,7 +96,7 @@ class TestStrategyIntegration(unittest.TestCase):
         }
 
         # Attach ctx and emit
-        stg.cfg["ctx"] = ctx
+        stg.update_context(ctx)
         stg.on_bar(breakout_bar)
         sigs = list(stg.signals())
         self.assertEqual(len(sigs), 1)

--- a/tests/test_mean_reversion_strategy.py
+++ b/tests/test_mean_reversion_strategy.py
@@ -54,7 +54,7 @@ class MeanReversionStrategyTest(unittest.TestCase):
         self.assertIsNotNone(self.strategy._pending_signal)
         ctx = self._base_ctx()
         self.assertTrue(self.strategy.strategy_gate(ctx, self.strategy._pending_signal))
-        self.strategy.cfg["ctx"] = ctx
+        self.strategy.update_context(ctx)
         intents = list(self.strategy.signals())
         self.assertEqual(len(intents), 1)
         intent = intents[0]

--- a/tests/test_run_sim_cli.py
+++ b/tests/test_run_sim_cli.py
@@ -191,7 +191,7 @@ class TestRunSimCLI(unittest.TestCase):
 
             def _signals_wrapper(self):
                 intents = original_signals(self)
-                ctx = dict(self.cfg.get("ctx", {}))
+                ctx = self.get_context()
                 if intents and ctx.get("ev_oco") is not None:
                     sig = intents[0]
                     expected = compute_qty_from_ctx(

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -448,11 +448,12 @@ class TestRunner(unittest.TestCase):
 
         class SingleBarStrategy(Strategy):
             def __init__(self) -> None:
-                self.cfg = {"ctx": {}}
+                super().__init__()
+                self.cfg = {}
                 self._pending_signal: Optional[OrderIntent] = None
 
             def on_start(self, cfg, instruments, state_store) -> None:
-                self.cfg = {"ctx": {}}
+                self.cfg = dict(cfg)
                 self._pending_signal = None
 
             def on_bar(self, bar) -> None:
@@ -1522,6 +1523,7 @@ class TestRunner(unittest.TestCase):
             }
         }
         stg.on_start(cfg, ["USDJPY"], {})
+        stg.update_context(cfg["ctx"])
         stg.state["bar_idx"] = 12
         stg._pending_signal = {
             "side": "SELL",
@@ -1567,6 +1569,7 @@ class TestRunner(unittest.TestCase):
             }
         }
         stg.on_start(cfg, ["USDJPY"], {})
+        stg.update_context(cfg["ctx"])
         stg.state["bar_idx"] = 25
         stg._pending_signal = {
             "side": "BUY",

--- a/tests/test_runner_features.py
+++ b/tests/test_runner_features.py
@@ -26,14 +26,14 @@ def runner() -> BacktestRunner:
     return BacktestRunner(equity=100_000.0, symbol="USDJPY")
 
 
-def test_pipeline_returns_runner_context_and_updates_strategy_cfg(runner: BacktestRunner) -> None:
+def test_pipeline_returns_runner_context_and_updates_strategy(runner: BacktestRunner) -> None:
     pipeline = FeaturePipeline(
         rcfg=runner.rcfg,
         window=runner.window,
         session_bars=runner.session_bars,
         rv_hist=runner.rv_hist,
-        strategy_cfg=runner.stg.cfg,
         ctx_builder=runner._build_ctx,
+        context_consumer=runner.stg.update_context,
     )
     ts = datetime(2024, 1, 1, 8, 0, tzinfo=timezone.utc)
     bar = make_bar(ts, 150.0)
@@ -46,7 +46,7 @@ def test_pipeline_returns_runner_context_and_updates_strategy_cfg(runner: Backte
 
     assert isinstance(ctx, RunnerContext)
     assert features.ctx is ctx
-    assert runner.stg.cfg["ctx"] == ctx.to_dict()
+    assert runner.stg.runtime_ctx == ctx.to_dict()
     assert ctx["session"] == "LDN"
     assert "rv_band" in ctx
     assert ctx.get("calibrating") is None
@@ -63,8 +63,8 @@ def test_pipeline_sanitises_invalid_micro_features(runner: BacktestRunner, monke
         window=runner.window,
         session_bars=runner.session_bars,
         rv_hist=runner.rv_hist,
-        strategy_cfg=runner.stg.cfg,
         ctx_builder=runner._build_ctx,
+        context_consumer=runner.stg.update_context,
     )
     ts = datetime(2024, 1, 1, 8, 0, tzinfo=timezone.utc)
     bar = make_bar(ts, 150.0)

--- a/tests/test_strategy_feature_integration.py
+++ b/tests/test_strategy_feature_integration.py
@@ -57,7 +57,7 @@ def test_tokyo_micro_mean_reversion_emits_signal_with_micro_features(scalping_ct
         ["USDJPY"],
         {},
     )
-    strategy.cfg["ctx"] = scalping_ctx
+    strategy.update_context(scalping_ctx)
 
     bar = {
         "o": 112.610,
@@ -99,7 +99,7 @@ def test_session_momentum_continuation_emits_signal_with_trend_features(day_ctx:
         ["USDJPY"],
         {},
     )
-    strategy.cfg["ctx"] = day_ctx
+    strategy.update_context(day_ctx)
 
     bar = {
         "o": 1.2035,


### PR DESCRIPTION
## Summary
- add a default Strategy.update_context implementation to persist runtime state and expose helpers for subclasses
- route BacktestRunner/FeaturePipeline context updates through the new hook instead of mutating strategy cfg
- update DayORB5m, shared templates, and strategy tests to consume the runtime context API and refresh mocks

## Testing
- python3 -m pytest tests/test_runner.py tests/test_runner_features.py tests/test_run_sim_cli.py tests/test_ev_and_sizing.py tests/test_mean_reversion_strategy.py tests/test_strategy_feature_integration.py

------
https://chatgpt.com/codex/tasks/task_e_68e381696674832abb4cc207f2e42010