### PR TITLE
Refine entry gate pipeline with typed evaluation results

### DIFF
--- a/core/runner.py
+++ b/core/runner.py
@@ -25,9 +25,9 @@ from core.runner_entry import (
     EntryGate,
     EVGate,
     SizingGate,
-    EntryEvaluation,
-    EVEvaluation,
-    SizingEvaluation,
+    EntryEvaluationResult,
+    EVEvaluationResult,
+    SizingEvaluationResult,
     TradeContextSnapshot,
     build_trade_context_snapshot,
     EntryContext,
@@ -944,19 +944,19 @@ class BacktestRunner:
         *,
         pending: Any,
         features: FeatureBundle,
-    ) -> EntryEvaluation:
+    ) -> EntryEvaluationResult:
         return EntryGate(self).evaluate(pending=pending, features=features)
 
     def _evaluate_ev_threshold(
         self,
         *,
-        ctx: EntryContext,
+        entry: EntryEvaluationResult,
         pending: Any,
         calibrating: bool,
         timestamp: Optional[str],
-    ) -> EVEvaluation:
+    ) -> EVEvaluationResult:
         return EVGate(self).evaluate(
-            ctx=ctx,
+            entry=entry,
             pending=pending,
             calibrating=calibrating,
             timestamp=timestamp,
@@ -966,14 +966,12 @@ class BacktestRunner:
         self,
         *,
         ctx: EVContext,
-        pending: Any,
-        ev_result: EVEvaluation,
+        ev_result: EVEvaluationResult,
         calibrating: bool,
         timestamp: Optional[str],
-    ) -> SizingEvaluation:
+    ) -> SizingEvaluationResult:
         return SizingGate(self).evaluate(
             ctx=ctx,
-            pending=pending,
             ev_result=ev_result,
             calibrating=calibrating,
             timestamp=timestamp,

--- a/core/runner_entry.py
+++ b/core/runner_entry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import MutableMapping
 from dataclasses import dataclass, field
 from typing import Any, Dict, Mapping, Optional, Tuple, TYPE_CHECKING, Union
 
@@ -16,6 +17,19 @@ class GateCheckOutcome:
     passed: bool
     reason: Optional[str] = None
     metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+def _assign_optional(
+    mapping: MutableMapping[str, Any],
+    key: str,
+    value: Any,
+    *,
+    include_false: bool = True,
+) -> None:
+    if value is None or (value is False and not include_false):
+        mapping.pop(key, None)
+    else:
+        mapping[key] = value
 
 
 @dataclass
@@ -87,6 +101,33 @@ class EntryContext:
             data["calibrating"] = self.calibrating
         return data
 
+    def apply_to_mapping(self, mapping: MutableMapping[str, Any]) -> None:
+        mapping["session"] = self.session
+        mapping["spread_band"] = self.spread_band
+        mapping["rv_band"] = self.rv_band
+        mapping["slip_cap_pip"] = self.slip_cap_pip
+        mapping["threshold_lcb_pip"] = self.threshold_lcb_pip
+        mapping["or_atr_ratio"] = self.or_atr_ratio
+        mapping["min_or_atr_ratio"] = self.min_or_atr_ratio
+        mapping["allow_low_rv"] = self.allow_low_rv
+        mapping["warmup_left"] = self.warmup_left
+        mapping["warmup_mult"] = self.warmup_mult
+        mapping["cooldown_bars"] = self.cooldown_bars
+        mapping["ev_mode"] = self.ev_mode
+        mapping["size_floor_mult"] = self.size_floor_mult
+        mapping["base_cost_pips"] = self.base_cost_pips
+        mapping["expected_slip_pip"] = self.expected_slip_pip
+        mapping["cost_pips"] = self.cost_pips
+        mapping["equity"] = self.equity
+        mapping["pip_value"] = self.pip_value
+        mapping["sizing_cfg"] = self.sizing_cfg
+        mapping["ev_key"] = self.ev_key
+        mapping["ev_oco"] = self.ev_manager
+        _assign_optional(mapping, "allowed_sessions", self.allowed_sessions)
+        _assign_optional(mapping, "ev_profile_stats", self.ev_profile_stats)
+        _assign_optional(mapping, "news_freeze", self.news_freeze, include_false=False)
+        _assign_optional(mapping, "calibrating", self.calibrating, include_false=False)
+
 
 @dataclass
 class EVContext(EntryContext):
@@ -110,6 +151,13 @@ class EVContext(EntryContext):
         data["ev_bypass"] = self.bypass
         return data
 
+    def apply_to_mapping(self, mapping: MutableMapping[str, Any]) -> None:  # type: ignore[override]
+        super().apply_to_mapping(mapping)
+        _assign_optional(mapping, "ev_lcb", self.ev_lcb)
+        _assign_optional(mapping, "threshold_lcb", self.threshold_lcb)
+        _assign_optional(mapping, "ev_pass", self.ev_pass)
+        mapping["ev_bypass"] = self.bypass
+
 
 @dataclass
 class SizingContext(EVContext):
@@ -125,28 +173,46 @@ class SizingContext(EVContext):
             data["qty"] = self.qty
         return data
 
-
-@dataclass
-class EntryEvaluation:
-    outcome: GateCheckOutcome
-    context: Optional[EntryContext] = None
-    pending_side: Optional[str] = None
+    def apply_to_mapping(self, mapping: MutableMapping[str, Any]) -> None:  # type: ignore[override]
+        super().apply_to_mapping(mapping)
+        _assign_optional(mapping, "qty", self.qty)
 
 
 @dataclass
-class EVEvaluation:
+class EntryEvaluationResult:
     outcome: GateCheckOutcome
-    manager: Optional[Any] = None
-    ev_lcb: Optional[float] = None
-    threshold_lcb: Optional[float] = None
-    bypass: bool = False
-    context: Optional[EVContext] = None
+    context: EntryContext
+    pending_side: str
+    tp_pips: Optional[float]
+    sl_pips: Optional[float]
+
+    def apply_to(self, mapping: MutableMapping[str, Any]) -> None:
+        self.context.apply_to_mapping(mapping)
 
 
 @dataclass
-class SizingEvaluation:
+class EVEvaluationResult:
     outcome: GateCheckOutcome
-    context: Optional[SizingContext] = None
+    manager: Optional[Any]
+    context: EVContext
+    ev_lcb: float
+    threshold_lcb: float
+    bypass: bool
+    pending_side: str
+    tp_pips: Optional[float]
+    sl_pips: Optional[float]
+
+    def apply_to(self, mapping: MutableMapping[str, Any]) -> None:
+        self.context.apply_to_mapping(mapping)
+
+
+@dataclass
+class SizingEvaluationResult:
+    outcome: GateCheckOutcome
+    context: SizingContext
+
+    def apply_to(self, mapping: MutableMapping[str, Any]) -> None:
+        self.context.apply_to_mapping(mapping)
 
 
 @dataclass
@@ -227,11 +293,11 @@ class EntryGate:
     def __init__(self, runner: "BacktestRunner") -> None:
         self._runner = runner
 
-    def evaluate(self, *, pending: Any, features: "FeatureBundle") -> EntryEvaluation:
+    def evaluate(self, *, pending: Any, features: "FeatureBundle") -> EntryEvaluationResult:
         entry_ctx = features.entry_ctx
         if entry_ctx is None:
             raise ValueError("Feature bundle did not include an entry context")
-        pending_side, _, _ = self._runner._extract_pending_fields(pending)
+        pending_side, tp_pips, sl_pips = self._runner._extract_pending_fields(pending)
         gate_allowed, gate_reason = self._runner._call_strategy_gate(
             entry_ctx,
             pending,
@@ -259,14 +325,16 @@ class EntryGate:
                 rv_band=metadata.get("rv_band"),
                 allow_low_rv=entry_ctx.allow_low_rv,
             )
-            return EntryEvaluation(
+            return EntryEvaluationResult(
                 outcome=GateCheckOutcome(
                     passed=False,
                     reason="strategy_gate",
                     metadata=metadata,
                 ),
-                context=None,
+                context=entry_ctx,
                 pending_side=pending_side,
+                tp_pips=tp_pips,
+                sl_pips=sl_pips,
             )
         if not pass_gates(entry_ctx.to_mapping()):
             self._runner.debug_counts["gate_block"] += 1
@@ -285,20 +353,24 @@ class EntryGate:
                 or_atr_ratio=entry_ctx.or_atr_ratio,
                 reason="router_gate",
             )
-            return EntryEvaluation(
+            return EntryEvaluationResult(
                 outcome=GateCheckOutcome(
                     passed=False,
                     reason="router_gate",
                     metadata=metadata,
                 ),
-                context=None,
+                context=entry_ctx,
                 pending_side=pending_side,
+                tp_pips=tp_pips,
+                sl_pips=sl_pips,
             )
         self._runner._increment_daily("gate_pass")
-        return EntryEvaluation(
+        return EntryEvaluationResult(
             outcome=GateCheckOutcome(passed=True),
             context=entry_ctx,
             pending_side=pending_side,
+            tp_pips=tp_pips,
+            sl_pips=sl_pips,
         )
 
 
@@ -309,12 +381,15 @@ class EVGate:
     def evaluate(
         self,
         *,
-        ctx: EntryContext,
+        entry: EntryEvaluationResult,
         pending: Any,
         calibrating: bool,
         timestamp: Optional[str],
-    ) -> EVEvaluation:
-        pending_side, tp_pips, sl_pips = self._runner._extract_pending_fields(pending)
+    ) -> EVEvaluationResult:
+        ctx = entry.context
+        pending_side = entry.pending_side
+        tp_pips = entry.tp_pips
+        sl_pips = entry.sl_pips
         ev_key = ctx.ev_key
         ev_mgr = ctx.ev_manager
         ev_mode_value = str(ctx.ev_mode).lower()
@@ -375,7 +450,7 @@ class EVGate:
                 ev_ctx.ev_lcb = ev_lcb
                 ev_ctx.ev_pass = False
                 ev_ctx.bypass = False
-                return EVEvaluation(
+                return EVEvaluationResult(
                     outcome=GateCheckOutcome(
                         passed=False,
                         reason="ev_reject",
@@ -385,10 +460,13 @@ class EVGate:
                         },
                     ),
                     manager=ev_mgr,
+                    context=ev_ctx,
                     ev_lcb=ev_lcb,
                     threshold_lcb=threshold_lcb,
                     bypass=False,
-                    context=ev_ctx,
+                    pending_side=pending_side,
+                    tp_pips=tp_pips,
+                    sl_pips=sl_pips,
                 )
         else:
             self._runner._increment_daily("ev_pass")
@@ -398,13 +476,16 @@ class EVGate:
         ev_ctx.ev_lcb = ev_lcb
         ev_ctx.ev_pass = not ev_bypass
         ev_ctx.bypass = ev_bypass
-        return EVEvaluation(
+        return EVEvaluationResult(
             outcome=GateCheckOutcome(passed=True),
             manager=ev_mgr,
+            context=ev_ctx,
             ev_lcb=ev_lcb,
             threshold_lcb=threshold_lcb,
             bypass=ev_bypass,
-            context=ev_ctx,
+            pending_side=pending_side,
+            tp_pips=tp_pips,
+            sl_pips=sl_pips,
         )
 
 
@@ -416,13 +497,14 @@ class SizingGate:
         self,
         *,
         ctx: EVContext,
-        pending: Any,
-        ev_result: EVEvaluation,
+        ev_result: EVEvaluationResult,
         calibrating: bool,
         timestamp: Optional[str],
-    ) -> SizingEvaluation:
+    ) -> SizingEvaluationResult:
         sizing_ctx = SizingContext.from_ev(ctx)
-        pending_side, tp_pips, sl_pips = self._runner._extract_pending_fields(pending)
+        pending_side = ev_result.pending_side
+        tp_pips = ev_result.tp_pips
+        sl_pips = ev_result.sl_pips
         slip_cap = sizing_ctx.slip_cap_pip
         expected_slip = sizing_ctx.expected_slip_pip
         if expected_slip > slip_cap:
@@ -439,7 +521,7 @@ class SizingGate:
                 expected_slip_pip=expected_slip,
                 slip_cap_pip=slip_cap,
             )
