### PR TITLE
Tighten run_sim CLI skip diagnostics assertions

### DIFF
--- a/state.md
+++ b/state.md
@@ -2,6 +2,10 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
+- 2026-04-12: Hardened `tests/test_run_sim_cli.py` skip-diagnostics coverage to assert reason counts and error messaging, re-ran
+  `python3 -m pytest tests/test_run_sim_cli.py tests/test_runner.py` followed by the full `python3 -m pytest` sweep.
+- 2026-04-11: Extended `tests/test_run_sim_cli.py` for ISO basic timestamps/uppercase TF coverage, added session regression in
+  `tests/test_runner.py`, ensured strict/tolerant skip diagnostics surface counts, and ran `python3 -m pytest tests/test_run_sim_cli.py tests/test_runner.py`.
 - 2026-04-09: Added CSV loader diagnostics/strict mode to `scripts/run_sim.py`, plumbed stats into CLI outputs/docs, updated grid/compare helpers, extended CLI tests, and ran `python3 -m pytest`.
 - 2026-04-10: Refactored `RunnerExecutionManager` entry flow to iterate multiple intents with per-order metrics, updated fill handling, added multi-intent runner regression, and ran `python3 -m pytest tests/test_runner.py`.
 - 2026-04-08: Normalised timeframe handling across `load_bars_csv` and `validate_bar`, plumbed runner timeframe whitelists, extended CLI/runner tests for uppercase bars, and ran `python3 -m pytest`.

--- a/tests/test_run_sim_cli.py
+++ b/tests/test_run_sim_cli.py
@@ -1,3 +1,8 @@
+"""Integration tests for ``scripts/run_sim`` CLI behaviour.
+
+Validation command: ``python3 -m pytest tests/test_run_sim_cli.py``
+"""
+
 import json
 import textwrap
 from pathlib import Path
