### PR TITLE
Route runner context updates through the strategy API

### DIFF
--- a/core/runner_execution.py
+++ b/core/runner_execution.py
@@ -221,7 +221,8 @@ class RunnerExecutionManager:
             return
         sizing_ctx = sizing_result.context
         sizing_result.apply_to(features.ctx)
-        intents = list(runner.stg.signals(features.ctx))
+        runner.stg.update_context(features.ctx.to_dict())
+        intents = list(runner.stg.signals())
         if not intents:
             runner.debug_counts["gate_block"] += 1
             return

--- a/core/strategy_api.py
+++ b/core/strategy_api.py
@@ -36,6 +36,14 @@ class Strategy(ABC):
         ...
 
     def update_context(self, ctx: Mapping[str, Any]) -> None:
+        """Store the latest runtime context provided by the runner.
+
+        Sub-classes overriding this method should call
+        ``super().update_context(ctx)`` so the cached dictionary stays in sync
+        with the runner pipeline while allowing per-strategy bookkeeping to
+        hook into context changes.
+        """
+
         self._runtime_ctx = dict(ctx)
 
     def resolve_runtime_context(

--- a/state.md
+++ b/state.md
@@ -2,6 +2,10 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
+- 2026-03-15: Routed runner context updates through ``Strategy.update_context`` so
+  signals consume post-gate data without mutating ``cfg`` payloads, refreshed
+  DayORB5m-related regressions plus CLI/feature strategy tests for the API
+  change, and executed ``python3 -m pytest``.
 - 2026-03-14: Routed strategy runtime context through the new ``signals(ctx)``
   API, updated DayORB5m/templates/mean reversion implementations plus runner
   regressions, and refreshed strategy-facing tests for the call signature.

--- a/tests/test_ev_and_sizing.py
+++ b/tests/test_ev_and_sizing.py
@@ -97,7 +97,8 @@ class TestStrategyIntegration(unittest.TestCase):
 
         # Attach ctx and emit
         stg.on_bar(breakout_bar)
-        sigs = list(stg.signals(ctx))
+        stg.update_context(ctx)
+        sigs = list(stg.signals())
         self.assertEqual(len(sigs), 1)
         self.assertGreater(sigs[0].qty, 0.0)
         self.assertIn("oco", sigs[0].__dict__)

--- a/tests/test_mean_reversion_strategy.py
+++ b/tests/test_mean_reversion_strategy.py
@@ -54,7 +54,8 @@ class MeanReversionStrategyTest(unittest.TestCase):
         self.assertIsNotNone(self.strategy._pending_signal)
         ctx = self._base_ctx()
         self.assertTrue(self.strategy.strategy_gate(ctx, self.strategy._pending_signal))
-        intents = list(self.strategy.signals(ctx))
+        self.strategy.update_context(ctx)
+        intents = list(self.strategy.signals())
         self.assertEqual(len(intents), 1)
         intent = intents[0]
         self.assertEqual(intent.side, "SELL")

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1758,12 +1758,11 @@ class TestRunner(unittest.TestCase):
     @patch("strategies.day_orb_5m.pass_gates", return_value=True)
     def test_calibration_signal_updates_cooldown_state(self, _mock_pass_gates):
         stg = DayORB5m()
-        cfg = {
-            "ctx": {
-                "cooldown_bars": 2,
-                "calibrating": True,
-                "ev_mode": "lcb",
-            }
+        cfg = {}
+        ctx = {
+            "cooldown_bars": 2,
+            "calibrating": True,
+            "ev_mode": "lcb",
         }
         stg.on_start(cfg, ["USDJPY"], {})
         stg.state["bar_idx"] = 12
@@ -1774,8 +1773,8 @@ class TestRunner(unittest.TestCase):
             "trail_pips": 0.0,
             "entry": 149.75,
         }
-
-        first_batch = stg.signals(cfg["ctx"])
+        stg.update_context(ctx)
+        first_batch = stg.signals()
         self.assertEqual(len(first_batch), 1)
         self.assertEqual(stg.state["last_signal_bar"], 12)
         self.assertTrue(stg.state["broken"])
@@ -1788,8 +1787,8 @@ class TestRunner(unittest.TestCase):
             "trail_pips": 0.0,
             "entry": 149.65,
         }
