### PR TITLE
Refine todo archive documentation references

### DIFF
--- a/docs/codex_quickstart.md
+++ b/docs/codex_quickstart.md
@@ -20,7 +20,7 @@ Codex オペレータが 1 セッションで追従すべき流れを 1 ペー�
 - 変更をレビュー → `git status` / `git diff` で不要ファイルが無いか確認。
 - テスト証跡を整理 → 実行したコマンドを `state.md` ログとコミットメッセージに記録。
 - `scripts/manage_task_cycle.py --dry-run finish-task --anchor <docs/task_backlog.md#...>` で close-out をプレビューし、問題なければ `--dry-run` を外して適用。
-- `docs/todo_next.md` の該当ブロックを [docs/todo_next_archive.md](todo_next_archive.md) へ移動し、`README.md` / ランブックのリンクが最新であることを確認。
+- `docs/todo_next.md` の該当ブロックを [docs/todo_next_archive.md](docs/todo_next_archive.md) へ移動し、`README.md` / ランブックのリンクが最新であることを確認。
 
 ## 4. よく使うコマンド
 | 目的 | コマンド例 |

--- a/docs/todo_next.md
+++ b/docs/todo_next.md
@@ -29,9 +29,10 @@
 
 ## Archive（達成済み）
 
-- 過去の達成済みログは [docs/todo_next_archive.md](docs/todo_next_archive.md) へ移動しました。履歴を参照する際はアーカイブファイルを確認してください。
-- `manage_task_cycle` のアンカープレースホルダは下記に残しています（削除しないでください）。
+> 過去の達成済みログは [docs/todo_next_archive.md](docs/todo_next_archive.md) に集約しました。履歴が必要な場合はアーカイブファイルを参照してください。
+> `manage_task_cycle` のアンカープレースホルダのみ下記に残しています（削除しないでください）。
 
+<!-- manage_task_cycle archive placeholder -->
 ✅ <!-- anchor placeholder to satisfy manage_task_cycle start-task detection -->
 - <!-- docs/task_backlog.md#p2-マルチ戦略ポートフォリオ化 -->
   - DoD チェックリスト: [docs/templates/dod_checklist.md](docs/templates/dod_checklist.md) を [docs/checklists/p2_manifest.md](docs/checklists/p2_manifest.md) にコピーし、進捗リンクを更新する。

--- a/docs/todo_next_archive.md
+++ b/docs/todo_next_archive.md
@@ -1,6 +1,6 @@
 # docs/todo_next Archive
 
-過去の `docs/todo_next.md` Archive セクションに掲載していた完了済みタスクのログをこのファイルへ集約しました。各エントリのアンカーコメントは従来通り維持しています。
+過去の `docs/todo_next.md` Archive セクションに掲載していた完了済みタスクのログをこのファイルへ集約しました。各エントリのアンカーコメントは従来通り維持しています。README / codex 系ワークフロードキュメント / DoD テンプレートからの参照先も本アーカイブへ統一しました。
 
 - **ルーター拡張** (Backlog: `docs/task_backlog.md` → [P2-マルチ戦略ポートフォリオ化](docs/task_backlog.md#p2-マルチ戦略ポートフォリオ化)) — 2026-02-13 完了 <!-- anchor: docs/task_backlog.md#p2-マルチ戦略ポートフォリオ化 -->
   - Finalised PortfolioState budgeting, correlation scoring, and execution-health penalties. Synced `docs/checklists/p2_router.md`, refreshed `docs/progress_phase2.md` deliverable notes, updated backlog progress, and ran `python3 -m pytest tests/test_router_v1.py tests/test_router_pipeline.py` before closing。

--- a/state.md
+++ b/state.md
@@ -2,6 +2,7 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist。
+- 2026-04-19: `docs/todo_next.md` の Archive セクション文面を整理し、`manage_task_cycle` プレースホルダのみを残したポインタへ刷新。`docs/codex_quickstart.md` / `docs/todo_next_archive.md` も新アーカイブ参照へ揃え、クロスドキュメントの参照先を統一。
 - 2026-04-18: `docs/todo_next.md` の Archive セクションを新設した [docs/todo_next_archive.md](docs/todo_next_archive.md) へ移設し、プレースホルダとアンカー検知用コメントを残した。README / codex ワークフロードキュメント / DoD テンプレ類の参照先を新アーカイブへ更新。
 - 2026-04-17: Observability dashboard pipeline を実装し、`analysis/dashboard/` のローダーと `analysis/export_dashboard_data.py` CLI で EV/スリッページ/勝率LCB/ターンオーバーを統合。`analysis/portfolio_monitor.ipynb` と `docs/observability_dashboard.md` を追加し、`docs/task_backlog.md` を更新。`python3 -m pytest` と `python3 analysis/export_dashboard_data.py --out-json /tmp/dashboard.json --portfolio-telemetry reports/portfolio_samples/router_demo/telemetry.json` を実行。
 - 2026-04-15: Extended `scripts/analyze_signal_latency.py` with JSON/CSV SLO出力と `--failure-threshold`、`ops/rotate_signal_latency.sh` / `ops/signal_latency_rotation.cron` を追加して日次ローテーション手順を整備。`docs/signal_ops.md` / `README.md` を更新し、`tests/test_analyze_signal_latency.py` で SLO 違反検知を回帰。`python3 -m pytest` と CLI 実行例 (`python3 scripts/analyze_signal_latency.py --input /tmp/latency_sample.csv --out-json /tmp/latency.json --out-csv /tmp/latency.csv`) を完了。


### PR DESCRIPTION
## Summary
- streamline the Archive section in `docs/todo_next.md` so it only points to the dedicated archive file while keeping the automation placeholder intact
- clarify that `docs/todo_next_archive.md` is now the canonical location for completed task history and align the quickstart guide’s link to the new path
- record the workflow documentation update in `state.md`

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e63f308060832a84460694d9a1e8ab