### PR TITLE
Normalize timeframe ingestion for backtest bars

### DIFF
--- a/state.md
+++ b/state.md
@@ -2,6 +2,7 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
+- 2026-04-08: Normalised timeframe handling across `load_bars_csv` and `validate_bar`, plumbed runner timeframe whitelists, extended CLI/runner tests for uppercase bars, and ran `python3 -m pytest`.
 - 2026-04-07: Propagated `--local-backup-csv` overrides from `run_daily_workflow.py` to the default `pull_prices` ingest path, added a CLI regression in `tests/test_run_daily_workflow.py`, and ran `python3 -m pytest`.
 - 2026-04-03: Added `--skip-yaml` to `scripts/aggregate_ev.py` so CSV summaries can run without writing profiles, updated
   `scripts/run_sim.py` to append the guard when `--no-ev-profile` is set, extended CLI/script pytest coverage, and ran

--- a/tests/test_run_sim_cli.py
+++ b/tests/test_run_sim_cli.py
@@ -118,6 +118,27 @@ def test_load_bars_csv_tolerates_blank_volume_and_spread(tmp_path: Path) -> None
     assert bars[1]["spread"] == 0.01
 
 
+def test_load_bars_csv_normalizes_timeframe(tmp_path: Path) -> None:
+    csv_path = tmp_path / "bars.csv"
+    csv_path.write_text(
+        "timestamp,symbol,tf,o,h,l,c,v,spread\n"
+        "2024-01-01T09:00:00Z,USDJPY,5M,150.10,150.20,150.00,150.12,0,0.01\n"
+        "2024-01-01T09:05:00Z,USDJPY,,150.11,150.21,150.01,150.13,0,0.02\n",
+        encoding="utf-8",
+    )
+
+    bars = list(
+        load_bars_csv(
+            str(csv_path),
+            symbol="USDJPY",
+            default_symbol="USDJPY",
+            default_tf="5M",
+        )
+    )
+
+    assert [bar["tf"] for bar in bars] == ["5m", "5m"]
+
+
 def test_load_bars_csv_requires_symbol_when_missing(tmp_path: Path) -> None:
     csv_path = tmp_path / "bars.csv"
     csv_path.write_text(CSV_OHLC_ONLY, encoding="utf-8")

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -18,6 +18,7 @@ from core.runner import (
     ExitDecision,
     Metrics,
     RunnerConfig,
+    validate_bar,
 )
 from core.runner_features import RunnerContext
 from core.runner_execution import RunnerExecutionManager
@@ -53,6 +54,39 @@ def make_bar(ts, symbol, o, h, l, c, spread):
         "v": 0.0,
         "spread": spread,
     }
+
+
+def test_validate_bar_accepts_uppercase_timeframe() -> None:
+    bar = {
+        "timestamp": "2024-01-01T00:00:00Z",
+        "symbol": "USDJPY",
+        "tf": "5M",
+        "o": 1.0,
+        "h": 2.0,
+        "l": 0.5,
+        "c": 1.5,
+        "v": 0.0,
+        "spread": 0.0,
+    }
+
+    assert validate_bar(bar)
+
+
+def test_validate_bar_respects_allowed_timeframes() -> None:
+    bar = {
+        "timestamp": "2024-01-01T00:05:00Z",
+        "symbol": "USDJPY",
+        "tf": "15m",
+        "o": 1.0,
+        "h": 2.0,
+        "l": 0.5,
+        "c": 1.5,
+        "v": 0.0,
+        "spread": 0.0,
+    }
+
+    assert not validate_bar(bar, allowed_timeframes=("5m",))
+    assert validate_bar(bar, allowed_timeframes=("5m", "15m"))
 
 
 class TestRunner(unittest.TestCase):


### PR DESCRIPTION
## Summary
- normalise CSV bar timeframes before they reach the runner and seed runner configs with manifest timeframes
- extend runner bar validation to honour configurable timeframe whitelists and reuse them during full runs
- cover uppercase timeframe handling with new CLI and core unit tests and update the workflow state log

## Testing
- python3 -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68e531395114832a8b6a9d8e1c0ae843