### PR TITLE
Move docs/todo_next archive entries to dedicated file

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ python3 scripts/manage_task_cycle.py --dry-run finish-task \
        --anchor docs/task_backlog.md#p1-10-ローリング検証パイプライン \
        --note "Sharpe/最大DD の監視とローリングrunの自動起動を整備"
    ```
-   - `state.md` から当該タスクを削除し `## Log` に完了メモを追記、`docs/todo_next.md` は `## Archive` セクションへストライク付きで移動し日付/✅が補完されます。
+   - `state.md` から当該タスクを削除し `## Log` に完了メモを追記、`docs/todo_next.md` から該当ブロックを外して [docs/todo_next_archive.md](docs/todo_next_archive.md) へストライク付きで移すと日付/✅が補完されます。
 
 > 補足: すべてのコマンドで `--date` は ISO 形式 (YYYY-MM-DD) を要求し、アンカーは `docs/task_backlog.md#...` で指定してください。
 

--- a/docs/checklists/p1-01.md
+++ b/docs/checklists/p1-01.md
@@ -19,7 +19,7 @@
 
 ## 成果物とログ更新
 - [x] `state.md` の `## Log` へ完了サマリを追記した。
-- [x] [docs/todo_next.md](../todo_next.md) の該当エントリを Archive へ移動した。
+- [x] [docs/todo_next_archive.md](../todo_next_archive.md) の該当エントリへ移し、`docs/todo_next.md` 側からは削除した。
 - [x] 関連コード/レポート/Notebook のパスを記録した。
 - [x] レビュー/承認者を記録した。
 

--- a/docs/checklists/p1-04_api_ingest.md
+++ b/docs/checklists/p1-04_api_ingest.md
@@ -38,7 +38,7 @@
 ## 成果物とログ更新
 - [x] `docs/state_runbook.md` と `README.md` のインジェスト手順を更新した（yfinance フェイルオーバー・依存導入・鮮度閾値レビューを記載）。
 - [x] `state.md` の `## Log` に完了サマリを追記した（2025-11-28 12:10Z 実行結果を記録）。
-- [x] [docs/todo_next.md](../todo_next.md) の該当エントリを Archive へ移動した（In Progress セクションは空へ整理）。
+- [x] [docs/todo_next_archive.md](../todo_next_archive.md) の該当エントリへ移し、`docs/todo_next.md` 側からは削除した（In Progress セクションは空へ整理）。
 - [x] 関連コード/設定ファイル/テストのパスを記録した（`scripts/run_daily_workflow.py`, `scripts/check_benchmark_freshness.py`, `ops/runtime_snapshot.json`）。
 - [x] レビュー/承認者を記録した（Self-review: Codex Operator, 2025-11-28）。
 
@@ -91,7 +91,7 @@
 - `python3 scripts/check_benchmark_freshness.py --target USDJPY:conservative --max-age-hours 6 --ingest-timeframe USDJPY_5m`
   - `ok: true` かつ `errors: []`・`advisories: []` を確認。`benchmark_pipeline` 側の遅延は 0.59h 以内、`ingest_metadata.freshness_minutes=0.614` を出力。
 - `ops/runtime_snapshot.json.benchmark_pipeline.USDJPY_conservative` を再確認し、`warnings: []`・`threshold_alerts: []` のまま `alert.triggered=true`（Sharpe delta 情報共有用）でエラー無しを確認。
-- ドキュメント同期: `state.md` ログ、`docs/todo_next.md` Archive、`docs/task_backlog.md#p1-04-価格インジェストapi基盤整備` へ完了メモを追加し、本チェックリストの未チェック項目をクローズ。
+- ドキュメント同期: `state.md` ログ、[docs/todo_next_archive.md](../todo_next_archive.md)、`docs/task_backlog.md#p1-04-価格インジェストapi基盤整備` へ完了メモを追加し、本チェックリストの未チェック項目をクローズ。
 
 ### 2025-11-24 Synthetic extension toggle
 - 運用側の要望で、ローカル CSV 復旧時に合成バーを挿入せず鮮度遅延を可視化したいケースに対応。`python3 scripts/run_daily_workflow.py --ingest --use-dukascopy --disable-synthetic-extension` を追加し、`ingest_meta` に `synthetic_local` が含まれない経路を選択できるようにした。

