### PR TITLE
feat: extend signal latency reporting

### DIFF
--- a/docs/signal_ops.md
+++ b/docs/signal_ops.md
@@ -9,11 +9,21 @@
 - `scripts/analyze_signal_latency.py` で SLO をチェックできます。
 
 ```
-python3 scripts/analyze_signal_latency.py --input ops/signal_latency.csv --slo-threshold 5
+python3 scripts/analyze_signal_latency.py \
+  --input ops/signal_latency.csv \
+  --slo-threshold 5 \
+  --failure-threshold 0.01 \
+  --out-json ops/latency_summary.json \
+  --out-csv ops/latency_summary.csv
 ```
 
 - `p95_latency` が閾値を超える、または失敗率が 1% を超えると終了コード 1 になります。
-- `--json-out` を指定すると JSON 形式でレポートを保存します。
+- JSON 出力 (`--out-json` / 互換の `--json-out`) には `thresholds` キーが含まれ、`p95_latency` / `failure_rate` の違反有無と閾値がまとめられます。
+- CSV 出力 (`--out-csv`) は `metric,value,threshold,breach` 列で保存され、ダッシュボードや BI 取り込み時に利用します。
+
+### CSV ローテーション
+- `ops/rotate_signal_latency.sh` で `ops/signal_latency.csv` を日次ローテーションし、当日の CSV をヘッダ付きの空ファイルとして再生成します。ローテーション済みファイルは `ops/archive/` に日付付きで保存されます。
+- サンプルスケジュールは `ops/signal_latency_rotation.cron` に記載しています。UTC で 00:05 に実行し、ローテーション後に `scripts/analyze_signal_latency.py` を別ジョブで流す想定です。実環境ではパスをリポジトリ設置場所に合わせて書き換えてください。
 
 ## 運用のポイント
 - 通知に利用する Webhook URL は secrets 管理（環境変数や Vault 等）で扱い、CI/CD で差し替えやすいようにしておくと便利です。

--- a/ops/rotate_signal_latency.sh
+++ b/ops/rotate_signal_latency.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CSV_PATH="${SCRIPT_DIR}/signal_latency.csv"
+ARCHIVE_DIR="${SCRIPT_DIR}/archive"
+
+mkdir -p "${ARCHIVE_DIR}"
+
+if [[ ! -f "${CSV_PATH}" ]]; then
+  printf 'signal_id,ts_emit,ts_ack,status,detail\n' > "${CSV_PATH}"
+  printf 'Initialized %s with default header\n' "${CSV_PATH}"
+  exit 0
+fi
+
+timestamp="$(date -u +"%Y%m%dT%H%M%SZ")"
+archive_path="${ARCHIVE_DIR}/signal_latency_${timestamp}.csv"
+
+mv "${CSV_PATH}" "${archive_path}"
+header_line="$(head -n 1 "${archive_path}" 2>/dev/null || printf 'signal_id,ts_emit,ts_ack,status,detail')"
+printf '%s\n' "${header_line}" > "${CSV_PATH}"
+
+printf 'Rotated %s to %s\n' "${CSV_PATH}" "${archive_path}"

--- a/ops/signal_latency_rotation.cron
+++ b/ops/signal_latency_rotation.cron
@@ -1,0 +1,3 @@
+# Example cron configuration for rotating ops/signal_latency.csv (UTC)
+# Replace /opt/codex with the actual repository root on the target host.
+5 0 * * * cd /opt/codex && /usr/bin/env bash ops/rotate_signal_latency.sh >> /var/log/signal_latency_rotation.log 2>&1

--- a/scripts/analyze_signal_latency.py
+++ b/scripts/analyze_signal_latency.py
@@ -6,7 +6,7 @@ import csv
 import json
 from datetime import datetime
 from pathlib import Path
-from typing import List, Dict
+from typing import Dict, Iterable, List, cast
 
 
 def parse_iso(ts: str) -> datetime:
@@ -47,23 +47,54 @@ def percentile(values: List[float], pct: float) -> float:
     return values_sorted[k]
 
 
-def analyze(records: List[Dict[str, object]], slo_threshold: float) -> Dict[str, object]:
+def analyze(
+    records: List[Dict[str, object]],
+    latency_threshold: float,
+    failure_threshold: float,
+) -> Dict[str, object]:
     total = len(records)
     failures = sum(1 for r in records if r.get("status") != "success")
     latencies = [float(r["latency"]) for r in records if isinstance(r.get("latency"), (int, float))]
