### PR TITLE
Refactor runner contexts to typed dataclasses

### DIFF
--- a/core/runner_entry.py
+++ b/core/runner_entry.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, Mapping, Optional, TYPE_CHECKING
+from typing import Any, Dict, Mapping, Optional, Tuple, TYPE_CHECKING, Union
 
 from router.router_v0 import pass_gates
 from core.sizing import compute_qty_from_ctx
@@ -19,9 +19,117 @@ class GateCheckOutcome:
 
 
 @dataclass
+class EntryContext:
+    session: str
+    spread_band: str
+    rv_band: str
+    slip_cap_pip: float
+    threshold_lcb_pip: float
+    or_atr_ratio: float
+    min_or_atr_ratio: float
+    allow_low_rv: bool
+    warmup_left: float
+    warmup_mult: float
+    cooldown_bars: int
+    ev_mode: str
+    size_floor_mult: float
+    base_cost_pips: float
+    expected_slip_pip: float
+    cost_pips: float
+    equity: float
+    pip_value: float
+    sizing_cfg: Dict[str, Any]
+    ev_key: Tuple[str, str, str]
+    ev_manager: Any
+    ev_profile_stats: Optional[Mapping[str, Any]] = None
+    allowed_sessions: Optional[Tuple[str, ...]] = None
+    news_freeze: bool = False
+    calibrating: bool = False
+
+    def _constructor_kwargs(self) -> Dict[str, Any]:
+        data = dict(vars(self))
+        sizing_cfg = data.get("sizing_cfg")
+        if isinstance(sizing_cfg, dict):
+            data["sizing_cfg"] = dict(sizing_cfg)
+        return data
+
+    def to_mapping(self) -> Dict[str, Any]:
+        data: Dict[str, Any] = {
+            "session": self.session,
+            "spread_band": self.spread_band,
+            "rv_band": self.rv_band,
+            "slip_cap_pip": self.slip_cap_pip,
+            "threshold_lcb_pip": self.threshold_lcb_pip,
+            "or_atr_ratio": self.or_atr_ratio,
+            "min_or_atr_ratio": self.min_or_atr_ratio,
+            "allow_low_rv": self.allow_low_rv,
+            "warmup_left": self.warmup_left,
+            "warmup_mult": self.warmup_mult,
+            "cooldown_bars": self.cooldown_bars,
+            "ev_mode": self.ev_mode,
+            "size_floor_mult": self.size_floor_mult,
+            "base_cost_pips": self.base_cost_pips,
+            "expected_slip_pip": self.expected_slip_pip,
+            "cost_pips": self.cost_pips,
+            "equity": self.equity,
+            "pip_value": self.pip_value,
+            "sizing_cfg": dict(self.sizing_cfg),
+            "ev_key": self.ev_key,
+            "ev_oco": self.ev_manager,
+        }
+        if self.allowed_sessions is not None:
+            data["allowed_sessions"] = list(self.allowed_sessions)
+        if self.ev_profile_stats is not None:
+            data["ev_profile_stats"] = self.ev_profile_stats
+        if self.news_freeze:
+            data["news_freeze"] = self.news_freeze
+        if self.calibrating:
+            data["calibrating"] = self.calibrating
+        return data
+
+
+@dataclass
+class EVContext(EntryContext):
+    ev_lcb: Optional[float] = None
+    threshold_lcb: Optional[float] = None
+    ev_pass: Optional[bool] = None
+    bypass: bool = False
+
+    @classmethod
+    def from_entry(cls, entry: EntryContext) -> "EVContext":
+        return cls(**entry._constructor_kwargs())
+
+    def to_mapping(self) -> Dict[str, Any]:  # type: ignore[override]
+        data = super().to_mapping()
+        if self.ev_lcb is not None:
+            data["ev_lcb"] = self.ev_lcb
+        if self.threshold_lcb is not None:
+            data["threshold_lcb"] = self.threshold_lcb
+        if self.ev_pass is not None:
+            data["ev_pass"] = self.ev_pass
+        data["ev_bypass"] = self.bypass
+        return data
+
+
+@dataclass
+class SizingContext(EVContext):
+    qty: Optional[float] = None
+
+    @classmethod
+    def from_ev(cls, ev_ctx: EVContext) -> "SizingContext":
+        return cls(**ev_ctx._constructor_kwargs())
+
+    def to_mapping(self) -> Dict[str, Any]:  # type: ignore[override]
+        data = super().to_mapping()
+        if self.qty is not None:
+            data["qty"] = self.qty
+        return data
+
+
+@dataclass
 class EntryEvaluation:
     outcome: GateCheckOutcome
