### PR TITLE
Add pending signal accessor to the strategy API

### DIFF
--- a/core/runner_execution.py
+++ b/core/runner_execution.py
@@ -218,7 +218,7 @@ class RunnerExecutionManager:
     ) -> None:
         runner = self._runner
         runner.stg.on_bar(features.bar_input)
-        pending = getattr(runner.stg, "_pending_signal", None)
+        pending = runner.stg.get_pending_signal()
         if pending is None:
             runner.debug_counts["no_breakout"] += 1
             runner._append_debug_record("no_breakout", ts=runner._last_timestamp)

--- a/core/strategy_api.py
+++ b/core/strategy_api.py
@@ -35,6 +35,19 @@ class Strategy(ABC):
     def signals(self, ctx: Optional[Mapping[str, Any]] = None) -> Iterable[OrderIntent]:
         ...
 
+    @abstractmethod
+    def get_pending_signal(self) -> Optional[Any]:
+        """Return the latest unconfirmed signal produced by the strategy.
+
+        The runner polls this accessor prior to executing entry/EV/sizing
+        checks. Sub-classes may override to expose additional metadata or to
+        normalise internal representations (e.g. mapping helper structs back to
+        dictionaries). The default implementation returns ``None`` so template
+        strategies that do not buffer signals can opt in lazily.
+        """
+
+        return None
+
     def update_context(self, ctx: Mapping[str, Any]) -> None:
         """Store the latest runtime context provided by the runner.
 

--- a/docs/backtest_runner_logging.md
+++ b/docs/backtest_runner_logging.md
@@ -13,6 +13,8 @@ Tests (`tests/test_runner.py::test_runner_delegates_to_lifecycle_and_execution_m
 
 ## Decision flow (`strategy_gate` → `ev_threshold` → EV → sizing)
 
+`RunnerExecutionManager` first calls `Strategy.get_pending_signal()` after invoking `Strategy.on_bar`. Strategies that buffer the latest setup should expose it through this accessor so the runner never touches private attributes such as `_pending_signal` directly.
+
 1. **Strategy gate hook** – When a pending signal exists, `BacktestRunner` calls `strategy_gate(ctx, pending)` if the strategy exposes it. Hook errors are counted under `strategy_gate_error` and recorded with the `strategy_gate_error` stage so the run never aborts.
 2. **Router gate** – If the hook allows the trade, the shared `pass_gates` router validates spread, RV bands, and ATR ratio. Any block increments `gate_block` and produces a `gate_block` record with `reason="router_gate"`.
 3. **Strategy EV threshold hook** – The runner resolves a per-signal EV floor via `ev_threshold(ctx, pending, threshold)` when available. Failures increment `ev_threshold_error` and fall back to the CLI threshold.

--- a/state.md
+++ b/state.md
@@ -5,6 +5,9 @@
 - 2025-10-06: Renamed the runner entry/EV/sizing evaluation dataclasses to `EntryEvaluation` / `EVEvaluation` / `SizingEvaluation`,
   updated BacktestRunner pipelines and regression tests to consume the new names, and ran
   `python3 -m pytest tests/test_runner.py` to confirm the refactor.
+- 2025-10-06: Added `Strategy.get_pending_signal()` so runner execution no longer reaches into
+  `_pending_signal`, implemented the accessor across DayORB/mean reversion/scalping templates,
+  refreshed docs/test fixtures, and executed `python3 -m pytest` to validate the integration.
 - 2026-03-16: Added helpers to serialise/deserialise `ActivePositionState` / `CalibrationPositionState`
   during runner state export/load, refactored calibration resolution to reuse typed dataclasses,
   and extended `tests/test_runner.py` with coverage that verifies metrics/EV updates under the dataclass

--- a/strategies/day_orb_5m.py
+++ b/strategies/day_orb_5m.py
@@ -134,8 +134,12 @@ class DayORB5m(Strategy):
                 elif (bar["l"] <= or_l) and ((not require_close) or (bar["c"] <= or_l)):
                     self._pending_signal = {"side":"SELL","tp_pips":tp_pips,"sl_pips":sl_pips,"trail_pips":trail_pips,"entry":or_l}
 
+    def get_pending_signal(self) -> Optional[Dict[str, Any]]:
+        return self._pending_signal
+
     def signals(self, ctx: Optional[Mapping[str, Any]] = None) -> Iterable[OrderIntent]:
-        if not self._pending_signal:
+        pending = self.get_pending_signal()
+        if not pending:
             return []
         # Context should include router gates + EV + sizing related configs
         ctx_data = self.resolve_runtime_context(ctx)
@@ -145,7 +149,7 @@ class DayORB5m(Strategy):
             return []
         if not pass_gates(ctx_data):
             return []
-        sig = self._pending_signal
+        sig = pending
 
         # Calibration mode: bypass EV sizing and emit minimal intent for fill simulation
         if ctx_data.get("calibrating") or ctx_data.get("ev_mode") == "off":

--- a/strategies/day_template.py
+++ b/strategies/day_template.py
@@ -59,8 +59,12 @@ class DayStrategyTemplate(Strategy):
         self.state["last_signal_bar"] = self.state["bar_idx"]
 
     # ------------------------------------------------------------------ Strategy API
+    def get_pending_signal(self) -> Optional[Dict[str, Any]]:
+        return self._pending_signal
+
     def signals(self, ctx: Optional[Mapping[str, Any]] = None) -> Iterable[OrderIntent]:
-        if not self._pending_signal:
+        pending = self.get_pending_signal()
+        if not pending:
             return []
         ctx_data = self.resolve_runtime_context(ctx)
         if not pass_gates(ctx_data):
@@ -70,7 +74,7 @@ class DayStrategyTemplate(Strategy):
         if cooldown > 0 and (self.state["bar_idx"] - self.state["last_signal_bar"] < cooldown):
             return []
 
-        signal = self._apply_signal_defaults(dict(self._pending_signal))
+        signal = self._apply_signal_defaults(dict(pending))
         sl_pips = max(0.1, float(signal.get("sl_pips", self.cfg.get("default_sl_pips", 18.0))))
         qty = compute_qty_from_ctx(ctx_data, sl_pips)
         if qty <= 0:

--- a/strategies/mean_reversion.py
+++ b/strategies/mean_reversion.py
@@ -144,14 +144,18 @@ class MeanReversionStrategy(Strategy):
                 threshold = max(0.0, threshold - confidence * expected)
         return threshold
 
+    def get_pending_signal(self) -> Optional[Dict[str, Any]]:
+        return self._pending_signal
+
     def signals(self, ctx: Optional[Mapping[str, Any]] = None) -> Iterable[OrderIntent]:
-        if not self._pending_signal:
+        pending = self.get_pending_signal()
+        if not pending:
             return []
         ctx_data = self.resolve_runtime_context(ctx)
         if not pass_gates(ctx_data):
             return []
 
-        sig = self._pending_signal
+        sig = pending
         cooldown = int(self.cfg.get("cooldown_bars", ctx_data.get("cooldown_bars", 0)))
         if cooldown > 0 and (self.state["bar_idx"] - self.state["last_signal_bar"] < cooldown):
             return []

--- a/strategies/scalping_template.py
+++ b/strategies/scalping_template.py
@@ -73,8 +73,12 @@ class ScalpingTemplate(Strategy):
         self.state["last_signal_bar"] = self.state["bar_idx"]
 
     # ------------------------------------------------------------------ Strategy API
+    def get_pending_signal(self) -> Optional[Dict[str, Any]]:
+        return self._pending_signal
+
     def signals(self, ctx: Optional[Mapping[str, Any]] = None) -> Iterable[OrderIntent]:
-        if not self._pending_signal:
+        pending = self.get_pending_signal()
+        if not pending:
             return []
         ctx_data = self.resolve_runtime_context(ctx)
         if not pass_gates(ctx_data):
@@ -84,7 +88,7 @@ class ScalpingTemplate(Strategy):
         if cooldown > 0 and (self.state["bar_idx"] - self.state["last_signal_bar"] < cooldown):
             return []
 
-        signal = self._apply_signal_defaults(dict(self._pending_signal))
+        signal = self._apply_signal_defaults(dict(pending))
         sl_pips = max(0.1, float(signal.get("sl_pips", self.cfg.get("default_sl_pips", 6.0))))
         qty = compute_qty_from_ctx(ctx_data, sl_pips)
         if qty <= 0:

--- a/tests/fixtures/strategies/forced_failure.py
+++ b/tests/fixtures/strategies/forced_failure.py
@@ -35,6 +35,9 @@ class DeterministicFailureStrategy(Strategy):
             "sl_pips": 5.0,
         }
 
+    def get_pending_signal(self) -> Optional[Dict[str, Any]]:
+        return self._pending_signal
+
     def signals(self, ctx: Optional[Mapping[str, Any]] = None) -> Iterable[OrderIntent]:
         if ctx is not None:
             self.update_context(ctx)

--- a/tests/test_day_orb_retest.py
+++ b/tests/test_day_orb_retest.py
@@ -38,7 +38,7 @@ def test_sell_breakout_waits_for_retest():
     strategy.on_bar(_bar(150.997, 150.990, 150.992, [or_seed_2, sell_break]))
     assert strategy.state["waiting_retest"]
     assert strategy.state["retest_direction"] == "sell"
-    assert strategy._pending_signal is None
+    assert strategy.get_pending_signal() is None
 
     # Price keeps falling without retesting OR low. Previously the OR condition would
     # short-circuit and mark a retest; ensure it no longer does so.
@@ -46,17 +46,18 @@ def test_sell_breakout_waits_for_retest():
     strategy.on_bar(_bar(150.994, 150.985, 150.988, [sell_break, no_retest]))
     assert strategy.state["waiting_retest"] is True
     assert strategy.state["retest_seen"] is False
-    assert strategy._pending_signal is None
+    assert strategy.get_pending_signal() is None
 
     # Proper retest that tags the OR low from below
     retest = {"h": 150.996, "l": 150.988}
     strategy.on_bar(_bar(150.996, 150.988, 150.989, [no_retest, retest]))
     assert not strategy.state["waiting_retest"]
     assert strategy.state["retest_seen"] is True
-    assert strategy._pending_signal is None
+    assert strategy.get_pending_signal() is None
 
     # Re-break to confirm entry
     confirm = {"h": 150.990, "l": 150.990 - 0.01}
     strategy.on_bar(_bar(confirm["h"], confirm["l"], 150.990 - 0.005, [retest, confirm]))
-    assert strategy._pending_signal is not None
-    assert strategy._pending_signal["side"] == "SELL"
+    pending = strategy.get_pending_signal()
+    assert pending is not None
+    assert pending["side"] == "SELL"

--- a/tests/test_mean_reversion_strategy.py
+++ b/tests/test_mean_reversion_strategy.py
@@ -51,9 +51,11 @@ class MeanReversionStrategyTest(unittest.TestCase):
     def test_emits_order_with_atr_defaults(self) -> None:
         bar = {"c": 150.1, "atr14": 0.2, "zscore": 2.0}
         self.strategy.on_bar(bar)
-        self.assertIsNotNone(self.strategy._pending_signal)
+        pending = self.strategy.get_pending_signal()
+        self.assertIsNotNone(pending)
         ctx = self._base_ctx()
-        self.assertTrue(self.strategy.strategy_gate(ctx, self.strategy._pending_signal))
+        assert pending is not None
+        self.assertTrue(self.strategy.strategy_gate(ctx, pending))
         self.strategy.update_context(ctx)
         intents = list(self.strategy.signals())
         self.assertEqual(len(intents), 1)
@@ -75,9 +77,10 @@ class MeanReversionStrategyTest(unittest.TestCase):
     def test_strategy_gate_blocks_high_rv_and_adx(self) -> None:
         bar = {"c": 150.0, "atr14": 0.15, "zscore": -2.0}
         self.strategy.on_bar(bar)
-        pending = self.strategy._pending_signal
+        pending = self.strategy.get_pending_signal()
         ctx = self._base_ctx()
         ctx["rv_band"] = "high"
+        assert pending is not None
         allowed = self.strategy.strategy_gate(ctx, pending)
         self.assertFalse(allowed)
         self.assertEqual(self.strategy._last_gate_reason["stage"], "rv_filter")
@@ -90,7 +93,8 @@ class MeanReversionStrategyTest(unittest.TestCase):
     def test_ev_threshold_responds_to_zscore_and_profiles(self) -> None:
         bar = {"c": 150.0, "atr14": 0.15, "zscore": -2.5}
         self.strategy.on_bar(bar)
-        pending = self.strategy._pending_signal
+        pending = self.strategy.get_pending_signal()
+        assert pending is not None
         ctx = self._base_ctx()
         ctx["ev_profile_stats"] = {
             "recent": {"p_mean": 0.75, "observations": 12},

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -815,6 +815,9 @@ class TestRunner(unittest.TestCase):
                     oco={"tp_pips": 1.0, "sl_pips": 1.0},
                 )
 
+            def get_pending_signal(self) -> Optional[OrderIntent]:
+                return self._pending_signal
+
             def signals(self, ctx: Optional[Mapping[str, object]] = None):
                 if ctx is not None:
                     self.update_context(ctx)


### PR DESCRIPTION
## Summary
- add the abstract Strategy.get_pending_signal() accessor and use it from RunnerExecutionManager
- implement the accessor for strategies that buffer signals and refresh docs/tests to cover the new API

## Testing
- python3 -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3e300712c832aafea2960a26b5284