-    over_slo = sum(1 for r in latencies if r > slo_threshold)
+    latency_count = len(latencies)
+    over_slo = sum(1 for r in latencies if r > latency_threshold)
+
+    failure_rate = (failures / total) if total else 0.0
+    avg_latency = (sum(latencies) / latency_count) if latencies else 0.0
+    p50_latency = percentile(latencies, 50) if latencies else 0.0
+    p95_latency = percentile(latencies, 95) if latencies else 0.0
+    p99_latency = percentile(latencies, 99) if latencies else 0.0
 
     summary = {
         "total": total,
         "failures": failures,
-        "failure_rate": (failures / total) if total else 0.0,
-        "avg_latency": (sum(latencies) / len(latencies)) if latencies else 0.0,
-        "p50_latency": percentile(latencies, 50) if latencies else 0.0,
-        "p95_latency": percentile(latencies, 95) if latencies else 0.0,
-        "p99_latency": percentile(latencies, 99) if latencies else 0.0,
-        "slo_threshold": slo_threshold,
-        "slo_breach_ratio": (over_slo / len(latencies)) if latencies else 0.0,
+        "failure_rate": failure_rate,
+        "avg_latency": avg_latency,
+        "p50_latency": p50_latency,
+        "p95_latency": p95_latency,
+        "p99_latency": p99_latency,
+        "slo_threshold": latency_threshold,
+        "slo_breach_ratio": (over_slo / latency_count) if latencies else 0.0,
+        "latency_samples": latency_count,
     }
+
+    thresholds = {
+        "p95_latency": {
+            "value": p95_latency,
+            "threshold": latency_threshold,
+            "breach": p95_latency > latency_threshold,
+            "count_above_threshold": over_slo,
+        },
+        "failure_rate": {
+            "value": failure_rate,
+            "threshold": failure_threshold,
+            "breach": failure_rate > failure_threshold,
+            "count_above_threshold": failures,
+        },
+    }
+    summary["thresholds"] = thresholds
+    summary["slo_breaches"] = [name for name, info in thresholds.items() if info["breach"]]
+    summary["slo_breach_count"] = len(summary["slo_breaches"])
+    summary["has_breach"] = bool(summary["slo_breaches"])
     return summary
 
 
@@ -71,19 +102,56 @@ def parse_args(argv=None):
     p = argparse.ArgumentParser(description="Analyze signal latency log")
     p.add_argument("--input", default="ops/signal_latency.csv", help="Path to latency CSV")
     p.add_argument("--slo-threshold", type=float, default=5.0, help="SLO閾値 (秒) (p95<=threshold)\n")
-    p.add_argument("--json-out", default=None, help="結果をJSONで出力するパス")
+    p.add_argument("--failure-threshold", type=float, default=0.01, help="Failure rate threshold (0-1 fraction)")
+    p.add_argument("--out-json", dest="out_json", default=None, help="結果JSONの出力先")
+    p.add_argument("--json-out", dest="out_json", help=argparse.SUPPRESS)
+    p.add_argument("--out-csv", dest="out_csv", default=None, help="結果CSVの出力先")
     return p.parse_args(argv)
+
+
+def write_summary_csv(summary: Dict[str, object], path: Path) -> None:
+    fieldnames = ["metric", "value", "threshold", "breach"]
+    metrics: Iterable[str] = (
+        "total",
+        "failures",
+        "failure_rate",
+        "avg_latency",
+        "p50_latency",
+        "p95_latency",
+        "p99_latency",
+        "slo_breach_ratio",
+        "latency_samples",
+    )
+    thresholds = cast(Dict[str, Dict[str, object]], summary.get("thresholds", {}))
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for metric in metrics:
+            threshold_info = thresholds.get(metric)
+            writer.writerow(
+                {
+                    "metric": metric,
+                    "value": summary.get(metric, ""),
+                    "threshold": (threshold_info or {}).get("threshold", ""),
+                    "breach": (threshold_info or {}).get("breach", ""),
+                }
+            )
 
 
 def main(argv=None) -> int:
     args = parse_args(argv)
     path = Path(args.input)
     records = load_latencies(path)
-    summary = analyze(records, args.slo_threshold)
+    summary = analyze(records, args.slo_threshold, args.failure_threshold)
     print(json.dumps(summary, ensure_ascii=False, indent=2))
