### PR TITLE
Fix spread conversion for pip-denominated data

### DIFF
--- a/state.md
+++ b/state.md
@@ -364,6 +364,9 @@
 - 2026-03-18: Persisted slip EWMA quantities when exporting/loading runner state so expected slip projections survive resets,
   added `tests/test_runner.py::test_slip_state_persists_qty_ewma_for_expected_slip` to cover the workflow, and ran
   `python3 -m pytest tests/test_runner.py` for validation.
+- 2026-03-19: Normalised spread handling in `core/runner.BacktestRunner._build_ctx` so pip-denominated feeds no longer undergo
+  duplicate conversion, added configuration hooks (`spread_input_mode`/`spread_scale`) plus regression tests covering pip
+  spreads, expected slip costs, and scaling, and executed `python3 -m pytest tests/test_runner.py tests/test_runner_features.py`.
 - 2026-03-10: Enabled `RunnerExecutionManager.process_fill_result` to return structured `PositionState` objects, updated
   `BacktestRunner._process_fill_result` delegations and regression tests to assert serialization/identity, and ran
   `python3 -m pytest tests/test_runner.py` to confirm behaviour.


### PR DESCRIPTION
## Summary
- extend `RunnerConfig` with configurable spread input/scale handling and use it in `_build_ctx` to avoid double converting pip-denominated feeds
- add tolerance to spread band classification and cover pip spread/expected slip scenarios with regression tests
- record the spread-handling update in `state.md`

## Testing
- python3 -m pytest tests/test_runner.py tests/test_runner_features.py

------
https://chatgpt.com/codex/tasks/task_e_68e3d4c9a2d0832a86cf59110dd4de62