### PR TITLE
Stream CSV loading in run_sim and extend streaming regression coverage

### DIFF
--- a/scripts/run_compare.py
+++ b/scripts/run_compare.py
@@ -92,9 +92,7 @@ def run_compare(args=None) -> Dict[str, Any]:
                 if fn.lower().endswith(".csv"):
                     suggestions.append(os.path.join("data", fn))
         return {"error": "csv_not_found", "path": args.csv, "suggestions": suggestions[:5]}
-    bars = load_bars_csv(args.csv)
-    if args.symbol:
-        bars = [b for b in bars if b.get("symbol") == args.symbol]
+    bars = list(load_bars_csv(args.csv, symbol=args.symbol))
     if not bars:
         return {"error": "no bars"}
     symbol = args.symbol or bars[0].get("symbol")

--- a/scripts/run_grid.py
+++ b/scripts/run_grid.py
@@ -177,9 +177,7 @@ def run_grid(argv=None) -> Dict[str,Any]:
                 if fn.lower().endswith(".csv"):
                     suggestions.append(os.path.join("data", fn))
         return {"error": "csv_not_found", "path": args.csv, "suggestions": suggestions[:5]}
-    bars = load_bars_csv(args.csv)
-    if args.symbol:
-        bars = [b for b in bars if b.get("symbol") == args.symbol]
+    bars = list(load_bars_csv(args.csv, symbol=args.symbol))
     if not bars:
         return {"error": "no bars"}
     symbol = args.symbol or bars[0].get("symbol")

--- a/state.md
+++ b/state.md
@@ -8,6 +8,10 @@
 - 2026-03-24: Seeded `scripts/run_sim.py` CLI namespaces with manifest `runner.cli_args` defaults while
   preserving user overrides, added regression coverage in `tests/test_run_sim_cli.py`, refreshed
   `configs/strategies/README.md`, and executed `python3 -m pytest tests/test_run_sim_cli.py`.
+- 2026-03-25: Streamed `scripts/run_sim.py` CSV ingestion by making `load_bars_csv` yield filtered bars,
+  updated the CLI to forward the iterator to `BacktestRunner.run` while retaining the first bar for symbol
+  resolution, adjusted `scripts/run_compare.py` / `scripts/run_grid.py` to materialise lists as needed,
+  extended `tests/test_run_sim_cli.py` with streaming coverage, and ran `python3 -m pytest tests/test_run_sim_cli.py`.
 - 2025-10-06: Added `Strategy.get_pending_signal()` so runner execution no longer reaches into
   `_pending_signal`, implemented the accessor across DayORB/mean reversion/scalping templates,
   refreshed docs/test fixtures, and executed `python3 -m pytest` to validate the integration.


### PR DESCRIPTION
## Summary
- refactor `load_bars_csv` to stream rows with inline symbol and time filters and let `run_sim` pass the iterator directly to `BacktestRunner`
- update `run_compare` and `run_grid` to materialise bar collections when they need to re-run multiple fills
- expand the CLI regression suite with iterator-focused coverage for streaming ingestion

## Testing
- python3 -m pytest tests/test_run_sim_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68e437bcc8b4832a946794ea3a5d2584