### PR TITLE
Normalize EV key restoration after JSON round trips

### DIFF
--- a/state.md
+++ b/state.md
@@ -5,6 +5,9 @@
 - 2026-04-03: Added `--skip-yaml` to `scripts/aggregate_ev.py` so CSV summaries can run without writing profiles, updated
   `scripts/run_sim.py` to append the guard when `--no-ev-profile` is set, extended CLI/script pytest coverage, and ran
   `python3 -m pytest tests/test_run_sim_cli.py tests/test_aggregate_ev_script.py`.
+- 2026-04-04: Normalised runner EV keys during state restoration and trade finalisation to accept JSON round-tripped payloads,
+  updated `RunnerExecutionManager` to pass canonical tuples to `_get_ev_manager`, added a regression covering
+  `load_state(json.loads(json.dumps(state)))`, and ran `python3 -m pytest tests/test_runner.py`.
 - 2026-03-31: Ensured `scripts/run_sim.py` respects `--no-ev-profile` when manifests set `state.ev_profile`,
   prevented `aggregate_ev.py` from receiving `--out-yaml` under the flag, extended
   `tests/test_run_sim_cli.py` with a regression, and ran `python3 -m pytest tests/test_run_sim_cli.py`.


### PR DESCRIPTION
## Summary
- normalize persisted `ev_key` values when deserializing position state so JSON round-tripped lists/strings become tuples
- ensure `RunnerExecutionManager` resolves calibration and trade EV keys through the shared normalizer before calling `_get_ev_manager`
- add a regression test covering `load_state(json.loads(json.dumps(state)))` and update the state log entry

## Testing
- python3 -m pytest tests/test_runner.py

------
https://chatgpt.com/codex/tasks/task_e_68e4e21c4fa4832a9b25260894620cbc