### PR TITLE
Filter run_sim bar stream by resolved symbol

### DIFF
--- a/scripts/run_sim.py
+++ b/scripts/run_sim.py
@@ -415,6 +415,8 @@ def main(argv=None):
         print(json.dumps({"error": "no bars"}))
         return 1
     symbol = args.symbol or first_bar.get("symbol")
+    if args.symbol is None:
+        args.symbol = symbol
     rcfg = build_runner_config(args, base=rcfg_base)
     debug_for_dump = args.debug or bool(args.dump_csv) or bool(args.dump_daily) or bool(args.out_dir)
     from importlib import import_module
@@ -467,7 +469,14 @@ def main(argv=None):
                 loaded_state_path = str(latest_state)
             except Exception:
                 loaded_state_path = None
-    bars_for_runner = chain([first_bar], bars_iter)
+    if symbol is None:
+        bars_for_runner = chain([first_bar], bars_iter)
+    else:
+        initial_bars = [first_bar] if first_bar.get("symbol") == symbol else []
+        bars_for_runner = chain(
+            initial_bars,
+            (bar for bar in bars_iter if bar.get("symbol") == symbol),
+        )
     metrics = runner.run(bars_for_runner, mode=args.mode)
     router_results = None
     if manifest is not None:

--- a/state.md
+++ b/state.md
@@ -2,6 +2,9 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
+- 2026-03-29: Filtered `scripts/run_sim.py` bar streaming so only the resolved symbol feeds the runner,
+  added a mixed-symbol regression test in `tests/test_run_sim_cli.py`, and ran
+  `python3 -m pytest tests/test_run_sim_cli.py` for confirmation.
 - 2025-10-07: Normalised `docs/task_backlog.md` anchors in `scripts/sync_task_docs.normalize_anchor`,
   added regression coverage for uppercase fragments in `tests/test_sync_task_template.py`,
   and ran `python3 -m pytest tests/test_manage_task_cycle.py tests/test_sync_task_template.py`.


### PR DESCRIPTION
## Summary
- filter the `run_sim` bar iterator so only rows matching the resolved symbol reach the runner
- add a regression test covering mixed-symbol CSV inputs when `--symbol` is omitted
- update `state.md` with the latest task record

## Testing
- python3 -m pytest tests/test_run_sim_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68e4a615ac98832ab2749be8ff81f70c