### PR TITLE
Add CSV loader diagnostics and strict mode to run_sim CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ python3 scripts/run_sim.py \
 CLI オプションは上記のみに絞り、EV/Fill/State 設定は manifest の `runner.cli_args` で制御します。トラブルシュート時は以下に注意:
 - `{"error":"csv_format","code":"missing_required_columns"}` が出た場合はヘッダを確認し、最低でも `timestamp,open/high/low/close` を揃える。
 - `{"error":"no_bars"}` はフィルタ条件でバーが存在しないことを示すため、期間とシンボルを再確認する。
+- CSV ローダーが行をスキップした場合は `stderr` に `[run_sim] Skipped ...` の警告が出力され、`metrics.debug.csv_loader` に統計が記録される。厳格に扱いたいケースでは `--strict` を併用すると `CSVFormatError` が送出される。
 
 `--out-dir <base_dir>` を指定すると `<base_dir>/<symbol>_<mode>_<timestamp>/` 以下に `params.json` / `metrics.json` / `records.csv` / `daily.csv`（存在する場合）/ `state.json` がまとめて保存され、`metrics.json` の `run_dir` からパスを辿れます。複数戦略の比較や incident 再現ではこの run ディレクトリを基点に解析してください。
 

--- a/scripts/run_compare.py
+++ b/scripts/run_compare.py
@@ -92,7 +92,7 @@ def run_compare(args=None) -> Dict[str, Any]:
                 if fn.lower().endswith(".csv"):
                     suggestions.append(os.path.join("data", fn))
         return {"error": "csv_not_found", "path": args.csv, "suggestions": suggestions[:5]}
-    bars = list(load_bars_csv(args.csv, symbol=args.symbol))
+    bars = list(load_bars_csv(args.csv, symbol=args.symbol, strict=False))
     if not bars:
         return {"error": "no bars"}
     symbol = args.symbol or bars[0].get("symbol")

--- a/scripts/run_grid.py
+++ b/scripts/run_grid.py
@@ -177,7 +177,7 @@ def run_grid(argv=None) -> Dict[str,Any]:
                 if fn.lower().endswith(".csv"):
                     suggestions.append(os.path.join("data", fn))
         return {"error": "csv_not_found", "path": args.csv, "suggestions": suggestions[:5]}
-    bars = list(load_bars_csv(args.csv, symbol=args.symbol))
+    bars = list(load_bars_csv(args.csv, symbol=args.symbol, strict=False))
     if not bars:
         return {"error": "no bars"}
     symbol = args.symbol or bars[0].get("symbol")

--- a/state.md
+++ b/state.md
@@ -2,6 +2,7 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
+- 2026-04-09: Added CSV loader diagnostics/strict mode to `scripts/run_sim.py`, plumbed stats into CLI outputs/docs, updated grid/compare helpers, extended CLI tests, and ran `python3 -m pytest`.
 - 2026-04-08: Normalised timeframe handling across `load_bars_csv` and `validate_bar`, plumbed runner timeframe whitelists, extended CLI/runner tests for uppercase bars, and ran `python3 -m pytest`.
 - 2026-04-07: Propagated `--local-backup-csv` overrides from `run_daily_workflow.py` to the default `pull_prices` ingest path, added a CLI regression in `tests/test_run_daily_workflow.py`, and ran `python3 -m pytest`.
 - 2026-04-03: Added `--skip-yaml` to `scripts/aggregate_ev.py` so CSV summaries can run without writing profiles, updated


### PR DESCRIPTION
## Summary
- add a CSVLoaderStats dataclass to track skipped rows, feed the metrics debug map, and surface stderr warnings/strict failures via the `--strict` flag
- update run_sim CLI docs along with run_grid/run_compare helpers so downstream consumers retain tolerant defaults
- extend the run_sim CLI tests to cover loader stats, warning output, and strict failure behaviour

## Testing
- python3 -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68e538fb085c832aa40620e3d09ec2f0