### PR TITLE
Expose bridge same-bar helpers for runner exits

### DIFF
--- a/core/runner_execution.py
+++ b/core/runner_execution.py
@@ -79,19 +79,14 @@ class RunnerExecutionManager:
                 exit_px, exit_reason = sl_px, "sl"
                 p_tp: Optional[float] = None
             else:
-                lam = float(getattr(self._runner.rcfg, "fill_bridge_lambda", 0.35))
-                drift_scale = float(
-                    getattr(self._runner.rcfg, "fill_bridge_drift_scale", 2.5)
-                )
-                exit_px, p_tp = BridgeFill.compute_same_bar_exit_price(
+                exit_px, p_tp = BridgeFill.compute_same_bar_exit_from_config(
+                    runner_config=self._runner.rcfg,
                     side=side,
                     entry_px=entry_px,
                     tp_px=tp_px,
                     stop_px=sl_px,
                     bar=bar,
                     pip_size=pip_size_value,
-                    lam=lam,
-                    drift_scale=drift_scale,
                 )
                 exit_reason = "tp" if p_tp >= 0.5 else "sl"
             exited = True

--- a/state.md
+++ b/state.md
@@ -374,6 +374,10 @@
 - 2026-03-21: Propagated same-bar TP probabilities through `RunnerExecutionManager` so EV buckets consume
   fractional updates via `update_weighted`, updated trade finalisation to forward the probability, added
   bridge/conservative regressions in `tests/test_runner.py`, and ran `python3 -m pytest tests/test_runner.py`.
+- 2026-03-22: Exposed Bridge same-bar TP probability/exit helpers that read `RunnerConfig` parameters,
+  refactored `RunnerExecutionManager.compute_exit_decision` to use the shared helper, added bridge collision
+  regression in `tests/test_runner.py` confirming `fill_bridge_lambda` / `fill_bridge_drift_scale` influence
+  `exit_px` and `p_tp`, and executed `python3 -m pytest tests/test_runner.py`.
 - 2026-03-10: Enabled `RunnerExecutionManager.process_fill_result` to return structured `PositionState` objects, updated
   `BacktestRunner._process_fill_result` delegations and regression tests to assert serialization/identity, and ran
   `python3 -m pytest tests/test_runner.py` to confirm behaviour.


### PR DESCRIPTION
## Summary
- expose BridgeFill helpers that derive same-bar TP probability and exit price from RunnerConfig
- refactor RunnerExecutionManager.compute_exit_decision to use the shared helper for bridge mode
- extend runner regression coverage for bridge same-bar collisions and document the change in state.md

## Testing
- python3 -m pytest tests/test_runner.py

------
https://chatgpt.com/codex/tasks/task_e_68e3dedca9b4832aabf954d282f34e6f