### PR TITLE
Adopt context-aware signals API for strategies

### DIFF
--- a/core/runner_execution.py
+++ b/core/runner_execution.py
@@ -221,7 +221,7 @@ class RunnerExecutionManager:
             return
         sizing_ctx = sizing_result.context
         sizing_result.apply_to(features.ctx)
-        intents = list(runner.stg.signals())
+        intents = list(runner.stg.signals(features.ctx))
         if not intents:
             runner.debug_counts["gate_block"] += 1
             return

--- a/core/strategy_api.py
+++ b/core/strategy_api.py
@@ -4,7 +4,7 @@ Strategy API (Design v1.1 / ADR-012..025)
 from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Iterable, Optional, Dict, Any, List
+from typing import Iterable, Optional, Dict, Any, List, Mapping
 
 @dataclass
 class OrderIntent:
@@ -32,11 +32,21 @@ class Strategy(ABC):
         ...
 
     @abstractmethod
-    def signals(self) -> Iterable[OrderIntent]:
+    def signals(self, ctx: Optional[Mapping[str, Any]] = None) -> Iterable[OrderIntent]:
         ...
 
-    def update_context(self, ctx: Dict[str, Any]) -> None:
+    def update_context(self, ctx: Mapping[str, Any]) -> None:
         self._runtime_ctx = dict(ctx)
+
+    def resolve_runtime_context(
+        self, ctx: Optional[Mapping[str, Any]] = None
+    ) -> Dict[str, Any]:
+        """Return the latest runtime context while syncing optional overrides."""
+
+        if ctx is None:
+            return self.get_context()
+        self.update_context(ctx)
+        return self.get_context()
 
     @property
     def runtime_ctx(self) -> Dict[str, Any]:

--- a/state.md
+++ b/state.md
@@ -2,6 +2,10 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
+- 2026-03-14: Routed strategy runtime context through the new ``signals(ctx)``
+  API, updated DayORB5m/templates/mean reversion implementations plus runner
+  regressions, and refreshed strategy-facing tests for the call signature.
+  Ran ``python3 -m pytest``.
 - 2026-03-13: Refined the feature pipeline sanitisation by normalising optional
   opening range bounds, expanded `tests/test_runner_features.py` to cover
   realized volatility history updates, session resets, and mapping behaviour of