-    context: Optional[Dict[str, Any]] = None
+    context: Optional[EntryContext] = None
     pending_side: Optional[str] = None
 
 
@@ -32,12 +140,13 @@ class EVEvaluation:
     ev_lcb: Optional[float] = None
     threshold_lcb: Optional[float] = None
     bypass: bool = False
-    context: Optional[Dict[str, Any]] = None
+    context: Optional[EVContext] = None
 
 
 @dataclass
 class SizingEvaluation:
     outcome: GateCheckOutcome
+    context: Optional[SizingContext] = None
 
 
 @dataclass
@@ -84,29 +193,28 @@ class TradeContextSnapshot:
         return data
 
 
+ContextType = Union[EntryContext, EVContext, SizingContext]
+
+
 def build_trade_context_snapshot(
     *,
-    ctx_dbg: Mapping[str, Any],
-    features_ctx: Mapping[str, Any],
+    ctx: ContextType,
     bar_input: Mapping[str, Any],
 ) -> TradeContextSnapshot:
-    base_cost = features_ctx.get("base_cost_pips", features_ctx.get("cost_pips", 0.0))
-    pip_value = features_ctx.get("pip_value")
-    if pip_value is None:
-        pip_value = ctx_dbg.get("pip_value")
     snapshot = TradeContextSnapshot(
-        session=ctx_dbg.get("session", features_ctx.get("session")),
-        rv_band=ctx_dbg.get("rv_band", features_ctx.get("rv_band")),
-        spread_band=ctx_dbg.get("spread_band", features_ctx.get("spread_band")),
-        or_atr_ratio=ctx_dbg.get("or_atr_ratio", features_ctx.get("or_atr_ratio")),
-        min_or_atr_ratio=ctx_dbg.get("min_or_atr_ratio", features_ctx.get("min_or_atr_ratio")),
-        ev_lcb=ctx_dbg.get("ev_lcb"),
-        threshold_lcb=ctx_dbg.get("threshold_lcb"),
-        ev_pass=ctx_dbg.get("ev_pass"),
-        expected_slip_pip=features_ctx.get("expected_slip_pip", 0.0),
-        cost_base=base_cost,
-        pip_value=pip_value,
+        session=ctx.session,
+        rv_band=ctx.rv_band,
+        spread_band=ctx.spread_band,
+        or_atr_ratio=ctx.or_atr_ratio,
+        min_or_atr_ratio=ctx.min_or_atr_ratio,
+        expected_slip_pip=ctx.expected_slip_pip,
+        cost_base=ctx.base_cost_pips,
+        pip_value=ctx.pip_value,
     )
+    if isinstance(ctx, EVContext):
+        snapshot.ev_lcb = ctx.ev_lcb
+        snapshot.threshold_lcb = ctx.threshold_lcb
+        snapshot.ev_pass = ctx.ev_pass
     if "zscore" in bar_input:
         try:
             snapshot.zscore = float(bar_input["zscore"])
@@ -120,10 +228,12 @@ class EntryGate:
         self._runner = runner
 
     def evaluate(self, *, pending: Any, features: "FeatureBundle") -> EntryEvaluation:
