### PR TITLE
Refine runner entry evaluation dataclasses

### DIFF
--- a/state.md
+++ b/state.md
@@ -2,6 +2,11 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
+- 2026-03-06: Added structured `EntryEvaluation`/`EVEvaluation`/`SizingEvaluation`
+  and `TradeContextSnapshot` dataclasses to capture gate outcomes and trade context,
+  refactored `BacktestRunner._maybe_enter_trade` to route through the new helpers,
+  and updated `tests/test_runner.py` to assert the dataclass-based flow while keeping
+  debug/daily metrics stable. Ran `python3 -m pytest tests/test_runner.py`.
 - 2026-03-03: Refactored feature computation by introducing `core/runner_features.FeaturePipeline`
   and `RunnerContext`, ensuring bar ingestion, realised volatility windows, and strategy ctx updates
   are centralised. Updated `BacktestRunner._compute_features` to delegate to the pipeline, added


### PR DESCRIPTION
## Summary
- introduce EntryEvaluation, EVEvaluation, SizingEvaluation, and TradeContextSnapshot dataclasses for capturing gate and trade context
- refactor BacktestRunner entry evaluation helpers to return the new dataclasses and centralise trade context assembly
- update tests/test_runner.py and state.md to exercise the dataclass flow and document the change

## Testing
- python3 -m pytest tests/test_runner.py

## 日本語サマリー
- ゲート評価と取引コンテキストを保持する新しいdataclassを導入し、エントリー判定ロジックを整理
- BacktestRunnerのヘルパーをdataclass返却へ統一し、取引スナップショット組み立てを共通化
- テストとstateログを更新してdataclass経由でも従来のメトリクスが得られることを確認


------
https://chatgpt.com/codex/tasks/task_e_68e385ce8338832a9841b065572e5f12