@@ -13,11 +18,11 @@ from scripts.run_sim import (
 
 
 CSV_CONTENT = """timestamp,symbol,tf,o,h,l,c,v,spread,zscore
-2024-01-01T08:00:00Z,USDJPY,5m,150.00,150.10,149.90,150.02,0,0.02,0.0
-2024-01-01T08:05:00Z,USDJPY,5m,150.01,150.11,149.91,150.03,0,0.02,0.3
-2024-01-01T08:10:00Z,USDJPY,5m,150.02,150.12,149.92,150.04,0,0.02,0.8
-2024-01-01T08:15:00Z,USDJPY,5m,150.03,150.13,149.93,150.05,0,0.02,-0.7
-2024-01-01T08:20:00Z,USDJPY,5m,150.04,150.14,149.94,150.06,0,0.02,0.6
+20240101T080000Z,USDJPY,5M,150.00,150.10,149.90,150.02,0,0.02,0.0
+20240101T080500Z,USDJPY,5m,150.01,150.11,149.91,150.03,0,0.02,0.3
+20240101T081000Z,USDJPY,5M,150.02,150.12,149.92,150.04,0,0.02,1.6
+20240101T081500Z,USDJPY,5m,150.03,150.13,149.93,150.05,0,0.02,-0.7
+20240101T082000Z,USDJPY,5m,150.04,150.14,149.94,150.06,0,0.02,0.6
 """
 
 
@@ -68,7 +73,7 @@ MANIFEST_TEMPLATE = textwrap.dedent(
       max_daily_dd_pct: 8.0
       notional_cap: 500000
       max_concurrent_positions: 1
-      warmup_trades: 0
+      warmup_trades: 2
     features:
       required: [zscore, rv_band]
       optional: [atr14, adx14]
@@ -82,7 +87,7 @@ MANIFEST_TEMPLATE = textwrap.dedent(
           narrow: 3.0
           normal: 5.0
           wide: 99.0
-        warmup_trades: 0
+        warmup_trades: 2
       cli_args:
         equity: 100000
         auto_state: false
@@ -204,7 +209,8 @@ def test_run_sim_with_manifest(tmp_path: Path) -> None:
     assert rc == 0
     assert json_out.exists()
     data = json.loads(json_out.read_text(encoding="utf-8"))
-    assert "trades" in data
+    assert data["trades"] > 0
+    assert data.get("runtime", {}).get("fills", 0) > 0
     assert data["symbol"] == "USDJPY"
     assert data["mode"] == "conservative"
     assert data["debug"]["csv_loader"]["skipped_rows"] == 0
@@ -264,13 +270,18 @@ def test_run_sim_warns_when_rows_skipped(tmp_path: Path, capsys: pytest.CaptureF
     assert rc == 0
     captured = capsys.readouterr()
     assert "Skipped 1 CSV row" in captured.err
+    assert "last_error=price_parse_error" in captured.err
     data = json.loads(json_out.read_text(encoding="utf-8"))
     loader_debug = data["debug"]["csv_loader"]
     assert loader_debug["skipped_rows"] == 1
     assert loader_debug["last_error_code"] == "price_parse_error"
+    assert loader_debug["reason_counts"] == {"price_parse_error": 1}
+    assert loader_debug["last_row"]["line"] == 2
 
 
-def test_run_sim_strict_raises_on_skips(tmp_path: Path) -> None:
+def test_run_sim_strict_raises_on_skips(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
     manifest_path = _write_manifest(tmp_path)
     csv_path = tmp_path / "bars.csv"
     csv_path.write_text(
@@ -294,6 +305,10 @@ def test_run_sim_strict_raises_on_skips(tmp_path: Path) -> None:
     assert excinfo.value.code == "rows_skipped"
     assert excinfo.value.details is not None
     assert "skipped=1" in excinfo.value.details
+    assert "last_error=price_parse_error" in excinfo.value.details
+    captured = capsys.readouterr()
+    assert "Skipped 1 CSV row" in captured.err
+    assert "last_error=price_parse_error" in captured.err
 
 
 def test_run_sim_creates_run_directory(tmp_path: Path) -> None:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -98,6 +98,7 @@ def test_session_of_ts_handles_extended_iso_with_offset() -> None:
 def test_session_of_ts_handles_basic_iso_z_suffix() -> None:
     runner = BacktestRunner(100_000.0, "USDJPY")
     assert runner._session_of_ts("20240101T075959Z") == "TOK"
+    assert runner._session_of_ts("20240101T080000Z") == "LDN"
     assert runner._session_of_ts("20240101T131500Z") == "NY"
 
 
@@ -107,6 +108,20 @@ def test_session_of_ts_records_parse_errors() -> None:
     assert runner.debug_counts["session_parse_error"] == 1
     assert runner.debug_records[0]["stage"] == "session_parse_error"
     assert runner.debug_records[0]["text"] == "invalid-ts"
+
+
+def test_update_daily_state_classifies_basic_iso_session() -> None:
+    runner = BacktestRunner(100_000.0, "USDJPY")
+    bar_ldn = {"timestamp": "20240101T080000Z"}
+    new_session, session, calibrating = runner._update_daily_state(bar_ldn)
+    assert new_session is True
+    assert session == "LDN"
+    assert calibrating is False
+
+    bar_same_session = {"timestamp": "20240101T081500Z"}
+    new_session_repeat, session_repeat, _ = runner._update_daily_state(bar_same_session)
+    assert new_session_repeat is False
+    assert session_repeat == "LDN"
 
 
 class TestRunner(unittest.TestCase):


### PR DESCRIPTION
## Summary
- tighten the run_sim CLI skip-diagnostics tests to assert reason counts and explicit last_error messaging in tolerant and strict paths
- log the refreshed pytest workflow guidance in `state.md`

## Testing
- python3 -m pytest tests/test_run_sim_cli.py tests/test_runner.py
- python3 -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5b7281a30832aae9e48d03e8cf80d