-        ctx_dbg = dict(features.ctx)
+        entry_ctx = features.entry_ctx
+        if entry_ctx is None:
+            raise ValueError("Feature bundle did not include an entry context")
         pending_side, _, _ = self._runner._extract_pending_fields(pending)
         gate_allowed, gate_reason = self._runner._call_strategy_gate(
-            ctx_dbg,
+            entry_ctx,
             pending,
             ts=self._runner._last_timestamp,
             side=pending_side,
@@ -147,7 +257,7 @@ class EntryGate:
                 or_atr_ratio=metadata.get("or_atr_ratio"),
                 min_or_atr_ratio=metadata.get("min_or_atr_ratio"),
                 rv_band=metadata.get("rv_band"),
-                allow_low_rv=ctx_dbg.get("allow_low_rv"),
+                allow_low_rv=entry_ctx.allow_low_rv,
             )
             return EntryEvaluation(
                 outcome=GateCheckOutcome(
@@ -158,21 +268,21 @@ class EntryGate:
                 context=None,
                 pending_side=pending_side,
             )
-        if not pass_gates(ctx_dbg):
+        if not pass_gates(entry_ctx.to_mapping()):
             self._runner.debug_counts["gate_block"] += 1
             self._runner._increment_daily("gate_block")
             metadata = {
-                "rv_band": ctx_dbg.get("rv_band"),
-                "spread_band": ctx_dbg.get("spread_band"),
-                "or_atr_ratio": ctx_dbg.get("or_atr_ratio"),
+                "rv_band": entry_ctx.rv_band,
+                "spread_band": entry_ctx.spread_band,
+                "or_atr_ratio": entry_ctx.or_atr_ratio,
             }
             self._runner._append_debug_record(
                 "gate_block",
                 ts=self._runner._last_timestamp,
                 side=pending_side,
-                rv_band=metadata["rv_band"],
-                spread_band=metadata["spread_band"],
-                or_atr_ratio=metadata["or_atr_ratio"],
+                rv_band=entry_ctx.rv_band,
+                spread_band=entry_ctx.spread_band,
+                or_atr_ratio=entry_ctx.or_atr_ratio,
                 reason="router_gate",
             )
             return EntryEvaluation(
@@ -187,7 +297,7 @@ class EntryGate:
         self._runner._increment_daily("gate_pass")
         return EntryEvaluation(
             outcome=GateCheckOutcome(passed=True),
-            context=ctx_dbg,
+            context=entry_ctx,
             pending_side=pending_side,
         )
 
@@ -199,38 +309,31 @@ class EVGate:
     def evaluate(
         self,
         *,
-        ctx_dbg: Dict[str, Any],
+        ctx: EntryContext,
         pending: Any,
         calibrating: bool,
         timestamp: Optional[str],
     ) -> EVEvaluation:
         pending_side, tp_pips, sl_pips = self._runner._extract_pending_fields(pending)
-        ev_key = ctx_dbg.get(
-            "ev_key",
-            (
-                ctx_dbg.get("session"),
-                ctx_dbg.get("spread_band"),
-                ctx_dbg.get("rv_band"),
-            ),
-        )
-        ev_mgr = self._runner._get_ev_manager(ev_key)
-        ev_mode_value = str(ctx_dbg.get("ev_mode", "")).lower()
+        ev_key = ctx.ev_key
+        ev_mgr = ctx.ev_manager
+        ev_mode_value = str(ctx.ev_mode).lower()
         if ev_mode_value == "off":
             threshold_lcb = float("-inf")
         else:
             threshold_lcb = self._runner._call_ev_threshold(
-                ctx_dbg,
+                ctx,
                 pending,
                 self._runner.rcfg.threshold_lcb_pip,
                 ts=timestamp,
                 side=pending_side,
             )
-        ctx_dbg["threshold_lcb_pip"] = threshold_lcb
+        ctx.threshold_lcb_pip = threshold_lcb
         ev_lcb = (
             ev_mgr.ev_lcb_oco(
                 float(tp_pips),
                 float(sl_pips),
-                ctx_dbg["cost_pips"],
+                ctx.cost_pips,
             )
             if (tp_pips is not None and sl_pips is not None and not calibrating)
             else 1e9
@@ -249,7 +352,7 @@ class EVGate:
                     threshold_lcb=threshold_lcb,
                     warmup_left=warmup_remaining,
                     warmup_total=int(self._runner.rcfg.warmup_trades),
-                    cost_pips=ctx_dbg.get("cost_pips"),
+                    cost_pips=ctx.cost_pips,
                     tp_pips=tp_pips,
                     sl_pips=sl_pips,
                 )
@@ -262,10 +365,16 @@ class EVGate:
                     side=pending_side,
                     ev_lcb=ev_lcb,
                     threshold_lcb=threshold_lcb,
-                    cost_pips=ctx_dbg.get("cost_pips"),
+                    cost_pips=ctx.cost_pips,
                     tp_pips=tp_pips,
                     sl_pips=sl_pips,
                 )
+                ev_ctx = EVContext.from_entry(ctx)
+                ev_ctx.threshold_lcb_pip = threshold_lcb
+                ev_ctx.threshold_lcb = threshold_lcb
+                ev_ctx.ev_lcb = ev_lcb
+                ev_ctx.ev_pass = False
+                ev_ctx.bypass = False
                 return EVEvaluation(
                     outcome=GateCheckOutcome(
                         passed=False,
@@ -279,20 +388,23 @@ class EVGate:
                     ev_lcb=ev_lcb,
                     threshold_lcb=threshold_lcb,
                     bypass=False,
-                    context=ctx_dbg,
+                    context=ev_ctx,
                 )
         else:
             self._runner._increment_daily("ev_pass")
-        ctx_dbg["ev_lcb"] = ev_lcb
-        ctx_dbg["threshold_lcb"] = threshold_lcb
-        ctx_dbg["ev_pass"] = not ev_bypass
+        ev_ctx = EVContext.from_entry(ctx)
+        ev_ctx.threshold_lcb_pip = threshold_lcb
+        ev_ctx.threshold_lcb = threshold_lcb
+        ev_ctx.ev_lcb = ev_lcb
+        ev_ctx.ev_pass = not ev_bypass
+        ev_ctx.bypass = ev_bypass
         return EVEvaluation(
             outcome=GateCheckOutcome(passed=True),
             manager=ev_mgr,
             ev_lcb=ev_lcb,
             threshold_lcb=threshold_lcb,
             bypass=ev_bypass,
-            context=ctx_dbg,
+            context=ev_ctx,
         )
 
 
@@ -303,15 +415,16 @@ class SizingGate:
     def evaluate(
         self,
         *,
-        ctx_dbg: Mapping[str, Any],
+        ctx: EVContext,
         pending: Any,
         ev_result: EVEvaluation,
         calibrating: bool,
         timestamp: Optional[str],
     ) -> SizingEvaluation:
+        sizing_ctx = SizingContext.from_ev(ctx)
         pending_side, tp_pips, sl_pips = self._runner._extract_pending_fields(pending)
-        slip_cap = ctx_dbg.get("slip_cap_pip", self._runner.rcfg.slip_cap_pip)
-        expected_slip = ctx_dbg.get("expected_slip_pip", 0.0)
+        slip_cap = sizing_ctx.slip_cap_pip
+        expected_slip = sizing_ctx.expected_slip_pip
         if expected_slip > slip_cap:
             self._runner.debug_counts["gate_block"] += 1
             self._runner._increment_daily("gate_block")
@@ -331,7 +444,8 @@ class SizingGate:
                     passed=False,
                     reason="slip_cap",
                     metadata=metadata,
-                )
+                ),
+                context=sizing_ctx,
             )
         if (
             not ev_result.bypass
@@ -339,9 +453,9 @@ class SizingGate:
             and tp_pips is not None
             and sl_pips is not None
         ):
