### PR TITLE
Add skip-yaml option for aggregate EV profiles

### DIFF
--- a/scripts/aggregate_ev.py
+++ b/scripts/aggregate_ev.py
@@ -205,6 +205,11 @@ def main() -> int:
     parser.add_argument("--beta-prior", type=float, default=1.0)
     parser.add_argument("--out-yaml", default=None, help="Path to write YAML profile (default: configs/ev_profiles/<strategy_module>.yaml)")
     parser.add_argument("--out-csv", default=None, help="Optional path to write CSV summary")
+    parser.add_argument(
+        "--skip-yaml",
+        action="store_true",
+        help="Skip writing the YAML profile while still allowing CSV summaries",
+    )
     args = parser.parse_args()
 
     strategy_module, _, strategy_class = args.strategy.rpartition(".")
@@ -257,16 +262,17 @@ def main() -> int:
         beta_prior=args.beta_prior,
     )
 
-    out_yaml_base = (
-        Path(args.out_yaml)
-        if args.out_yaml
-        else Path("configs/ev_profiles") / f"{module_tail}.yaml"
-    )
-    out_yaml = resolve_repo_path(out_yaml_base)
-    out_yaml.parent.mkdir(parents=True, exist_ok=True)
-    with out_yaml.open("w") as f:
-        yaml.safe_dump(profile, f, sort_keys=False)
-    print(f"Wrote YAML profile -> {out_yaml}")
+    if not args.skip_yaml:
+        out_yaml_base = (
+            Path(args.out_yaml)
+            if args.out_yaml
+            else Path("configs/ev_profiles") / f"{module_tail}.yaml"
+        )
+        out_yaml = resolve_repo_path(out_yaml_base)
+        out_yaml.parent.mkdir(parents=True, exist_ok=True)
+        with out_yaml.open("w") as f:
+            yaml.safe_dump(profile, f, sort_keys=False)
+        print(f"Wrote YAML profile -> {out_yaml}")
 
     if args.out_csv:
         summary = {

--- a/scripts/run_sim.py
+++ b/scripts/run_sim.py
@@ -792,8 +792,11 @@ def main(argv=None):
         ]
         if archive_namespace_arg:
             agg_cmd.extend(["--archive-namespace", archive_namespace_arg])
-        if _ev_profile_enabled(args) and args.ev_profile:
-            agg_cmd.extend(["--out-yaml", args.ev_profile])
+        if _ev_profile_enabled(args):
+            if args.ev_profile:
+                agg_cmd.extend(["--out-yaml", args.ev_profile])
+        else:
+            agg_cmd.append("--skip-yaml")
         agg_cmd.extend(["--out-csv", "analysis/ev_profile_summary.csv"])
         try:
             result = subprocess.run(

--- a/state.md
+++ b/state.md
@@ -2,6 +2,9 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
+- 2026-04-03: Added `--skip-yaml` to `scripts/aggregate_ev.py` so CSV summaries can run without writing profiles, updated
+  `scripts/run_sim.py` to append the guard when `--no-ev-profile` is set, extended CLI/script pytest coverage, and ran
+  `python3 -m pytest tests/test_run_sim_cli.py tests/test_aggregate_ev_script.py`.
 - 2026-03-31: Ensured `scripts/run_sim.py` respects `--no-ev-profile` when manifests set `state.ev_profile`,
   prevented `aggregate_ev.py` from receiving `--out-yaml` under the flag, extended
   `tests/test_run_sim_cli.py` with a regression, and ran `python3 -m pytest tests/test_run_sim_cli.py`.

--- a/tests/test_run_sim_cli.py
+++ b/tests/test_run_sim_cli.py
@@ -782,6 +782,7 @@ class TestRunSimCLI(unittest.TestCase):
         cmd_args = mock_run.call_args[0][0]
         self.assertIsInstance(cmd_args, list)
         self.assertNotIn("--out-yaml", cmd_args)
+        self.assertIn("--skip-yaml", cmd_args)
 
     @mock.patch("scripts.run_sim.BacktestRunner")
     def test_cli_no_ev_profile_flag_blocks_aggregate_out_yaml(self, mock_runner):
@@ -834,6 +835,7 @@ class TestRunSimCLI(unittest.TestCase):
         self.assertIsInstance(cmd_args, list)
         self.assertNotIn("--out-yaml", cmd_args)
         self.assertIn("--out-csv", cmd_args)
+        self.assertIn("--skip-yaml", cmd_args)
 
     @mock.patch("scripts.run_sim.BacktestRunner")
     def test_run_sim_cli_applies_fill_overrides(self, mock_runner):


### PR DESCRIPTION
## Summary
- add a `--skip-yaml` flag to `scripts/aggregate_ev.py` so CSV summaries can run without writing profiles
- update `scripts/run_sim.py` to append the skip flag when EV profiles are disabled and extend regression coverage
- document the change in `state.md`

## Testing
- python3 -m pytest tests/test_run_sim_cli.py tests/test_aggregate_ev_script.py


------
https://chatgpt.com/codex/tasks/task_e_68e4dc015d80832abecc47bde2fbcb00