-
-        second_batch = stg.signals(cfg["ctx"])
+        stg.update_context(ctx)
+        second_batch = stg.signals()
         self.assertEqual(second_batch, [])
         self.assertEqual(stg.state["last_signal_bar"], 12)
         self.assertTrue(stg.state["broken"])
@@ -1797,18 +1796,17 @@ class TestRunner(unittest.TestCase):
     @patch("strategies.day_orb_5m.pass_gates", return_value=True)
     def test_warmup_signal_respects_cooldown_and_session_block(self, _mock_pass_gates):
         stg = DayORB5m()
-        cfg = {
-            "ctx": {
-                "cooldown_bars": 2,
-                "warmup_left": 3,
-                "equity": 100_000.0,
-                "pip_value": 10.0,
-                "warmup_mult": 0.05,
-                "sizing_cfg": {
-                    "risk_per_trade_pct": 1.0,
-                    "units_cap": 10.0,
-                },
-            }
+        cfg = {}
+        ctx = {
+            "cooldown_bars": 2,
+            "warmup_left": 3,
+            "equity": 100_000.0,
+            "pip_value": 10.0,
+            "warmup_mult": 0.05,
+            "sizing_cfg": {
+                "risk_per_trade_pct": 1.0,
+                "units_cap": 10.0,
+            },
         }
         stg.on_start(cfg, ["USDJPY"], {})
         stg.state["bar_idx"] = 25
@@ -1819,8 +1817,8 @@ class TestRunner(unittest.TestCase):
             "trail_pips": 0.0,
             "entry": 150.25,
         }
-
-        first_batch = stg.signals(cfg["ctx"])
+        stg.update_context(ctx)
+        first_batch = stg.signals()
         self.assertEqual(len(first_batch), 1)
         self.assertEqual(stg.state["last_signal_bar"], 25)
         self.assertTrue(stg.state["broken"])
@@ -1833,8 +1831,8 @@ class TestRunner(unittest.TestCase):
             "trail_pips": 0.0,
             "entry": 150.35,
         }
-
-        second_batch = stg.signals(cfg["ctx"])
+        stg.update_context(ctx)
+        second_batch = stg.signals()
         self.assertEqual(second_batch, [])
         self.assertEqual(stg.state["last_signal_bar"], 25)
         self.assertTrue(stg.state["broken"])

--- a/tests/test_strategy_feature_integration.py
+++ b/tests/test_strategy_feature_integration.py
@@ -72,7 +72,8 @@ def test_tokyo_micro_mean_reversion_emits_signal_with_micro_features(scalping_ct
     strategy.on_bar(bar)
 
     with patch("strategies.scalping_template.compute_qty_from_ctx", return_value=1.0):
-        intents = list(strategy.signals(scalping_ctx))
+        strategy.update_context(scalping_ctx)
+        intents = list(strategy.signals())
 
     assert len(intents) == 1
     intent = intents[0]
@@ -113,7 +114,8 @@ def test_session_momentum_continuation_emits_signal_with_trend_features(day_ctx:
     strategy.on_bar(bar)
 
     with patch("strategies.day_template.compute_qty_from_ctx", return_value=2.0):
-        intents = list(strategy.signals(day_ctx))
+        strategy.update_context(day_ctx)
+        intents = list(strategy.signals())
 
     assert len(intents) == 1
     intent = intents[0]


### PR DESCRIPTION
## Summary
- pass the fully-evaluated runner context to strategies via `Strategy.update_context` before invoking `signals`
- refresh DayORB5m and mean reversion strategy tests to drive signals through the new context flow
- document the runtime hand-off change in `state.md`

## Testing
- python3 -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3bc8c84e4832aa7c722c9f821a147