### PR TITLE
Handle multiple intents per bar in RunnerExecutionManager

### DIFF
--- a/state.md
+++ b/state.md
@@ -2,6 +2,7 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
+- 2026-04-10: Refactored `RunnerExecutionManager.maybe_enter_trade` to process multiple intents with per-intent metrics, updated fill/state handling, added regression coverage for multi-intent order processing, and ran `python3 -m pytest tests/test_runner.py`.
 - 2026-04-09: Added CSV loader diagnostics/strict mode to `scripts/run_sim.py`, plumbed stats into CLI outputs/docs, updated grid/compare helpers, extended CLI tests, and ran `python3 -m pytest`.
 - 2026-04-08: Normalised timeframe handling across `load_bars_csv` and `validate_bar`, plumbed runner timeframe whitelists, extended CLI/runner tests for uppercase bars, and ran `python3 -m pytest`.
 - 2026-04-07: Propagated `--local-backup-csv` overrides from `run_daily_workflow.py` to the default `pull_prices` ingest path, added a CLI regression in `tests/test_run_daily_workflow.py`, and ran `python3 -m pytest`.


### PR DESCRIPTION
## Summary
- iterate through every intent returned by the strategy, cloning sizing/context data so fills can be simulated safely for each order
- keep per-intent daily metrics and warmup handling while reusing the fill/snapshot logic inside the loop
- add a regression that feeds multiple intents and asserts fills, metrics, and context cloning all behave as expected

## Testing
- python3 -m pytest tests/test_runner.py

------
https://chatgpt.com/codex/tasks/task_e_68e590a622d4832a9f0d2621b3a6d57f