### PR TITLE
Ensure CSV loader strict mode raises on skipped rows

### DIFF
--- a/state.md
+++ b/state.md
@@ -2,6 +2,7 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
+- 2026-04-14: Hardened `load_bars_csv` strict enforcement to raise when rows are skipped, extended CLI loader regressions for strict vs tolerant parsing, confirmed script helpers keep `strict=False`, and ran `python3 -m pytest tests/test_run_sim_cli.py`.
 - 2026-04-12: Added manifest instrument selection flags to `scripts/run_sim.py`, refreshed CLI regression/README guidance, and ran `python3 -m pytest`.
 - 2026-04-13: Normalised `scripts/run_sim.py` JSON output path resolution for relative values, added a CLI regression verifying repo-root anchoring, refreshed README guidance, and ran `python3 -m pytest tests/test_run_sim_cli.py`.
 - 2026-04-11: Hardened `scripts/run_sim.py` EV aggregation failure handling to bubble subprocess output with a non-zero exit, added a CLI regression for the failure path, and ran `python3 -m pytest`.

--- a/tests/test_run_sim_cli.py
+++ b/tests/test_run_sim_cli.py
@@ -212,6 +212,32 @@ def test_load_bars_csv_collects_skip_stats(tmp_path: Path) -> None:
     assert iterator.stats.skipped_rows == 1
 
 
+def test_load_bars_csv_strict_raises_on_skip(tmp_path: Path) -> None:
+    csv_path = tmp_path / "bars.csv"
+    csv_path.write_text(
+        "timestamp,symbol,tf,o,h,l,c,v,spread\n"
+        "2024-01-01T09:00:00Z,USDJPY,5m,150.10,150.20,150.00,bad,0,0.01\n"
+        "2024-01-01T09:05:00Z,USDJPY,5m,150.11,150.21,150.01,150.13,0,0.02\n",
+        encoding="utf-8",
+    )
+
+    iterator = load_bars_csv(
+        str(csv_path),
+        symbol="USDJPY",
+        default_symbol="USDJPY",
+        default_tf="5m",
+        strict=True,
+    )
+
+    with pytest.raises(CSVFormatError) as exc:
+        list(iterator)
+
+    assert exc.value.code == "rows_skipped"
+    assert exc.value.details is not None
+    assert "last_error=price_parse_error" in exc.value.details
+    assert iterator.stats.skipped_rows == 1
+
+
 def test_load_bars_csv_requires_symbol_when_missing(tmp_path: Path) -> None:
     csv_path = tmp_path / "bars.csv"
     csv_path.write_text(CSV_OHLC_ONLY, encoding="utf-8")


### PR DESCRIPTION
## Summary
- raise `CSVFormatError` from `load_bars_csv` whenever strict mode encounters skipped rows, including reason and line metadata
- extend CLI loader tests to cover strict failure vs tolerant skip accumulation and document the worklog update
- verified that helper scripts (`run_compare`, `run_grid`) continue to pass `strict=False` explicitly to preserve tolerant behaviour

## Testing
- python3 -m pytest tests/test_run_sim_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68e5e37c9710832a86fbff3a510f0f3c