### PR TITLE
Apply strategy manifest CLI defaults to run_sim

### DIFF
--- a/configs/strategies/README.md
+++ b/configs/strategies/README.md
@@ -42,7 +42,10 @@ listed when a strategy is multi-instrument.
 ### Runner defaults
 `runner.runner_config` mirrors the arguments accepted by `RunnerConfig`, while
 `runner.cli_args` matches CLI flags (e.g. `scripts/run_sim.py`). These sections
-are advisory and can be used by orchestration tools to bootstrap runs.
+are advisory and can be used by orchestration tools to bootstrap runs. When
+invoking `scripts/run_sim.py --strategy-manifest`, the CLI automatically seeds
+unspecified options from `runner.cli_args`, but any explicit flag passed on the
+command line still takes precedence.
 
 #### Router guard fields
 

--- a/state.md
+++ b/state.md
@@ -5,6 +5,9 @@
 - 2025-10-06: Renamed the runner entry/EV/sizing evaluation dataclasses to `EntryEvaluation` / `EVEvaluation` / `SizingEvaluation`,
   updated BacktestRunner pipelines and regression tests to consume the new names, and ran
   `python3 -m pytest tests/test_runner.py` to confirm the refactor.
+- 2026-03-24: Seeded `scripts/run_sim.py` CLI namespaces with manifest `runner.cli_args` defaults while
+  preserving user overrides, added regression coverage in `tests/test_run_sim_cli.py`, refreshed
+  `configs/strategies/README.md`, and executed `python3 -m pytest tests/test_run_sim_cli.py`.
 - 2025-10-06: Added `Strategy.get_pending_signal()` so runner execution no longer reaches into
   `_pending_signal`, implemented the accessor across DayORB/mean reversion/scalping templates,
   refreshed docs/test fixtures, and executed `python3 -m pytest` to validate the integration.


### PR DESCRIPTION
## Summary
- seed the run_sim CLI namespace with manifest-provided runner.cli_args defaults without overwriting explicit user flags
- refactor parser construction so defaults can be inspected and add detection of user-supplied arguments
- extend run_sim CLI tests to cover manifest default seeding and override precedence, refresh manifest documentation, and log the change in state.md

## Testing
- python3 -m pytest tests/test_run_sim_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68e42a74983c832aa3f5c9e6cdca453f