-    if args.json_out:
-        Path(args.json_out).write_text(json.dumps(summary, ensure_ascii=False, indent=2), encoding="utf-8")
-    if summary["p95_latency"] > args.slo_threshold or summary["failure_rate"] > 0.01:
+    if args.out_json:
+        Path(args.out_json).write_text(
+            json.dumps(summary, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+    if args.out_csv:
+        write_summary_csv(summary, Path(args.out_csv))
+    if summary["thresholds"]["p95_latency"]["breach"] or summary["thresholds"]["failure_rate"]["breach"]:
         return 1
     return 0
 

--- a/state.md
+++ b/state.md
@@ -2,6 +2,7 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist.
+- 2026-04-15: Extended `scripts/analyze_signal_latency.py` with JSON/CSV SLO出力と `--failure-threshold`、`ops/rotate_signal_latency.sh` / `ops/signal_latency_rotation.cron` を追加して日次ローテーション手順を整備。`docs/signal_ops.md` / `README.md` を更新し、`tests/test_analyze_signal_latency.py` で SLO 違反検知を回帰。`python3 -m pytest` と CLI 実行例 (`python3 scripts/analyze_signal_latency.py --input /tmp/latency_sample.csv --out-json /tmp/latency.json --out-csv /tmp/latency.csv`) を完了。
 - 2025-10-08: Drafted `docs/codex_quickstart.md`, trimmed `docs/state_runbook.md` checklists, refreshed README/roadmap/backlog links, and ran `python3 scripts/manage_task_cycle.py --dry-run finish-task --anchor docs/task_backlog.md#p0-12-codex-first-documentation-cleanup --date 2025-10-08 --note "Refreshed Codex quickstart, state runbook, and roadmap anchors"`.
 - 2026-04-14: Hardened `load_bars_csv` strict enforcement to raise when rows are skipped, extended CLI loader regressions for strict vs tolerant parsing, confirmed script helpers keep `strict=False`, and ran `python3 -m pytest tests/test_run_sim_cli.py`.
 - 2026-04-12: Added manifest instrument selection flags to `scripts/run_sim.py`, refreshed CLI regression/README guidance, and ran `python3 -m pytest`.

--- a/tests/test_analyze_signal_latency.py
+++ b/tests/test_analyze_signal_latency.py
@@ -1,0 +1,59 @@
+import csv
+import json
+
+import scripts.analyze_signal_latency as analyze_module
+
+
+def test_analyze_flags_latency_breach():
+    records = [
+        {"latency": 2.0, "status": "success"},
+        {"latency": 8.0, "status": "success"},
+        {"latency": 9.0, "status": "success"},
+    ]
+
+    summary = analyze_module.analyze(records, latency_threshold=5.0, failure_threshold=0.5)
+
+    assert summary["thresholds"]["p95_latency"]["breach"] is True
+    assert summary["thresholds"]["failure_rate"]["breach"] is False
+    assert summary["slo_breach_ratio"] == 2 / summary["latency_samples"]
+
+
+def test_main_writes_structured_outputs(tmp_path):
+    csv_path = tmp_path / "latency.csv"
+    csv_path.write_text(
+        "signal_id,ts_emit,ts_ack,status,detail\n"
+        "id1,2025-01-01T00:00:00+00:00,2025-01-01T00:00:01+00:00,success,ok\n"
+        "id2,2025-01-01T00:00:01+00:00,2025-01-01T00:00:02+00:00,success,ok\n",
+        encoding="utf-8",
+    )
+    out_json = tmp_path / "summary.json"
+    out_csv = tmp_path / "summary.csv"
+
+    exit_code = analyze_module.main(
+        [
+            "--input",
+            str(csv_path),
+            "--slo-threshold",
+            "5",
+            "--failure-threshold",
+            "0.25",
+            "--out-json",
+            str(out_json),
+            "--out-csv",
+            str(out_csv),
+        ]
+    )
+
+    assert exit_code == 0
+
+    summary = json.loads(out_json.read_text(encoding="utf-8"))
+    assert summary["latency_samples"] == 2
+    assert summary["thresholds"]["p95_latency"]["breach"] is False
+    assert summary["thresholds"]["failure_rate"]["breach"] is False
+
+    with out_csv.open(newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+
+    assert rows[0]["metric"] == "total"
+    assert rows[5]["metric"] == "p95_latency"
+    assert rows[5]["breach"] in {"False", ""}


### PR DESCRIPTION
## Summary
- extend `scripts/analyze_signal_latency.py` with SLO threshold metadata, JSON/CSV exports, and a failure-rate guard
- document the CLI in the README/runbook and provide cron-friendly rotation assets for `ops/signal_latency.csv`
- add regression coverage for SLO breaches and update state.md with the completed workflow note

## Testing
- python3 -m pytest
- python3 scripts/analyze_signal_latency.py --input /tmp/latency_sample.csv --out-json /tmp/latency.json --out-csv /tmp/latency.csv

------
https://chatgpt.com/codex/tasks/task_e_68e61a0284fc832a9a4272e9b988edf0