### PR TITLE
Propagate same-bar exit probability to EV updates

### DIFF
--- a/core/runner.py
+++ b/core/runner.py
@@ -847,6 +847,7 @@ class BacktestRunner:
         sl_pips: float,
         debug_stage: str,
         debug_extra: Optional[Mapping[str, Any]] = None,
+        p_tp: Optional[float] = None,
     ) -> None:
         self.execution.finalize_trade(
             exit_ts=exit_ts,
@@ -864,6 +865,7 @@ class BacktestRunner:
             sl_pips=sl_pips,
             debug_stage=debug_stage,
             debug_extra=debug_extra,
+            p_tp=p_tp,
         )
 
     def _update_daily_state(

--- a/state.md
+++ b/state.md
@@ -371,6 +371,9 @@
   `RunnerConfig.fill_bridge_lambda` / `fill_bridge_drift_scale`, exposed the probability in trade debug output, added a
   regression that verifies exit price / probability react to config changes, and ran
   `python3 -m pytest tests/test_runner.py`.
+- 2026-03-21: Propagated same-bar TP probabilities through `RunnerExecutionManager` so EV buckets consume
+  fractional updates via `update_weighted`, updated trade finalisation to forward the probability, added
+  bridge/conservative regressions in `tests/test_runner.py`, and ran `python3 -m pytest tests/test_runner.py`.
 - 2026-03-10: Enabled `RunnerExecutionManager.process_fill_result` to return structured `PositionState` objects, updated
   `BacktestRunner._process_fill_result` delegations and regression tests to assert serialization/identity, and ran
   `python3 -m pytest tests/test_runner.py` to confirm behaviour.


### PR DESCRIPTION
## Summary
- carry same-bar fill probabilities through RunnerExecutionManager so trade finalisation can forward them
- weight EV bucket updates with the propagated probability, falling back to binary hits when no probability is provided
- add bridge/conservative regression coverage for the weighted EV updates and assert `p_tp` is surfaced to trade finalisation

## Testing
- python3 -m pytest tests/test_runner.py

------
https://chatgpt.com/codex/tasks/task_e_68e3daa6080c832a96dba373785fcc36