### PR TITLE
Rename runner evaluation dataclasses to Entry/EVE/Sizing

### DIFF
--- a/core/runner.py
+++ b/core/runner.py
@@ -25,9 +25,9 @@ from core.runner_entry import (
     EntryGate,
     EVGate,
     SizingGate,
-    EntryEvaluationResult,
-    EVEvaluationResult,
-    SizingEvaluationResult,
+    EntryEvaluation,
+    EVEvaluation,
+    SizingEvaluation,
     TradeContextSnapshot,
     build_trade_context_snapshot,
     EntryContext,
@@ -944,17 +944,17 @@ class BacktestRunner:
         *,
         pending: Any,
         features: FeatureBundle,
-    ) -> EntryEvaluationResult:
+    ) -> EntryEvaluation:
         return EntryGate(self).evaluate(pending=pending, features=features)
 
     def _evaluate_ev_threshold(
         self,
         *,
-        entry: EntryEvaluationResult,
+        entry: EntryEvaluation,
         pending: Any,
         calibrating: bool,
         timestamp: Optional[str],
-    ) -> EVEvaluationResult:
+    ) -> EVEvaluation:
         return EVGate(self).evaluate(
             entry=entry,
             pending=pending,
@@ -966,10 +966,10 @@ class BacktestRunner:
         self,
         *,
         ctx: EVContext,
-        ev_result: EVEvaluationResult,
+        ev_result: EVEvaluation,
         calibrating: bool,
         timestamp: Optional[str],
-    ) -> SizingEvaluationResult:
+    ) -> SizingEvaluation:
         return SizingGate(self).evaluate(
             ctx=ctx,
             ev_result=ev_result,

--- a/state.md
+++ b/state.md
@@ -2,6 +2,9 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
+- 2025-10-06: Renamed the runner entry/EV/sizing evaluation dataclasses to `EntryEvaluation` / `EVEvaluation` / `SizingEvaluation`,
+  updated BacktestRunner pipelines and regression tests to consume the new names, and ran
+  `python3 -m pytest tests/test_runner.py` to confirm the refactor.
 - 2026-03-15: Routed runner context updates through ``Strategy.update_context`` so
   signals consume post-gate data without mutating ``cfg`` payloads, refreshed
   DayORB5m-related regressions plus CLI/feature strategy tests for the API

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -23,11 +23,11 @@ from core.runner_lifecycle import RunnerLifecycleManager
 from core.runner_entry import (
     EntryGate,
     EVGate,
-    EntryEvaluationResult,
+    EntryEvaluation,
     SizingGate,
     GateCheckOutcome,
-    EVEvaluationResult,
-    SizingEvaluationResult,
+    EVEvaluation,
+    SizingEvaluation,
     TradeContextSnapshot,
     EntryContext,
     EVContext,
@@ -892,7 +892,7 @@ class TestRunner(unittest.TestCase):
         ev_ctx.ev_lcb = 0.0
         ev_ctx.threshold_lcb = 0.0
         ev_ctx.ev_pass = True
-        ev_result = EVEvaluationResult(
+        ev_result = EVEvaluation(
             outcome=GateCheckOutcome(passed=True),
             manager=ev_mgr,
             context=ev_ctx,
@@ -960,7 +960,7 @@ class TestRunner(unittest.TestCase):
         ev_ctx.ev_lcb = 0.0
         ev_ctx.threshold_lcb = 0.0
         ev_ctx.ev_pass = True
-        ev_result = EVEvaluationResult(
+        ev_result = EVEvaluation(
             outcome=GateCheckOutcome(passed=True),
             manager=ev_mgr,
             context=ev_ctx,
@@ -1266,7 +1266,7 @@ class TestRunner(unittest.TestCase):
             ev_ctx.cost_pips = 0.0
         sizing_gate = SizingGate(runner)
         with patch("core.runner_entry.compute_qty_from_ctx", return_value=1.0) as mock_compute:
-            forced_ev_result = EVEvaluationResult(
+            forced_ev_result = EVEvaluation(
                 outcome=GateCheckOutcome(passed=True),
                 manager=stub_ev,
                 context=ev_ctx,
@@ -1409,7 +1409,7 @@ class TestRunner(unittest.TestCase):
             warmup_left=0
         )
         pip_value = pip_size(runner.symbol)
-        fail_result = EntryEvaluationResult(
+        fail_result = EntryEvaluation(
             outcome=GateCheckOutcome(passed=False, reason="router_gate"),
             context=features.entry_ctx,
             pending_side=pending["side"],
@@ -1459,14 +1459,14 @@ class TestRunner(unittest.TestCase):
         ev_ctx.threshold_lcb = 0.6
         ev_ctx.ev_pass = True
         sizing_ctx = SizingContext.from_ev(ev_ctx)
-        entry_result = EntryEvaluationResult(
+        entry_result = EntryEvaluation(
             outcome=GateCheckOutcome(passed=True),
             context=entry_ctx,
             pending_side=pending["side"],
             tp_pips=pending["tp_pips"],
             sl_pips=pending["sl_pips"],
         )
-        ev_result = EVEvaluationResult(
+        ev_result = EVEvaluation(
             outcome=GateCheckOutcome(passed=True),
             manager=stub_ev,
             context=ev_ctx,
@@ -1477,7 +1477,7 @@ class TestRunner(unittest.TestCase):
             tp_pips=pending["tp_pips"],
             sl_pips=pending["sl_pips"],
         )
-        sizing_result = SizingEvaluationResult(
+        sizing_result = SizingEvaluation(
             outcome=GateCheckOutcome(passed=True),
             context=sizing_ctx,
         )
@@ -1581,7 +1581,7 @@ class TestRunner(unittest.TestCase):
 
         with patch(
             "core.runner_entry.SizingGate.evaluate",
-            side_effect=lambda **_: SizingEvaluationResult(
+            side_effect=lambda **_: SizingEvaluation(
                 outcome=GateCheckOutcome(True),
                 context=SizingContext.from_ev(EVContext.from_entry(features.entry_ctx)),
             ),
@@ -1630,7 +1630,7 @@ class TestRunner(unittest.TestCase):
 
         with patch(
             "core.runner_entry.SizingGate.evaluate",
-            side_effect=lambda **_: SizingEvaluationResult(
+            side_effect=lambda **_: SizingEvaluation(
                 outcome=GateCheckOutcome(True),
                 context=SizingContext.from_ev(EVContext.from_entry(features.entry_ctx)),
             ),
@@ -1685,7 +1685,7 @@ class TestRunner(unittest.TestCase):
 
         with patch(
             "core.runner_entry.SizingGate.evaluate",
-            side_effect=lambda **_: SizingEvaluationResult(
+            side_effect=lambda **_: SizingEvaluation(
                 outcome=GateCheckOutcome(True),
                 context=SizingContext.from_ev(EVContext.from_entry(features.entry_ctx)),
             ),


### PR DESCRIPTION
## Summary
- rename the runner entry/EV/sizing evaluation dataclasses to EntryEvaluation, EVEvaluation, and SizingEvaluation
- update BacktestRunner helpers to return the renamed dataclasses and keep context snapshot composition unchanged
- refresh runner regression tests to import and instantiate the new dataclass names and document the change in state.md

## Testing
- python3 -m pytest tests/test_runner.py

------
https://chatgpt.com/codex/tasks/task_e_68e3c12fd490832aad3a29d59ad2249e