--- a/docs/checklists/p1-07_phase1_bug_refactor.md
+++ b/docs/checklists/p1-07_phase1_bug_refactor.md
@@ -55,7 +55,7 @@ python3 scripts/manage_task_cycle.py --dry-run finish-task \
     --task-id P1-07
 ```
 
-ドライランで内容を確認したうえで `--dry-run` を外す。完了後は `state.md` と `docs/todo_next.md` の該当ブロックを Archive/Log へ移動する。
+ドライランで内容を確認したうえで `--dry-run` を外す。完了後は `state.md` の該当ブロックを Log へ移し、[docs/todo_next_archive.md](../todo_next_archive.md) へエントリを移動する。
 
 ## リファクタリング計画テンプレート
 - [x] リファクタリング候補を「影響範囲」「期待効果」「リスク」「リグレッションテスト」の列で整理するテンプレートを追加した。
@@ -107,4 +107,4 @@ python3 scripts/manage_task_cycle.py --dry-run finish-task \
 ## クローズ条件
 - [x] 主要バグ観点（実行系、戦略ロジック、データパイプライン、ドキュメントギャップ）について調査完了/未解決/フォローアップのステータスが整理され、`docs/todo_next.md` へリンクされている。
 - [x] リファクタリング候補リストに優先度付けと担当候補が記載され、次フェーズ以降に引き継ぐための TODO が残っていない。
-- [x] 本チェックリストをすべて更新し、`docs/task_backlog.md` / `docs/todo_next.md` / `state.md` の該当エントリを Archive/Log へ移動した。
+- [x] 本チェックリストをすべて更新し、`docs/task_backlog.md` / [docs/todo_next_archive.md](../todo_next_archive.md) / `state.md` の該当エントリを Archive/Log へ移動した。

--- a/docs/checklists/p2_manifest.md
+++ b/docs/checklists/p2_manifest.md
@@ -31,7 +31,7 @@
 - [x] 追加した検証ログを `state.md` の該当ブロックへ追記。
 
 ## ドキュメント同期
-- [x] `docs/todo_next.md` の In Progress 項目を最新化し、完了後は Archive へ移動。
+- [x] `docs/todo_next.md` の In Progress 項目を最新化し、完了後は [docs/todo_next_archive.md](../todo_next_archive.md) へ移動。
 - [x] `docs/task_backlog.md` の P2 セクションへ進捗メモを追記。
 - [x] `state.md` に完了ログを記録し、Next Task を更新。
 

--- a/docs/checklists/p2_router.md
+++ b/docs/checklists/p2_router.md
@@ -23,8 +23,8 @@
 
 ## 成果物とログ更新
 - [x] `state.md` の `## Log` へ完了サマリを追記した。
-- [x] [docs/todo_next.md](../todo_next.md) の該当エントリを Archive へ移動した。
+- [x] [docs/todo_next_archive.md](../todo_next_archive.md) の該当エントリへ移し、`docs/todo_next.md` 側からは削除した。
 - [x] 関連コード/レポート/Notebook のパスを記録した。
 - [ ] レビュー/承認者を記録した。
 
-> Ready 昇格チェックと固有 DoD を満たしたら、`docs/todo_next.md` から本チェックリストへリンクし、進捗を同期してください。
+> Ready 昇格チェックと固有 DoD を満たしたら、`docs/todo_next.md` から本チェックリストへリンクし、完了後はアーカイブ ([docs/todo_next_archive.md](../todo_next_archive.md)) へ移して同期してください。

--- a/docs/codex_quickstart.md
+++ b/docs/codex_quickstart.md
@@ -20,7 +20,7 @@ Codex オペレータが 1 セッションで追従すべき流れを 1 ペー�
 - 変更をレビュー → `git status` / `git diff` で不要ファイルが無いか確認。
 - テスト証跡を整理 → 実行したコマンドを `state.md` ログとコミットメッセージに記録。
 - `scripts/manage_task_cycle.py --dry-run finish-task --anchor <docs/task_backlog.md#...>` で close-out をプレビューし、問題なければ `--dry-run` を外して適用。
-- `docs/todo_next.md` の該当ブロックを Archive へ移動し、`README.md` / ランブックのリンクが最新であることを確認。
+- `docs/todo_next.md` の該当ブロックを [docs/todo_next_archive.md](todo_next_archive.md) へ移動し、`README.md` / ランブックのリンクが最新であることを確認。
 
 ## 4. よく使うコマンド
 | 目的 | コマンド例 |

--- a/docs/codex_workflow.md
+++ b/docs/codex_workflow.md
@@ -39,7 +39,7 @@ One-page の流れは [docs/codex_quickstart.md](codex_quickstart.md) に集約�
 
 ### 3. Wrap-up
 - `state.md` → `## Log` にセッション結果を追記し、`## Next Task` から完了したタスクを除外。
-- `docs/todo_next.md` は `In Progress` → `Archive` へ移動し、アンカーコメント（`<!-- anchor: ... -->`）が残っているか確認。
+- `docs/todo_next.md` の該当ブロックを [docs/todo_next_archive.md](docs/todo_next_archive.md) へ移動し、アンカーコメント（`<!-- anchor: ... -->`）が残っているか確認。
 - `docs/task_backlog.md` の対象項目にリンクやノートを追加する。完了済みなら該当タスクを打ち消し線で囲み、進捗メモを最終ログとして残す。
 - テスト証跡（実行コマンド）はコミットメッセージと PR テンプレの両方に記録する。
 

