### PR TITLE
Support multi-intent entry handling in the runner

### DIFF
--- a/state.md
+++ b/state.md
@@ -3,6 +3,7 @@
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
 - 2026-04-09: Added CSV loader diagnostics/strict mode to `scripts/run_sim.py`, plumbed stats into CLI outputs/docs, updated grid/compare helpers, extended CLI tests, and ran `python3 -m pytest`.
+- 2026-04-10: Refactored `RunnerExecutionManager` entry flow to iterate multiple intents with per-order metrics, updated fill handling, added multi-intent runner regression, and ran `python3 -m pytest tests/test_runner.py`.
 - 2026-04-08: Normalised timeframe handling across `load_bars_csv` and `validate_bar`, plumbed runner timeframe whitelists, extended CLI/runner tests for uppercase bars, and ran `python3 -m pytest`.
 - 2026-04-07: Propagated `--local-backup-csv` overrides from `run_daily_workflow.py` to the default `pull_prices` ingest path, added a CLI regression in `tests/test_run_daily_workflow.py`, and ran `python3 -m pytest`.
 - 2026-04-03: Added `--skip-yaml` to `scripts/aggregate_ev.py` so CSV summaries can run without writing profiles, updated

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -326,6 +326,9 @@ class TestRunner(unittest.TestCase):
         def update(self, hit: bool) -> None:
             self.last_update = hit
 
+        def update_weighted(self, prob: float) -> None:
+            self.last_weighted = prob
+
     def _prepare_breakout_environment(
         self,
         *,
@@ -2168,6 +2171,90 @@ class TestRunner(unittest.TestCase):
                     )
         self.assertEqual(runner._warmup_left, initial_warmup - 1)
         mock_process.assert_called_once()
+
+    def test_maybe_enter_trade_processes_multiple_intents(self):
+        runner, pending, breakout, features, calibrating = self._prepare_breakout_environment(
+            warmup_left=2
+        )
+        self.assertFalse(calibrating)
+        stub_ev = self.DummyEV(ev_lcb=5.0, p_lcb=0.6)
+        runner._get_ev_manager = lambda key: stub_ev
+        features.entry_ctx.ev_manager = stub_ev
+        features.entry_ctx.cost_pips = features.entry_ctx.base_cost_pips
+        features.ctx["ev_oco"] = stub_ev
+        features.ctx.setdefault("slip_cap_pip", runner.rcfg.slip_cap_pip)
+        features.ctx.setdefault("expected_slip_pip", 0.0)
+        features.ctx.setdefault("ev_key", ("LDN", "normal", "mid"))
+        pip_value = pip_size(runner.symbol)
+        base_entry = pending["entry"]
+        intent_primary = OrderIntent(
+            pending["side"],
+            qty=1.0,
+            price=base_entry,
+            oco={
+                "tp_pips": pending["tp_pips"],
+                "sl_pips": pending["sl_pips"],
+                "trail_pips": pending["trail_pips"],
+            },
+        )
+        intent_secondary = OrderIntent(
+            pending["side"],
+            qty=1.0,
+            price=base_entry + pip_value,
+            oco={
+                "tp_pips": pending["tp_pips"],
+                "sl_pips": pending["sl_pips"],
+                "trail_pips": pending["trail_pips"],
+            },
+        )
+        fill_primary = {
+            "fill": True,
+            "entry_px": intent_primary.price,
+            "exit_px": intent_primary.price + pip_value,
+            "exit_reason": "tp",
+        }
+        fill_secondary = {
+            "fill": True,
+            "entry_px": intent_secondary.price,
+            "exit_px": intent_secondary.price - pip_value,
+            "exit_reason": "sl",
+        }
+        with patch.object(runner.stg, "on_bar", return_value=None), patch.object(
+            runner.stg,
+            "get_pending_signal",
+            return_value=pending,
+        ), patch.object(
+            runner.stg,
+            "signals",
+            return_value=[intent_primary, intent_secondary],
+        ), patch.object(
+            runner.fill_engine_c,
+            "simulate",
+            side_effect=[fill_primary, fill_secondary],
+        ) as mock_sim:
+            runner._maybe_enter_trade(
+                bar=breakout,
+                features=features,
+                mode="conservative",
+                pip_size_value=pip_value,
+                calibrating=calibrating,
+            )
+
+        self.assertEqual(mock_sim.call_count, 2)
+        self.assertIsNone(runner.pos)
+        self.assertEqual(len(runner.records), 2)
+        self.assertEqual(runner.metrics.trades, 2)
+        self.assertEqual(runner.metrics.wins, 1)
+        self.assertEqual(runner._warmup_left, 0)
+        daily_entry = getattr(runner, "_current_daily_entry", None)
+        self.assertIsNotNone(daily_entry)
+        if daily_entry is not None:
+            self.assertEqual(daily_entry["breakouts"], 2)
+            self.assertEqual(daily_entry["gate_pass"], 2)
+            self.assertEqual(daily_entry["ev_pass"], 2)
+            self.assertEqual(daily_entry["fills"], 2)
+            self.assertEqual(daily_entry["wins"], 1)
+        self.assertEqual(stub_ev.last_update, False)
 
     def test_calibration_warmup_counter_remains_unchanged(self):
         runner, pending, breakout, features, calibrating = self._prepare_breakout_environment(


### PR DESCRIPTION
## Summary
- refactor RunnerExecutionManager.maybe_enter_trade to iterate all strategy intents, cloning contexts safely and updating per-intent metrics
- ensure fill simulation, snapshot creation, and warmup counters run inside the intent loop so multiple fills remain consistent
- add a regression in tests/test_runner.py that exercises a stub strategy emitting two intents and verifies metrics and records

## Testing
- python3 -m pytest tests/test_runner.py

## サマリー
- RunnerExecutionManager を複数インテント処理に対応させ、メトリクスやウォームアップ管理を意図通りに更新
- 複数インテントの充当を検証するランナーテストを追加し、pytest を実行

------
https://chatgpt.com/codex/tasks/task_e_68e5aa8ca318832a8f92eb206812524c