-            ctx_for_sizing: Dict[str, Any] = dict(ctx_dbg)
+            ctx_for_sizing = sizing_ctx.to_mapping()
             ctx_for_sizing.setdefault("equity", self._runner._equity_live)
-            manager = ev_result.manager
+            manager = ev_result.manager or sizing_ctx.ev_manager
             if manager is None:
                 raise ValueError("EV manager is required when sizing evaluation runs")
             qty_dbg = compute_qty_from_ctx(
@@ -351,6 +465,7 @@ class SizingGate:
                 tp_pips=float(tp_pips),
                 p_lcb=manager.p_lcb(),
             )
+            sizing_ctx.qty = qty_dbg
             if qty_dbg <= 0:
                 self._runner.debug_counts["zero_qty"] += 1
                 return SizingEvaluation(
@@ -358,6 +473,10 @@ class SizingGate:
                         passed=False,
                         reason="zero_qty",
                         metadata={"qty": qty_dbg},
-                    )
+                    ),
+                    context=sizing_ctx,
                 )
-        return SizingEvaluation(outcome=GateCheckOutcome(passed=True))
+        return SizingEvaluation(
+            outcome=GateCheckOutcome(passed=True),
+            context=sizing_ctx,
+        )

--- a/state.md
+++ b/state.md
@@ -324,6 +324,9 @@
 - [P2-01] 2026-01-08: 戦略テンプレと manifest を整備し、manifest CLI 回帰と run_sim ドライランを完了. DoD: [docs/task_backlog.md#p2-マルチ戦略ポートフォリオ化](docs/task_backlog.md#p2-マルチ戦略ポートフォリオ化).
 
 - [P2-01] 2026-01-08: 戦略テンプレと manifest を整備し、pytest/run_sim で配線確認済み. DoD: [docs/task_backlog.md#p2-マルチ戦略ポートフォリオ化](docs/task_backlog.md#p2-マルチ戦略ポートフォリオ化).
+- 2026-03-09: Replaced runner entry/EV/sizing contexts with typed dataclasses, refactored the feature pipeline and gating flow to
+  propagate structured contexts, updated trade snapshot helpers, and refreshed runner feature/unit tests to assert the new
+  attribute-based API. Ran `python3 -m pytest tests/test_runner_features.py tests/test_runner.py`.
 ## Next Task
 - Backlog Anchor: [Codex Session Operations Guide](docs/task_backlog.md#codex-session-operations-guide)
 - Vision / Runbook References:

--- a/tests/test_runner_features.py
+++ b/tests/test_runner_features.py
@@ -46,6 +46,8 @@ def test_pipeline_returns_runner_context_and_updates_strategy(runner: BacktestRu
 
     assert isinstance(ctx, RunnerContext)
     assert features.ctx is ctx
+    assert features.entry_ctx.session == "LDN"
+    assert features.entry_ctx.rv_band == ctx["rv_band"]
     assert runner.stg.runtime_ctx == ctx.to_dict()
     assert ctx["session"] == "LDN"
     assert "rv_band" in ctx
@@ -82,3 +84,5 @@ def test_pipeline_sanitises_invalid_micro_features(runner: BacktestRunner, monke
     assert features.pullback == 0.0
     assert ctx["threshold_lcb_pip"] == -1e9
     assert ctx["calibrating"] is True
+    assert features.entry_ctx.calibrating is True
+    assert features.entry_ctx.threshold_lcb_pip == -1e9


### PR DESCRIPTION
## Summary
- introduce typed EntryContext/EVContext/SizingContext and snapshot helpers so runner gates operate on structured attributes
- update BacktestRunner, FeaturePipeline, and execution flow to construct and propagate the new dataclasses
- refresh runner unit tests and state log to validate attribute-based contexts

## Testing
- `python3 -m pytest tests/test_runner_features.py tests/test_runner.py`


------
https://chatgpt.com/codex/tasks/task_e_68e3938c5884832ab3723379eb8ef217