--- a/docs/task_backlog.md
+++ b/docs/task_backlog.md
@@ -98,7 +98,7 @@ Document the repeatable workflow that lets Codex keep `state.md`, `docs/todo_nex
 
 **完了記録**
 - `docs/checklists/p1-07_phase1_bug_refactor.md` へ調査チェックボード・テスト手順・リファクタリング計画テンプレ・ドキュメント更新チェックを追加し、DoD セクションの項目を全て充足。
-- `docs/todo_next.md` の Ready から当該タスクを除外し、Archive へ移動。`state.md` の `## Log` に完了メモを追記し、`## Next Task` からアンカーを取り外した。
+- `docs/todo_next.md` の Ready から当該タスクを除外し、[docs/todo_next_archive.md](docs/todo_next_archive.md) へ移動。`state.md` の `## Log` に完了メモを追記し、`## Next Task` からアンカーを取り外した。
 - バックログ本節をクローズ扱いに変更し、後続作業は必要に応じて新タスク（例: P2 系列）として起票する方針。
 
 **進捗メモ（アーカイブ）**

--- a/docs/templates/dod_checklist.md
+++ b/docs/templates/dod_checklist.md
@@ -19,7 +19,7 @@
 
 ## 成果物とログ更新
 - [ ] `state.md` の `## Log` へ完了サマリを追記した。
-- [ ] [docs/todo_next.md](../todo_next.md) の該当エントリを Archive へ移動した。
+- [ ] [docs/todo_next_archive.md](../todo_next_archive.md) の該当エントリへ移し、`docs/todo_next.md` 側からは削除した。
 - [ ] 関連コード/レポート/Notebook のパスを記録した。
 - [ ] レビュー/承認者を記録した。
 

--- a/docs/todo_next.md
+++ b/docs/todo_next.md
@@ -29,64 +29,10 @@
 
 ## Archive（達成済み）
 
