### PR TITLE
Resolve run_sim state archive paths relative to repo root

### DIFF
--- a/state.md
+++ b/state.md
@@ -12,6 +12,9 @@
   updated the CLI to forward the iterator to `BacktestRunner.run` while retaining the first bar for symbol
   resolution, adjusted `scripts/run_compare.py` / `scripts/run_grid.py` to materialise lists as needed,
   extended `tests/test_run_sim_cli.py` with streaming coverage, and ran `python3 -m pytest tests/test_run_sim_cli.py`.
+- 2026-03-27: Normalised `scripts/run_sim.py` state archive resolution to anchor relative paths at `ROOT`, forwarded the
+  absolute archive directory to `aggregate_ev.py`, added regression coverage for launching from a temporary working
+  directory, and executed `python3 -m pytest tests/test_run_sim_cli.py` for verification.
 - 2025-10-06: Added `Strategy.get_pending_signal()` so runner execution no longer reaches into
   `_pending_signal`, implemented the accessor across DayORB/mean reversion/scalping templates,
   refreshed docs/test fixtures, and executed `python3 -m pytest` to validate the integration.


### PR DESCRIPTION
## Summary
- anchor run_sim state archive reads and writes to an absolute path rooted at the repository and pass the resolved directory to aggregate_ev
- add a regression test that launches run_sim from a temporary working directory and confirms the aggregate subprocess receives a reachable archive
- record the workflow update in state.md

## Testing
- python3 -m pytest tests/test_run_sim_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68e45346528c832ab5ad67d05b5eb357