--- a/strategies/scalping_template.py
+++ b/strategies/scalping_template.py
@@ -16,7 +16,7 @@ Usage guidelines:
 """
 from __future__ import annotations
 
-from typing import Any, Dict, Iterable, Optional
+from typing import Any, Dict, Iterable, Optional, Mapping
 
 from core.sizing import compute_qty_from_ctx
 from core.strategy_api import OrderIntent, Strategy
@@ -73,20 +73,20 @@ class ScalpingTemplate(Strategy):
         self.state["last_signal_bar"] = self.state["bar_idx"]
 
     # ------------------------------------------------------------------ Strategy API
-    def signals(self) -> Iterable[OrderIntent]:
+    def signals(self, ctx: Optional[Mapping[str, Any]] = None) -> Iterable[OrderIntent]:
         if not self._pending_signal:
             return []
-        ctx = self.get_context()
-        if not pass_gates(ctx):
+        ctx_data = self.resolve_runtime_context(ctx)
+        if not pass_gates(ctx_data):
             return []
 
-        cooldown = int(ctx.get("cooldown_bars", self.cfg.get("cooldown_bars", 0)))
+        cooldown = int(ctx_data.get("cooldown_bars", self.cfg.get("cooldown_bars", 0)))
         if cooldown > 0 and (self.state["bar_idx"] - self.state["last_signal_bar"] < cooldown):
             return []
 
         signal = self._apply_signal_defaults(dict(self._pending_signal))
         sl_pips = max(0.1, float(signal.get("sl_pips", self.cfg.get("default_sl_pips", 6.0))))
-        qty = compute_qty_from_ctx(ctx, sl_pips)
+        qty = compute_qty_from_ctx(ctx_data, sl_pips)
         if qty <= 0:
             return []
 

--- a/tests/fixtures/strategies/forced_failure.py
+++ b/tests/fixtures/strategies/forced_failure.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Iterable, List
+from typing import Any, Dict, Iterable, List, Mapping, Optional
 
 from core.strategy_api import OrderIntent, Strategy
 
@@ -35,7 +35,9 @@ class DeterministicFailureStrategy(Strategy):
             "sl_pips": 5.0,
         }
 
-    def signals(self) -> Iterable[OrderIntent]:
+    def signals(self, ctx: Optional[Mapping[str, Any]] = None) -> Iterable[OrderIntent]:
+        if ctx is not None:
+            self.update_context(ctx)
         # Emit a deterministic intent so downstream sizing/fill paths remain stable.
         self._pending_signal = None
         return [

--- a/tests/test_ev_and_sizing.py
+++ b/tests/test_ev_and_sizing.py
@@ -96,9 +96,8 @@ class TestStrategyIntegration(unittest.TestCase):
         }
 
         # Attach ctx and emit
-        stg.update_context(ctx)
         stg.on_bar(breakout_bar)
-        sigs = list(stg.signals())
+        sigs = list(stg.signals(ctx))
         self.assertEqual(len(sigs), 1)
         self.assertGreater(sigs[0].qty, 0.0)
         self.assertIn("oco", sigs[0].__dict__)

--- a/tests/test_mean_reversion_strategy.py
+++ b/tests/test_mean_reversion_strategy.py
@@ -54,8 +54,7 @@ class MeanReversionStrategyTest(unittest.TestCase):
         self.assertIsNotNone(self.strategy._pending_signal)
         ctx = self._base_ctx()
         self.assertTrue(self.strategy.strategy_gate(ctx, self.strategy._pending_signal))
-        self.strategy.update_context(ctx)
-        intents = list(self.strategy.signals())
+        intents = list(self.strategy.signals(ctx))
         self.assertEqual(len(intents), 1)
         intent = intents[0]
         self.assertEqual(intent.side, "SELL")

--- a/tests/test_run_sim_cli.py
+++ b/tests/test_run_sim_cli.py
@@ -222,17 +222,17 @@ class TestRunSimCLI(unittest.TestCase):
                 "--no-aggregate-ev",
             ]
 
-            def _signals_wrapper(self):
-                intents = original_signals(self)
-                ctx = self.get_context()
-                if intents and ctx.get("ev_oco") is not None:
+            def _signals_wrapper(self, ctx=None):
+                intents = original_signals(self, ctx)
+                ctx_snapshot = self.resolve_runtime_context(ctx)
+                if intents and ctx_snapshot.get("ev_oco") is not None:
                     sig = intents[0]
                     expected = compute_qty_from_ctx(
-                        ctx,
+                        ctx_snapshot,
                         sig.oco["sl_pips"],
                         mode="production",
                         tp_pips=sig.oco["tp_pips"],
-                        p_lcb=ctx["ev_oco"].p_lcb(),
+                        p_lcb=ctx_snapshot["ev_oco"].p_lcb(),
                     )
                     qty_checks.append((sig.qty, expected))
                 return intents

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -2,7 +2,7 @@ import csv
 import math
 from contextlib import ExitStack
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Mapping
 import unittest
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
@@ -548,7 +548,9 @@ class TestRunner(unittest.TestCase):
                     oco={"tp_pips": 1.0, "sl_pips": 1.0},
                 )
 
-            def signals(self):
+            def signals(self, ctx: Optional[Mapping[str, object]] = None):
+                if ctx is not None:
+                    self.update_context(ctx)
                 if self._pending_signal is None:
                     return []
                 return [self._pending_signal]
@@ -1764,7 +1766,6 @@ class TestRunner(unittest.TestCase):
             }
         }
         stg.on_start(cfg, ["USDJPY"], {})
-        stg.update_context(cfg["ctx"])
         stg.state["bar_idx"] = 12
         stg._pending_signal = {
             "side": "SELL",
@@ -1774,7 +1775,7 @@ class TestRunner(unittest.TestCase):
             "entry": 149.75,
         }
 
-        first_batch = stg.signals()
+        first_batch = stg.signals(cfg["ctx"])
         self.assertEqual(len(first_batch), 1)
         self.assertEqual(stg.state["last_signal_bar"], 12)
         self.assertTrue(stg.state["broken"])
@@ -1788,7 +1789,7 @@ class TestRunner(unittest.TestCase):
             "entry": 149.65,
         }
 
-        second_batch = stg.signals()
+        second_batch = stg.signals(cfg["ctx"])
         self.assertEqual(second_batch, [])
         self.assertEqual(stg.state["last_signal_bar"], 12)
         self.assertTrue(stg.state["broken"])
@@ -1810,7 +1811,6 @@ class TestRunner(unittest.TestCase):
             }
         }
         stg.on_start(cfg, ["USDJPY"], {})
-        stg.update_context(cfg["ctx"])
         stg.state["bar_idx"] = 25
         stg._pending_signal = {
             "side": "BUY",
@@ -1820,7 +1820,7 @@ class TestRunner(unittest.TestCase):
             "entry": 150.25,
         }
 
-        first_batch = stg.signals()
+        first_batch = stg.signals(cfg["ctx"])
         self.assertEqual(len(first_batch), 1)
         self.assertEqual(stg.state["last_signal_bar"], 25)
         self.assertTrue(stg.state["broken"])
@@ -1834,7 +1834,7 @@ class TestRunner(unittest.TestCase):
             "entry": 150.35,
         }
 
-        second_batch = stg.signals()
+        second_batch = stg.signals(cfg["ctx"])
         self.assertEqual(second_batch, [])
         self.assertEqual(stg.state["last_signal_bar"], 25)
         self.assertTrue(stg.state["broken"])

--- a/tests/test_strategy_feature_integration.py
+++ b/tests/test_strategy_feature_integration.py
@@ -57,8 +57,6 @@ def test_tokyo_micro_mean_reversion_emits_signal_with_micro_features(scalping_ct
         ["USDJPY"],
         {},
     )
-    strategy.update_context(scalping_ctx)
-
     bar = {
         "o": 112.610,
         "h": 112.645,
@@ -74,7 +72,7 @@ def test_tokyo_micro_mean_reversion_emits_signal_with_micro_features(scalping_ct
     strategy.on_bar(bar)
 
     with patch("strategies.scalping_template.compute_qty_from_ctx", return_value=1.0):
-        intents = list(strategy.signals())
+        intents = list(strategy.signals(scalping_ctx))
 
     assert len(intents) == 1
     intent = intents[0]
@@ -99,8 +97,6 @@ def test_session_momentum_continuation_emits_signal_with_trend_features(day_ctx:
         ["USDJPY"],
         {},
     )
-    strategy.update_context(day_ctx)
-
     bar = {
         "o": 1.2035,
         "h": 1.2070,
@@ -117,7 +113,7 @@ def test_session_momentum_continuation_emits_signal_with_trend_features(day_ctx:
     strategy.on_bar(bar)
 
     with patch("strategies.day_template.compute_qty_from_ctx", return_value=2.0):
-        intents = list(strategy.signals())
+        intents = list(strategy.signals(day_ctx))
 
     assert len(intents) == 1
     intent = intents[0]


### PR DESCRIPTION
## Summary
- extend the core Strategy API with a context-aware `signals` signature and helper for resolving runtime context
- update the backtest runner and all strategy implementations to consume the injected context instead of relying on stored config copies
- align strategy-focused unit tests, fixtures, and state tracking with the new entry point for runtime context

## Testing
- python3 -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3b7805c38832a8b670669fc8d7fa4