### PR TITLE
Propagate gate-adjusted TP/SL through EV and sizing

### DIFF
--- a/core/runner.py
+++ b/core/runner.py
@@ -25,9 +25,9 @@ from core.runner_entry import (
     EntryGate,
     EVGate,
     SizingGate,
-    EntryEvaluation,
-    EVEvaluation,
-    SizingEvaluation,
+    EntryEvaluationResult,
+    EVEvaluationResult,
+    SizingEvaluationResult,
     TradeContextSnapshot,
     build_trade_context_snapshot,
     EntryContext,
@@ -944,19 +944,19 @@ class BacktestRunner:
         *,
         pending: Any,
         features: FeatureBundle,
-    ) -> EntryEvaluation:
+    ) -> EntryEvaluationResult:
         return EntryGate(self).evaluate(pending=pending, features=features)
 
     def _evaluate_ev_threshold(
         self,
         *,
-        ctx: EntryContext,
+        entry: EntryEvaluationResult,
         pending: Any,
         calibrating: bool,
         timestamp: Optional[str],
-    ) -> EVEvaluation:
+    ) -> EVEvaluationResult:
         return EVGate(self).evaluate(
-            ctx=ctx,
+            entry=entry,
             pending=pending,
             calibrating=calibrating,
             timestamp=timestamp,
@@ -966,14 +966,12 @@ class BacktestRunner:
         self,
         *,
         ctx: EVContext,
-        pending: Any,
-        ev_result: EVEvaluation,
+        ev_result: EVEvaluationResult,
         calibrating: bool,
         timestamp: Optional[str],
-    ) -> SizingEvaluation:
+    ) -> SizingEvaluationResult:
         return SizingGate(self).evaluate(
             ctx=ctx,
-            pending=pending,
             ev_result=ev_result,
             calibrating=calibrating,
             timestamp=timestamp,

--- a/core/runner_execution.py
+++ b/core/runner_execution.py
@@ -197,31 +197,30 @@ class RunnerExecutionManager:
             pending=pending,
             features=features,
         )
-        if not entry_result.outcome.passed or entry_result.context is None:
+        if not entry_result.outcome.passed:
             return
         entry_ctx = entry_result.context
-        features.ctx.update(entry_ctx.to_mapping())
+        entry_result.apply_to(features.ctx)
         ev_result = runner._evaluate_ev_threshold(
-            ctx=entry_ctx,
+            entry=entry_result,
             pending=pending,
             calibrating=calibrating,
             timestamp=runner._last_timestamp,
         )
         if not ev_result.outcome.passed:
             return
-        ev_ctx = ev_result.context or EVContext.from_entry(entry_ctx)
-        features.ctx.update(ev_ctx.to_mapping())
+        ev_ctx = ev_result.context
+        ev_result.apply_to(features.ctx)
         sizing_result = runner._check_slip_and_sizing(
             ctx=ev_ctx,
-            pending=pending,
             ev_result=ev_result,
             calibrating=calibrating,
             timestamp=runner._last_timestamp,
         )
         if not sizing_result.outcome.passed:
             return
-        sizing_ctx = sizing_result.context or SizingContext.from_ev(ev_ctx)
-        features.ctx.update(sizing_ctx.to_mapping())
+        sizing_ctx = sizing_result.context
+        sizing_result.apply_to(features.ctx)
         intents = list(runner.stg.signals())
         if not intents:
             runner.debug_counts["gate_block"] += 1

--- a/state.md
+++ b/state.md
@@ -2,6 +2,15 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
+- 2026-03-12: Re-synced entry/EV/sizing pipelines so strategy-gate TP/SL
+  adjustments propagate to EV threshold and sizing calculations by re-running
+  `_extract_pending_fields` post-gate, and added a regression covering mutated
+  pending signals. Ran `python3 -m pytest tests/test_runner.py`.
+- 2026-03-11: Introduced `EntryEvaluationResult` / `EVEvaluationResult` / `SizingEvaluationResult`
+  dataclasses for entry gating, updated `BacktestRunner` and `RunnerExecutionManager`
+  to pass typed stage outcomes without optional context checks or dictionary copies,
+  and refreshed `tests/test_runner.py` to exercise pipeline success and failure paths
+  via the structured results. Ran `python3 -m pytest tests/test_runner.py`.
 - 2026-03-08: Split `BacktestRunner` responsibilities into `RunnerLifecycleManager`
   and `RunnerExecutionManager`, moved position state helpers into `core/runner_state.py`,
   refreshed runner/CLI regression tests for the delegation, and updated lifecycle


### PR DESCRIPTION
## Summary
- re-run pending field extraction after the strategy gate so entry results retain any TP/SL adjustments
- refresh EV evaluation to read the latest pending parameters and add a regression that ensures sizing sees the updated values
- document the pipeline fix in state.md for session history

## Testing
- python3 -m pytest tests/test_runner.py

------
https://chatgpt.com/codex/tasks/task_e_68e3a7964bd8832a8304ebc4cc60216c