### PR TITLE
Normalize backlog anchor fragments before syncing docs

### DIFF
--- a/state.md
+++ b/state.md
@@ -2,6 +2,9 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
+- 2025-10-07: Normalised `docs/task_backlog.md` anchors in `scripts/sync_task_docs.normalize_anchor`,
+  added regression coverage for uppercase fragments in `tests/test_sync_task_template.py`,
+  and ran `python3 -m pytest tests/test_manage_task_cycle.py tests/test_sync_task_template.py`.
 - 2025-10-06: Renamed the runner entry/EV/sizing evaluation dataclasses to `EntryEvaluation` / `EVEvaluation` / `SizingEvaluation`,
   updated BacktestRunner pipelines and regression tests to consume the new names, and ran
   `python3 -m pytest tests/test_runner.py` to confirm the refactor.

--- a/tests/test_sync_task_template.py
+++ b/tests/test_sync_task_template.py
@@ -141,3 +141,11 @@ def test_apply_next_task_template_defaults_ready_section(tmp_path, monkeypatch):
         "Clarify gating metrics, data dependencies, or open questions." in line
         for line in block_lines
     )
+
+
+def test_normalize_anchor_slugifies_uppercase_fragment() -> None:
+    anchor = "docs/task_backlog.md#P1-Example Task  "
+    assert (
+        sync.normalize_anchor(anchor)
+        == "docs/task_backlog.md#p1-example-task"
+    )


### PR DESCRIPTION
## Summary
- normalize `docs/task_backlog.md` anchor fragments before syncing task docs
- cover uppercase backlog anchors in the sync task template regression suite
- log the workflow update in `state.md`

## Testing
- python3 -m pytest tests/test_manage_task_cycle.py tests/test_sync_task_template.py

------
https://chatgpt.com/codex/tasks/task_e_68e48efbddac832a9db04995aefbdac9