-- **ルーター拡張** (Backlog: `docs/task_backlog.md` → [P2-マルチ戦略ポートフォリオ化](docs/task_backlog.md#p2-マルチ戦略ポートフォリオ化)) — 2026-02-13 完了 <!-- anchor: docs/task_backlog.md#p2-マルチ戦略ポートフォリオ化 -->
-  - Finalised PortfolioState budgeting, correlation scoring, and execution-health penalties. Synced `docs/checklists/p2_router.md`, refreshed `docs/progress_phase2.md` deliverable notes, updated backlog progress, and ran `python3 -m pytest tests/test_router_v1.py tests/test_router_pipeline.py` before closing。
-- **マルチ戦略比較バリデーション** (Backlog: `docs/task_backlog.md` → [P2-マルチ戦略ポートフォリオ化](docs/task_backlog.md#p2-マルチ戦略ポートフォリオ化)) — 2026-02-13 完了
-  - Regenerated `runs/multi_strategy/` artefacts, compared Day ORB vs Mean Reversion (`ev_reject=0` vs `330`), and confirmed `--no-ev-profile` の挙動が不変。`docs/checklists/multi_strategy_validation.md` のサマリ表と実測メモを更新し、チェックリスト完了状態を維持。
-- **Fill エンジン / ブローカー仕様アライン** (Backlog: `docs/task_backlog.md` → [P1-06](docs/task_backlog.md#p1-06-fill-エンジン--ブローカー仕様アライン)) — 2026-02-13 完了
-  - Added fill-engine overrides (`fill_same_bar_policy_*`, `fill_bridge_lambda`, `fill_bridge_drift_scale`) to RunnerConfig と manifest (`runner.runner_config`). Updated docs (`docs/broker_oco_matrix.md`, `docs/benchmark_runbook.md`, `docs/progress_phase1.md`) and regression suites (`tests/test_runner.py`, `tests/test_run_sim_cli.py`) before closing。
-- ~~**フェーズ1 バグチェック & リファクタリング運用整備**~~ ✅ — `state.md` 2026-01-08 <!-- anchor: docs/task_backlog.md#p1-07-フェーズ1-バグチェック--リファクタリング運用整備 -->
-  - `docs/checklists/p1-07_phase1_bug_refactor.md` に調査チェックボード・テスト手順・リファクタリング計画テンプレを追加し、運用チェック項目を全て埋めた。`scripts/manage_task_cycle.py` の start/finish 例も掲載。
-  - `docs/task_backlog.md` から P1-07 をアーカイブし、`docs/todo_next.md` / `state.md` の Ready / Next Task ブロックを整理。今後はチェックボードの行追加と `state.md` ログ更新のみで継続できる。
+- 過去の達成済みログは [docs/todo_next_archive.md](docs/todo_next_archive.md) へ移動しました。履歴を参照する際はアーカイブファイルを確認してください。
+- `manage_task_cycle` のアンカープレースホルダは下記に残しています（削除しないでください）。
 
-- ~~**価格インジェストAPI基盤整備**~~ ✅ — `state.md` 2025-10-16, 2025-11-05, 2025-11-06, 2025-11-28 <!-- anchor: docs/task_backlog.md#p1-04-価格インジェストapi基盤整備 -->
-  - `python3 scripts/run_daily_workflow.py --ingest --use-dukascopy --symbol USDJPY --mode conservative` を実行し、yfinance フォールバックで 91 行を取り込み `ops/runtime_snapshot.json.ingest_meta.USDJPY_5m.freshness_minutes=0.614` を確認。
-  - 続けて `python3 scripts/check_benchmark_freshness.py --target USDJPY:conservative --max-age-hours 6 --ingest-timeframe USDJPY_5m` を実行し、`ok: true`・`errors: []`・`advisories: []` を確認。`benchmark_pipeline` 側も遅延 0.59h 以内を維持。
-  - `state.md` / `docs/checklists/p1-04_api_ingest.md` / `docs/api_ingest_plan.md` / `docs/state_runbook.md` / `README.md` の該当箇所を再確認し、フォールバック仕様と依存導入手順が現行運用と一致していることをレビューしたうえで todo を Archive へ移動。
-- ~~**ローリング検証パイプライン**~~ ✅ — `state.md` 2025-11-27 <!-- anchor: docs/task_backlog.md#p1-01-ローリング検証パイプライン -->
-  - `python3 scripts/run_benchmark_pipeline.py --windows 365,180,90 --disable-plot` を実行し、`reports/rolling/{365,180,90}/USDJPY_conservative.json` と `reports/benchmark_summary.json` に勝率・Sharpe・最大DDの最新値を反映。
-  - `python3 scripts/check_benchmark_freshness.py --target USDJPY:conservative --max-age-hours 6 --benchmark-freshness-max-age-hours 6` を完走させ、`ops/runtime_snapshot.json` の `benchmark_pipeline` セクションが `ok: true` で `errors` 空となることを確認。
-  - README / `docs/benchmark_runbook.md` のローリング検証手順を更新し、`docs/checklists/p1-01.md` / `docs/task_backlog.md` / `state.md` / `docs/todo_next.md` の関連メモを同期。完了ログを `state.md` の `## Log` に追記済み。
-- ~~**目標指数の定義**~~ ✅ — `state.md` 2024-06-01 <!-- anchor: docs/task_backlog.md#目標指数の定義 -->
-  - `configs/targets.json` と `scripts/evaluate_targets.py` を整備済み。
-- ~~**ウォークフォワード検証**~~ ✅ — `state.md` 2024-06-02, 2024-06-03 <!-- anchor: docs/task_backlog.md#ウォークフォワード検証 -->
-  - `scripts/run_walk_forward.py` を追加し、`analysis/wf_log.json` に窓別ログを出力。
-- ~~**自動探索の高度化**~~ ✅ — `state.md` 2024-06-04 <!-- anchor: docs/task_backlog.md#自動探索の高度化 -->
-  - `scripts/run_optuna_search.py` で多指標目的の探索骨子を構築。
-- ~~**運用ループへの組み込み**~~ ✅ — `state.md` 2024-06-05 <!-- anchor: docs/task_backlog.md#運用ループへの組み込み -->
-  - `scripts/run_target_loop.py` による Optuna → run_sim → 指標計算 → 判定のループを実装。
-- ~~**state ヘルスチェック**~~ ✅ — `state.md` 2024-06-11 <!-- anchor: docs/task_backlog.md#state-ヘルスチェック -->
-  - `scripts/check_state_health.py` の警告生成・履歴ローテーション・Webhook テストを追加。
-- ~~**ベースライン/ローリング run 起動ジョブ**~~ ✅ — `state.md` 2024-06-12 <!-- anchor: docs/task_backlog.md#ベースラインローリング-run-起動ジョブ -->
-  - `scripts/run_benchmark_pipeline.py` と `tests/test_run_benchmark_pipeline.py` を整備し、runbook を更新。
-- ~~**ベンチマークサマリー閾値伝播**~~ ✅ — `state.md` 2024-06-13 <!-- anchor: docs/task_backlog.md#ベンチマークサマリー閾値伝播 -->
-  - `run_daily_workflow.py` からの Webhook/閾値伝播と README 更新を完了。
-- ~~**絶対パス整備と CLI テスト強化**~~ ✅ — `state.md` 2024-06-14 <!-- anchor: docs/task_backlog.md#絶対パス整備と-cli-テスト強化 -->
-  - `run_daily_workflow.py` 最適化/状態アーカイブコマンドで絶対パスを使用するよう更新し、pytest で検証。
-
-- ~~**インシデントリプレイテンプレート**~~（バックログ: `docs/task_backlog.md` → P1「インシデントリプレイテンプレート」） — `state.md` 2024-06-14, 2024-06-15, 2024-06-21, 2025-12-01 ✅ <!-- anchor: docs/task_backlog.md#p1-02-インシデントリプレイテンプレート -->
-  - 期間指定リプレイ CLI の拡張と Notebook (`analysis/incident_review.ipynb`) のテンプレ整備を完了。`docs/state_runbook.md#インシデントリプレイワークフロー` と README に再現フロー/成果物の整理手順を追記し、`ops/incidents/<incident_id>/` の出力ファイル（`replay_notes.md`・`replay_params.json`・`runs/incidents/...`）掲載先とステークホルダー共有ルールを明文化した。
-
- ✅ <!-- anchor placeholder to satisfy manage_task_cycle start-task detection -->
+✅ <!-- anchor placeholder to satisfy manage_task_cycle start-task detection -->
 - <!-- docs/task_backlog.md#p2-マルチ戦略ポートフォリオ化 -->
   - DoD チェックリスト: [docs/templates/dod_checklist.md](docs/templates/dod_checklist.md) を [docs/checklists/p2_manifest.md](docs/checklists/p2_manifest.md) にコピーし、進捗リンクを更新する。
-
-- ~~**戦略マニフェスト整備**~~ (Backlog: `docs/task_backlog.md` → [P2-01](docs/task_backlog.md#p2-マルチ戦略ポートフォリオ化)) — `state.md` 2026-01-08 ✅ <!-- anchor: docs/task_backlog.md#p2-マルチ戦略ポートフォリオ化 -->
-  - `configs/strategies/*.yaml` を整理し、依存特徴量・セッション・リスク上限を統一形式で記述。`docs/checklists/p2_manifest.md` の DoD を参照して、RunnerConfig/CLI へのパラメータ伝播を検証する。
-  - `scripts/run_sim.py --manifest` の引数マッピングを再確認し、必要なら loader/CLI を更新。pytest (`tests/test_run_sim_cli.py`, `tests/test_mean_reversion_strategy.py` など) をターゲットに追加実行する。
-  - 2026-01-08: `strategies/scalping_template.py` / `strategies/day_template.py` / `strategies/tokyo_micro_mean_reversion.py` / `strategies/session_momentum_continuation.py` を追加し、対応する manifest (`configs/strategies/*.yaml`) を新設。`python3 -m pytest tests/test_strategy_manifest.py` (2 passed) と `python3 -m pytest tests/test_run_sim_cli.py -k manifest` (1 passed, 4 deselected) を実行済み。
-  - 2026-01-08: `python3 scripts/run_sim.py --manifest configs/strategies/tokyo_micro_mean_reversion.yaml --csv data/sample_orb.csv --json-out /tmp/tokyo_micro.json`、`python3 scripts/run_sim.py --manifest configs/strategies/session_momentum_continuation.yaml --csv data/sample_orb.csv --json-out /tmp/session_momo.json`、`python3 scripts/run_sim.py --manifest configs/strategies/day_orb_5m.yaml --csv data/sample_orb.csv --json-out /tmp/day_orb.json` を完了。manifest 経由の CLI 配線を確認し、DoD テスト項目を更新済み。各 manifest の `runner.cli_args` で auto_state / aggregate_ev を制御しながら再実行。
-  - manage_task_cycle start-task は Ready セクションのアンカー不一致で失敗したため、当面は手動更新を継続。ドキュメント更新後にアンカー修正を検討。
-  - Backlog Anchor: [戦略マニフェスト整備 (P2-01)](docs/task_backlog.md#p2-マルチ戦略ポートフォリオ化)
-  - Vision / Runbook References:
-    - [docs/logic_overview.md](docs/logic_overview.md)
-    - [docs/simulation_plan.md](docs/simulation_plan.md)
-    - 主要ランブック: [docs/state_runbook.md](docs/state_runbook.md)
-  - Pending Questions:
-    - [ ] Clarify gating metrics, data dependencies, or open questions.
-  - DoD チェックリスト: [docs/templates/dod_checklist.md](docs/templates/dod_checklist.md) を [docs/checklists/p2-01.md](docs/checklists/p2-01.md) にコピーし、進捗リンクを更新する。
-
-- ~~**Workflow Integration Guide**~~ (Backlog: `docs/task_backlog.md` → "ワークフロー統合" section) — `state.md` 2024-06-18, 2025-09-29, 2026-02-13, 2025-10-08 ✅ <!-- anchor: docs/task_backlog.md#codex-session-operations-guide -->
-  <!-- REVIEW: Archived after confirming workflow loop, dry-run coverage, and template links met the reviewer DoD. -->
-  - Documented the sandbox approval matrix (package installs, API calls, large transfers, privileged writes) and linked it from `docs/state_runbook.md`. Verified that the workflow trio (`docs/codex_workflow.md`, `docs/state_runbook.md`, `docs/todo_next.md`) now shares consistent anchors/terminology and preserves Japanese summaries while addressing reviewer feedback。
 

--- a/docs/todo_next_archive.md
+++ b/docs/todo_next_archive.md
@@ -1,0 +1,62 @@
+# docs/todo_next Archive
+
+過去の `docs/todo_next.md` Archive セクションに掲載していた完了済みタスクのログをこのファイルへ集約しました。各エントリのアンカーコメントは従来通り維持しています。
+
+- **ルーター拡張** (Backlog: `docs/task_backlog.md` → [P2-マルチ戦略ポートフォリオ化](docs/task_backlog.md#p2-マルチ戦略ポートフォリオ化)) — 2026-02-13 完了 <!-- anchor: docs/task_backlog.md#p2-マルチ戦略ポートフォリオ化 -->
+  - Finalised PortfolioState budgeting, correlation scoring, and execution-health penalties. Synced `docs/checklists/p2_router.md`, refreshed `docs/progress_phase2.md` deliverable notes, updated backlog progress, and ran `python3 -m pytest tests/test_router_v1.py tests/test_router_pipeline.py` before closing。
+- **マルチ戦略比較バリデーション** (Backlog: `docs/task_backlog.md` → [P2-マルチ戦略ポートフォリオ化](docs/task_backlog.md#p2-マルチ戦略ポートフォリオ化)) — 2026-02-13 完了
+  - Regenerated `runs/multi_strategy/` artefacts, compared Day ORB vs Mean Reversion (`ev_reject=0` vs `330`), and confirmed `--no-ev-profile` の挙動が不変。`docs/checklists/multi_strategy_validation.md` のサマリ表と実測メモを更新し、チェックリスト完了状態を維持。
+- **Fill エンジン / ブローカー仕様アライン** (Backlog: `docs/task_backlog.md` → [P1-06](docs/task_backlog.md#p1-06-fill-エンジン--ブローカー仕様アライン)) — 2026-02-13 完了
+  - Added fill-engine overrides (`fill_same_bar_policy_*`, `fill_bridge_lambda`, `fill_bridge_drift_scale`) to RunnerConfig と manifest (`runner.runner_config`). Updated docs (`docs/broker_oco_matrix.md`, `docs/benchmark_runbook.md`, `docs/progress_phase1.md`) and regression suites (`tests/test_runner.py`, `tests/test_run_sim_cli.py`) before closing。
+- ~~**フェーズ1 バグチェック & リファクタリング運用整備**~~ ✅ — `state.md` 2026-01-08 <!-- anchor: docs/task_backlog.md#p1-07-フェーズ1-バグチェック--リファクタリング運用整備 -->
+  - `docs/checklists/p1-07_phase1_bug_refactor.md` に調査チェックボード・テスト手順・リファクタリング計画テンプレを追加し、運用チェック項目を全て埋めた。`scripts/manage_task_cycle.py` の start/finish 例も掲載。
+  - `docs/task_backlog.md` から P1-07 をアーカイブし、`docs/todo_next.md` / `state.md` の Ready / Next Task ブロックを整理。今後はチェックボードの行追加と `state.md` ログ更新のみで継続できる。
+
+- ~~**価格インジェストAPI基盤整備**~~ ✅ — `state.md` 2025-10-16, 2025-11-05, 2025-11-06, 2025-11-28 <!-- anchor: docs/task_backlog.md#p1-04-価格インジェストapi基盤整備 -->
+  - `python3 scripts/run_daily_workflow.py --ingest --use-dukascopy --symbol USDJPY --mode conservative` を実行し、yfinance フォールバックで 91 行を取り込み `ops/runtime_snapshot.json.ingest_meta.USDJPY_5m.freshness_minutes=0.614` を確認。
+  - 続けて `python3 scripts/check_benchmark_freshness.py --target USDJPY:conservative --max-age-hours 6 --ingest-timeframe USDJPY_5m` を実行し、`ok: true`・`errors: []`・`advisories: []` を確認。`benchmark_pipeline` 側も遅延 0.59h 以内を維持。
+  - `state.md` / `docs/checklists/p1-04_api_ingest.md` / `docs/api_ingest_plan.md` / `docs/state_runbook.md` / `README.md` の該当箇所を再確認し、フォールバック仕様と依存導入手順が現行運用と一致していることをレビューしたうえで todo を Archive へ移動。
+- ~~**ローリング検証パイプライン**~~ ✅ — `state.md` 2025-11-27 <!-- anchor: docs/task_backlog.md#p1-01-ローリング検証パイプライン -->
+  - `python3 scripts/run_benchmark_pipeline.py --windows 365,180,90 --disable-plot` を実行し、`reports/rolling/{365,180,90}/USDJPY_conservative.json` と `reports/benchmark_summary.json` に勝率・Sharpe・最大DDの最新値を反映。
+  - `python3 scripts/check_benchmark_freshness.py --target USDJPY:conservative --max-age-hours 6 --benchmark-freshness-max-age-hours 6` を完走させ、`ops/runtime_snapshot.json` の `benchmark_pipeline` セクションが `ok: true` で `errors` 空となることを確認。
+  - README / `docs/benchmark_runbook.md` のローリング検証手順を更新し、`docs/checklists/p1-01.md` / `docs/task_backlog.md` / `state.md` / `docs/todo_next.md` の関連メモを同期。完了ログを `state.md` の `## Log` に追記済み。
+- ~~**目標指数の定義**~~ ✅ — `state.md` 2024-06-01 <!-- anchor: docs/task_backlog.md#目標指数の定義 -->
+  - `configs/targets.json` と `scripts/evaluate_targets.py` を整備済み。
+- ~~**ウォークフォワード検証**~~ ✅ — `state.md` 2024-06-02, 2024-06-03 <!-- anchor: docs/task_backlog.md#ウォークフォワード検証 -->
+  - `scripts/run_walk_forward.py` を追加し、`analysis/wf_log.json` に窓別ログを出力。
+- ~~**自動探索の高度化**~~ ✅ — `state.md` 2024-06-04 <!-- anchor: docs/task_backlog.md#自動探索の高度化 -->
+  - `scripts/run_optuna_search.py` で多指標目的の探索骨子を構築。
+- ~~**運用ループへの組み込み**~~ ✅ — `state.md` 2024-06-05 <!-- anchor: docs/task_backlog.md#運用ループへの組み込み -->
+  - `scripts/run_target_loop.py` による Optuna → run_sim → 指標計算 → 判定のループを実装。
+- ~~**state ヘルスチェック**~~ ✅ — `state.md` 2024-06-11 <!-- anchor: docs/task_backlog.md#state-ヘルスチェック -->
+  - `scripts/check_state_health.py` の警告生成・履歴ローテーション・Webhook テストを追加。
+- ~~**ベースライン/ローリング run 起動ジョブ**~~ ✅ — `state.md` 2024-06-12 <!-- anchor: docs/task_backlog.md#ベースラインローリング-run-起動ジョブ -->
+  - `scripts/run_benchmark_pipeline.py` と `tests/test_run_benchmark_pipeline.py` を整備し、runbook を更新。
+- ~~**ベンチマークサマリー閾値伝播**~~ ✅ — `state.md` 2024-06-13 <!-- anchor: docs/task_backlog.md#ベンチマークサマリー閾値伝播 -->
+  - `run_daily_workflow.py` からの Webhook/閾値伝播と README 更新を完了。
+- ~~**絶対パス整備と CLI テスト強化**~~ ✅ — `state.md` 2024-06-14 <!-- anchor: docs/task_backlog.md#絶対パス整備と-cli-テスト強化 -->
+  - `run_daily_workflow.py` 最適化/状態アーカイブコマンドで絶対パスを使用するよう更新し、pytest で検証。
+
+- ~~**インシデントリプレイテンプレート**~~（バックログ: `docs/task_backlog.md` → P1「インシデントリプレイテンプレート」） — `state.md` 2024-06-14, 2024-06-15, 2024-06-21, 2025-12-01 ✅ <!-- anchor: docs/task_backlog.md#p1-02-インシデントリプレイテンプレート -->
+  - 期間指定リプレイ CLI の拡張と Notebook (`analysis/incident_review.ipynb`) のテンプレ整備を完了。`docs/state_runbook.md#インシデントリプレイワークフロー` と README に再現フロー/成果物の整理手順を追記し、`ops/incidents/<incident_id>/` の出力ファイル（`replay_notes.md`・`replay_params.json`・`runs/incidents/...`）掲載先とステークホルダー共有ルールを明文化した。
+
+ 
+
+- ~~**戦略マニフェスト整備**~~ (Backlog: `docs/task_backlog.md` → [P2-01](docs/task_backlog.md#p2-マルチ戦略ポートフォリオ化)) — `state.md` 2026-01-08 ✅ <!-- anchor: docs/task_backlog.md#p2-マルチ戦略ポートフォリオ化 -->
+  - `configs/strategies/*.yaml` を整理し、依存特徴量・セッション・リスク上限を統一形式で記述。`docs/checklists/p2_manifest.md` の DoD を参照して、RunnerConfig/CLI へのパラメータ伝播を検証する。
+  - `scripts/run_sim.py --manifest` の引数マッピングを再確認し、必要なら loader/CLI を更新。pytest (`tests/test_run_sim_cli.py`, `tests/test_mean_reversion_strategy.py` など) をターゲットに追加実行する。
+  - 2026-01-08: `strategies/scalping_template.py` / `strategies/day_template.py` / `strategies/tokyo_micro_mean_reversion.py` / `strategies/session_momentum_continuation.py` を追加し、対応する manifest (`configs/strategies/*.yaml`) を新設。`python3 -m pytest tests/test_strategy_manifest.py` (2 passed) と `python3 -m pytest tests/test_run_sim_cli.py -k manifest` (1 passed, 4 deselected) を実行済み。
+  - 2026-01-08: `python3 scripts/run_sim.py --manifest configs/strategies/tokyo_micro_mean_reversion.yaml --csv data/sample_orb.csv --json-out /tmp/tokyo_micro.json`、`python3 scripts/run_sim.py --manifest configs/strategies/session_momentum_continuation.yaml --csv data/sample_orb.csv --json-out /tmp/session_momo.json`、`python3 scripts/run_sim.py --manifest configs/strategies/day_orb_5m.yaml --csv data/sample_orb.csv --json-out /tmp/day_orb.json` を完了。manifest 経由の CLI 配線を確認し、DoD テスト項目を更新済み。各 manifest の `runner.cli_args` で auto_state / aggregate_ev を制御しながら再実行。
+  - manage_task_cycle start-task は Ready セクションのアンカー不一致で失敗したため、当面は手動更新を継続。ドキュメント更新後にアンカー修正を検討。
+  - Backlog Anchor: [戦略マニフェスト整備 (P2-01)](docs/task_backlog.md#p2-マルチ戦略ポートフォリオ化)
+  - Vision / Runbook References:
+    - [docs/logic_overview.md](docs/logic_overview.md)
+    - [docs/simulation_plan.md](docs/simulation_plan.md)
+    - 主要ランブック: [docs/state_runbook.md](docs/state_runbook.md)
+  - Pending Questions:
+    - [ ] Clarify gating metrics, data dependencies, or open questions.
+  - DoD チェックリスト: [docs/templates/dod_checklist.md](docs/templates/dod_checklist.md) を [docs/checklists/p2-01.md](docs/checklists/p2-01.md) にコピーし、進捗リンクを更新する。
+
+- ~~**Workflow Integration Guide**~~ (Backlog: `docs/task_backlog.md` → "ワークフロー統合" section) — `state.md` 2024-06-18, 2025-09-29, 2026-02-13, 2025-10-08 ✅ <!-- anchor: docs/task_backlog.md#codex-session-operations-guide -->
+  <!-- REVIEW: Archived after confirming workflow loop, dry-run coverage, and template links met the reviewer DoD. -->
+  - Documented the sandbox approval matrix (package installs, API calls, large transfers, privileged writes) and linked it from `docs/state_runbook.md`. Verified that the workflow trio (`docs/codex_workflow.md`, `docs/state_runbook.md`, `docs/todo_next.md`) now shares consistent anchors/terminology and preserves Japanese summaries while addressing reviewer feedback。

--- a/state.md
+++ b/state.md
@@ -1,7 +1,8 @@
 # Work State Log
 
 ## Workflow Rule
-- Review this file before starting any task to confirm the latest context and checklist.
+- Review this file before starting any task to confirm the latest context and checklist。
+- 2026-04-18: `docs/todo_next.md` の Archive セクションを新設した [docs/todo_next_archive.md](docs/todo_next_archive.md) へ移設し、プレースホルダとアンカー検知用コメントを残した。README / codex ワークフロードキュメント / DoD テンプレ類の参照先を新アーカイブへ更新。
 - 2026-04-17: Observability dashboard pipeline を実装し、`analysis/dashboard/` のローダーと `analysis/export_dashboard_data.py` CLI で EV/スリッページ/勝率LCB/ターンオーバーを統合。`analysis/portfolio_monitor.ipynb` と `docs/observability_dashboard.md` を追加し、`docs/task_backlog.md` を更新。`python3 -m pytest` と `python3 analysis/export_dashboard_data.py --out-json /tmp/dashboard.json --portfolio-telemetry reports/portfolio_samples/router_demo/telemetry.json` を実行。
 - 2026-04-15: Extended `scripts/analyze_signal_latency.py` with JSON/CSV SLO出力と `--failure-threshold`、`ops/rotate_signal_latency.sh` / `ops/signal_latency_rotation.cron` を追加して日次ローテーション手順を整備。`docs/signal_ops.md` / `README.md` を更新し、`tests/test_analyze_signal_latency.py` で SLO 違反検知を回帰。`python3 -m pytest` と CLI 実行例 (`python3 scripts/analyze_signal_latency.py --input /tmp/latency_sample.csv --out-json /tmp/latency.json --out-csv /tmp/latency.csv`) を完了。
 - 2026-04-16: `scripts/summarize_runs.py` をベンチマーク/ポートフォリオ/ヘルスチェックの統合サマリーへ拡張し、Webhook 配信（`--dry-run-webhook`/`--fail-on-webhook-error`）と YAML 設定連携を追加。`docs/benchmark_runbook.md` / `docs/task_backlog.md` を同期し、`tests/test_summarize_runs.py` を新設して集計精度と Webhook 送信フォーマットを回帰。`python3 -m pytest` を完走し、CLI 例 (`python3 scripts/summarize_runs.py --runs-root runs --out-json /tmp/weekly_summary.json --webhook-url http://example.com --dry-run-webhook`) を確認。


### PR DESCRIPTION
## Summary
- move the completed entries out of `docs/todo_next.md` into the new `docs/todo_next_archive.md` while keeping anchor comments intact
- leave a pointer and manage_task_cycle placeholder in `docs/todo_next.md` and refresh README/workflow/checklist links to the archive
- log the archival refactor in `state.md` for future sessions

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e6323db258832aa8a7752905828cf8