-            return SizingEvaluation(
+            return SizingEvaluationResult(
                 outcome=GateCheckOutcome(
                     passed=False,
                     reason="slip_cap",
@@ -468,7 +550,7 @@ class SizingGate:
             sizing_ctx.qty = qty_dbg
             if qty_dbg <= 0:
                 self._runner.debug_counts["zero_qty"] += 1
-                return SizingEvaluation(
+                return SizingEvaluationResult(
                     outcome=GateCheckOutcome(
                         passed=False,
                         reason="zero_qty",
@@ -476,7 +558,7 @@ class SizingGate:
                     ),
                     context=sizing_ctx,
                 )
-        return SizingEvaluation(
+        return SizingEvaluationResult(
             outcome=GateCheckOutcome(passed=True),
             context=sizing_ctx,
         )

--- a/core/runner_execution.py
+++ b/core/runner_execution.py
@@ -197,31 +197,30 @@ class RunnerExecutionManager:
             pending=pending,
             features=features,
         )
-        if not entry_result.outcome.passed or entry_result.context is None:
+        if not entry_result.outcome.passed:
             return
         entry_ctx = entry_result.context
-        features.ctx.update(entry_ctx.to_mapping())
+        entry_result.apply_to(features.ctx)
         ev_result = runner._evaluate_ev_threshold(
-            ctx=entry_ctx,
+            entry=entry_result,
             pending=pending,
             calibrating=calibrating,
             timestamp=runner._last_timestamp,
         )
         if not ev_result.outcome.passed:
             return
-        ev_ctx = ev_result.context or EVContext.from_entry(entry_ctx)
-        features.ctx.update(ev_ctx.to_mapping())
+        ev_ctx = ev_result.context
+        ev_result.apply_to(features.ctx)
         sizing_result = runner._check_slip_and_sizing(
             ctx=ev_ctx,
-            pending=pending,
             ev_result=ev_result,
             calibrating=calibrating,
             timestamp=runner._last_timestamp,
         )
         if not sizing_result.outcome.passed:
             return
-        sizing_ctx = sizing_result.context or SizingContext.from_ev(ev_ctx)
-        features.ctx.update(sizing_ctx.to_mapping())
+        sizing_ctx = sizing_result.context
+        sizing_result.apply_to(features.ctx)
         intents = list(runner.stg.signals())
         if not intents:
             runner.debug_counts["gate_block"] += 1

--- a/state.md
+++ b/state.md
@@ -2,6 +2,11 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
+- 2026-03-11: Introduced `EntryEvaluationResult` / `EVEvaluationResult` / `SizingEvaluationResult`
+  dataclasses for entry gating, updated `BacktestRunner` and `RunnerExecutionManager`
+  to pass typed stage outcomes without optional context checks or dictionary copies,
+  and refreshed `tests/test_runner.py` to exercise pipeline success and failure paths
+  via the structured results. Ran `python3 -m pytest tests/test_runner.py`.
 - 2026-03-08: Split `BacktestRunner` responsibilities into `RunnerLifecycleManager`
   and `RunnerExecutionManager`, moved position state helpers into `core/runner_state.py`,
   refreshed runner/CLI regression tests for the delegation, and updated lifecycle

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -22,11 +22,11 @@ from core.runner_lifecycle import RunnerLifecycleManager
 from core.runner_entry import (
     EntryGate,
     EVGate,
-    EntryEvaluation,
+    EntryEvaluationResult,
     SizingGate,
     GateCheckOutcome,
-    EVEvaluation,
-    SizingEvaluation,
+    EVEvaluationResult,
+    SizingEvaluationResult,
     TradeContextSnapshot,
     EntryContext,
     EVContext,
@@ -887,18 +887,20 @@ class TestRunner(unittest.TestCase):
         ev_ctx.ev_lcb = 0.0
         ev_ctx.threshold_lcb = 0.0
         ev_ctx.ev_pass = True
-        ev_result = EVEvaluation(
+        ev_result = EVEvaluationResult(
             outcome=GateCheckOutcome(passed=True),
             manager=ev_mgr,
+            context=ev_ctx,
             ev_lcb=0.0,
             threshold_lcb=0.0,
             bypass=False,
-            context=ev_ctx,
+            pending_side=pending["side"],
+            tp_pips=pending["tp_pips"],
+            sl_pips=pending["sl_pips"],
         )
 
         result = sizing_gate.evaluate(
             ctx=ev_ctx,
-            pending=pending,
             ev_result=ev_result,
             calibrating=False,
             timestamp="2024-01-01T00:00:00Z",
@@ -953,18 +955,20 @@ class TestRunner(unittest.TestCase):
         ev_ctx.ev_lcb = 0.0
         ev_ctx.threshold_lcb = 0.0
         ev_ctx.ev_pass = True
-        ev_result = EVEvaluation(
+        ev_result = EVEvaluationResult(
             outcome=GateCheckOutcome(passed=True),
             manager=ev_mgr,
+            context=ev_ctx,
             ev_lcb=0.0,
             threshold_lcb=0.0,
             bypass=False,
-            context=ev_ctx,
+            pending_side=pending["side"],
+            tp_pips=pending["tp_pips"],
+            sl_pips=pending["sl_pips"],
         )
 
         result = sizing_gate.evaluate(
             ctx=ev_ctx,
-            pending=pending,
             ev_result=ev_result,
             calibrating=False,
             timestamp="2024-01-01T00:05:00Z",
@@ -1144,12 +1148,10 @@ class TestRunner(unittest.TestCase):
             features=features,
         )
         self.assertTrue(entry_result.outcome.passed)
-        entry_ctx = entry_result.context
-        self.assertIsNotNone(entry_ctx)
-        assert entry_ctx is not None
+        self.assertIs(entry_result.context, features.entry_ctx)
         ev_gate = EVGate(runner)
         ev_result = ev_gate.evaluate(
-            ctx=entry_ctx,
+            entry=entry_result,
             pending=pending,
             calibrating=calibrating,
             timestamp=runner._last_timestamp,
@@ -1158,13 +1160,10 @@ class TestRunner(unittest.TestCase):
         self.assertIs(ev_result.manager, stub_ev)
         self.assertGreater(ev_result.ev_lcb, ev_result.threshold_lcb)
         self.assertFalse(ev_result.bypass)
-        self.assertIsNotNone(ev_result.context)
-        assert ev_result.context is not None
         self.assertTrue(ev_result.context.ev_pass)
         sizing_gate = SizingGate(runner)
         sizing_result = sizing_gate.evaluate(
             ctx=ev_result.context,
-            pending=pending,
             ev_result=ev_result,
             calibrating=calibrating,
             timestamp=runner._last_timestamp,
@@ -1185,11 +1184,8 @@ class TestRunner(unittest.TestCase):
             features=features,
         )
         self.assertTrue(entry_result.outcome.passed)
-        entry_ctx = entry_result.context
-        self.assertIsNotNone(entry_ctx)
-        assert entry_ctx is not None
         ev_result = EVGate(runner).evaluate(
-            ctx=entry_ctx,
+            entry=entry_result,
             pending=pending,
             calibrating=calibrating,
             timestamp=runner._last_timestamp,
@@ -1213,12 +1209,9 @@ class TestRunner(unittest.TestCase):
             features=features,
         )
         self.assertTrue(entry_result.outcome.passed)
-        entry_ctx = entry_result.context
-        self.assertIsNotNone(entry_ctx)
-        assert entry_ctx is not None
-        self.assertEqual(entry_ctx.ev_mode, "off")
+        self.assertEqual(entry_result.context.ev_mode, "off")
         ev_result = EVGate(runner).evaluate(
-            ctx=entry_ctx,
+            entry=entry_result,
             pending=pending,
             calibrating=calibrating,
             timestamp=runner._last_timestamp,
@@ -1229,9 +1222,7 @@ class TestRunner(unittest.TestCase):
         self.assertTrue(math.isinf(ev_result.threshold_lcb))
         self.assertLess(ev_result.threshold_lcb, 0.0)
         ev_ctx = ev_result.context
-        self.assertIsNotNone(ev_ctx)
-        assert ev_ctx is not None
-        self.assertTrue(math.isinf(entry_ctx.threshold_lcb_pip))
+        self.assertTrue(math.isinf(entry_result.context.threshold_lcb_pip))
         self.assertEqual(ev_ctx.threshold_lcb, ev_result.threshold_lcb)
         self.assertTrue(ev_ctx.ev_pass)
         self.assertEqual(runner.debug_counts["ev_reject"], 0)
@@ -1254,11 +1245,8 @@ class TestRunner(unittest.TestCase):
             features=features,
         )
         self.assertTrue(entry_result.outcome.passed)
-        entry_ctx = entry_result.context
-        self.assertIsNotNone(entry_ctx)
-        assert entry_ctx is not None
         ev_result = EVGate(runner).evaluate(
-            ctx=entry_ctx,
+            entry=entry_result,
             pending=intent,
             calibrating=calibrating,
             timestamp=runner._last_timestamp,
@@ -1266,8 +1254,6 @@ class TestRunner(unittest.TestCase):
         self.assertFalse(ev_result.outcome.passed)
         self.assertEqual(runner.debug_counts["ev_reject"], 1)
         ev_ctx = ev_result.context
-        self.assertIsNotNone(ev_ctx)
-        assert ev_ctx is not None
         if ev_ctx.expected_slip_pip is None:
             ev_ctx.expected_slip_pip = 0.0
         ev_ctx.slip_cap_pip = runner.rcfg.slip_cap_pip
@@ -1275,17 +1261,19 @@ class TestRunner(unittest.TestCase):
             ev_ctx.cost_pips = 0.0
         sizing_gate = SizingGate(runner)
         with patch("core.runner_entry.compute_qty_from_ctx", return_value=1.0) as mock_compute:
-            forced_ev_result = EVEvaluation(
+            forced_ev_result = EVEvaluationResult(
                 outcome=GateCheckOutcome(passed=True),
                 manager=stub_ev,
+                context=ev_ctx,
                 ev_lcb=ev_result.ev_lcb,
                 threshold_lcb=ev_result.threshold_lcb,
                 bypass=False,
-                context=ev_ctx,
+                pending_side=entry_result.pending_side,
+                tp_pips=entry_result.tp_pips,
+                sl_pips=entry_result.sl_pips,
             )
             sizing_result = sizing_gate.evaluate(
                 ctx=ev_ctx,
-                pending=intent,
                 ev_result=forced_ev_result,
                 calibrating=False,
                 timestamp=runner._last_timestamp,
@@ -1312,11 +1300,8 @@ class TestRunner(unittest.TestCase):
             features=features,
         )
         self.assertTrue(entry_result.outcome.passed)
-        entry_ctx = entry_result.context
-        self.assertIsNotNone(entry_ctx)
-        assert entry_ctx is not None
         ev_result = EVGate(runner).evaluate(
-            ctx=entry_ctx,
+            entry=entry_result,
             pending=pending,
             calibrating=calibrating,
             timestamp=runner._last_timestamp,
@@ -1324,12 +1309,9 @@ class TestRunner(unittest.TestCase):
         self.assertTrue(ev_result.outcome.passed)
         self.assertTrue(ev_result.bypass)
         ev_ctx = ev_result.context
-        self.assertIsNotNone(ev_ctx)
-        assert ev_ctx is not None
         self.assertFalse(ev_ctx.ev_pass)
         sizing_result = SizingGate(runner).evaluate(
             ctx=ev_ctx,
-            pending=pending,
             ev_result=ev_result,
             calibrating=calibrating,
             timestamp=runner._last_timestamp,
@@ -1353,10 +1335,12 @@ class TestRunner(unittest.TestCase):
             warmup_left=0
         )
         pip_value = pip_size(runner.symbol)
-        fail_result = EntryEvaluation(
+        fail_result = EntryEvaluationResult(
             outcome=GateCheckOutcome(passed=False, reason="router_gate"),
-            context=None,
+            context=features.entry_ctx,
             pending_side=pending["side"],
+            tp_pips=pending["tp_pips"],
+            sl_pips=pending["sl_pips"],
         )
         with patch.object(runner.stg, "on_bar", return_value=None):
             runner.stg._pending_signal = pending
@@ -1401,20 +1385,28 @@ class TestRunner(unittest.TestCase):
         ev_ctx.threshold_lcb = 0.6
         ev_ctx.ev_pass = True
         sizing_ctx = SizingContext.from_ev(ev_ctx)
-        entry_result = EntryEvaluation(
+        entry_result = EntryEvaluationResult(
             outcome=GateCheckOutcome(passed=True),
             context=entry_ctx,
             pending_side=pending["side"],
+            tp_pips=pending["tp_pips"],
+            sl_pips=pending["sl_pips"],
         )
-        ev_result = EVEvaluation(
+        ev_result = EVEvaluationResult(
             outcome=GateCheckOutcome(passed=True),
             manager=stub_ev,
+            context=ev_ctx,
             ev_lcb=1.2,
             threshold_lcb=0.6,
             bypass=False,
-            context=ev_ctx,
+            pending_side=pending["side"],
+            tp_pips=pending["tp_pips"],
+            sl_pips=pending["sl_pips"],
         )
-        sizing_result = SizingEvaluation(GateCheckOutcome(passed=True), context=sizing_ctx)
+        sizing_result = SizingEvaluationResult(
+            outcome=GateCheckOutcome(passed=True),
+            context=sizing_ctx,
+        )
         intent = OrderIntent(
             pending["side"],
             qty=1.0,
@@ -1515,7 +1507,10 @@ class TestRunner(unittest.TestCase):
 
         with patch(
             "core.runner_entry.SizingGate.evaluate",
-            side_effect=lambda **_: SizingEvaluation(GateCheckOutcome(True)),
+            side_effect=lambda **_: SizingEvaluationResult(
+                outcome=GateCheckOutcome(True),
+                context=SizingContext.from_ev(EVContext.from_entry(features.entry_ctx)),
+            ),
         ):
             with patch.object(runner.stg, "signals", return_value=[intent]):
                 with patch.object(runner.execution, "process_fill_result") as mock_process:
@@ -1561,7 +1556,10 @@ class TestRunner(unittest.TestCase):
 
         with patch(
             "core.runner_entry.SizingGate.evaluate",
-            side_effect=lambda **_: SizingEvaluation(GateCheckOutcome(True)),
+            side_effect=lambda **_: SizingEvaluationResult(
+                outcome=GateCheckOutcome(True),
+                context=SizingContext.from_ev(EVContext.from_entry(features.entry_ctx)),
+            ),
         ):
             with patch.object(runner.stg, "signals", return_value=[intent]):
                 with patch.object(
@@ -1613,7 +1611,10 @@ class TestRunner(unittest.TestCase):
 
         with patch(
             "core.runner_entry.SizingGate.evaluate",
-            side_effect=lambda **_: SizingEvaluation(GateCheckOutcome(True)),
+            side_effect=lambda **_: SizingEvaluationResult(
+                outcome=GateCheckOutcome(True),
+                context=SizingContext.from_ev(EVContext.from_entry(features.entry_ctx)),
+            ),
         ):
             with patch.object(runner.stg, "signals", return_value=[intent]):
                 with patch.object(


### PR DESCRIPTION
## Summary
- add EntryEvaluationResult, EVEvaluationResult, and SizingEvaluationResult dataclasses to provide typed stage outputs and context propagation helpers
- refactor BacktestRunner and RunnerExecutionManager entry flow to compose the new results without optional context checks or dictionary copies
- update tests/test_runner.py to cover success and failure paths using the structured results

## Testing
- python3 -m pytest tests/test_runner.py

------
https://chatgpt.com/codex/tasks/task_e_68e3a7964bd8832a8304ebc4cc60216c