### PR TITLE
Normalize docs relative links and update sync tooling

### DIFF
--- a/docs/codex_quickstart.md
+++ b/docs/codex_quickstart.md
@@ -20,7 +20,7 @@ Codex オペレータが 1 セッションで追従すべき流れを 1 ペー�
 - 変更をレビュー → `git status` / `git diff` で不要ファイルが無いか確認。
 - テスト証跡を整理 → 実行したコマンドを `state.md` ログとコミットメッセージに記録。
 - `scripts/manage_task_cycle.py --dry-run finish-task --anchor <docs/task_backlog.md#...>` で close-out をプレビューし、問題なければ `--dry-run` を外して適用。
-- `docs/todo_next.md` の該当ブロックを [docs/todo_next_archive.md](docs/todo_next_archive.md) へ移動し、`README.md` / ランブックのリンクが最新であることを確認。
+- `docs/todo_next.md` の該当ブロックを [docs/todo_next_archive.md](./todo_next_archive.md) へ移動し、`README.md` / ランブックのリンクが最新であることを確認。
 
 ## 4. よく使うコマンド
 | 目的 | コマンド例 |

--- a/docs/codex_workflow.md
+++ b/docs/codex_workflow.md
@@ -39,7 +39,8 @@ One-page の流れは [docs/codex_quickstart.md](codex_quickstart.md) に集約�
 
 ### 3. Wrap-up
 - `state.md` → `## Log` にセッション結果を追記し、`## Next Task` から完了したタスクを除外。
-- `docs/todo_next.md` の該当ブロックを [docs/todo_next_archive.md](docs/todo_next_archive.md) へ移動し、アンカーコメント（`<!-- anchor: ... -->`）が残っているか確認。
+- ドキュメント内リンクはリポジトリ内の相対パス（例: `./codex_quickstart.md`, `checklists/<task>.md`）で統一し、`rg '\\]\(docs/' docs` で `docs/` 始まりのリンクが残っていないか確認する。
+- `docs/todo_next.md` の該当ブロックを [docs/todo_next_archive.md](./todo_next_archive.md) へ移動し、アンカーコメント（`<!-- anchor: ... -->`）が残っているか確認。
 - `docs/task_backlog.md` の対象項目にリンクやノートを追加する。完了済みなら該当タスクを打ち消し線で囲み、進捗メモを最終ログとして残す。
 - テスト証跡（実行コマンド）はコミットメッセージと PR テンプレの両方に記録する。
 

--- a/docs/progress_phase1.md
+++ b/docs/progress_phase1.md
@@ -5,7 +5,7 @@
 - サンプル戦略として `strategies/reversion_stub.py` を追加。低ボラ時の閾値緩和・高ボラ時のブロック動作を確認済み。`
 - 2025-12-02: `strategies/mean_reversion.py` を導入し、RV/ADX フィルタや ATR ベースのリスクリワード計算、EV プロファイル補正を実装。`configs/strategies/mean_reversion.yaml` / `configs/ev_profiles/mean_reversion.yaml` を刷新し、`tests/test_mean_reversion_strategy.py` でゲート・閾値・サイズ計算の回帰を確保。
 - manifest を介して任意戦略を注入できるよう `configs/strategies/*.yaml` を標準化。
-- `scripts/run_sim.py --manifest` が RunnerConfig の許容セッション/リスク上限と戦略パラメータ（例: `allow_high_rv` / `zscore_threshold`）を自動適用し、`Strategy.on_start` に渡すフローを整備。回帰テスト: `tests/test_run_sim_cli.py`。DoD: [docs/task_backlog.md#p2-マルチ戦略ポートフォリオ化](docs/task_backlog.md#p2-マルチ戦略ポートフォリオ化)。
+- `scripts/run_sim.py --manifest` が RunnerConfig の許容セッション/リスク上限と戦略パラメータ（例: `allow_high_rv` / `zscore_threshold`）を自動適用し、`Strategy.on_start` に渡すフローを整備。回帰テスト: `tests/test_run_sim_cli.py`。DoD: [docs/task_backlog.md#p2-マルチ戦略ポートフォリオ化](./task_backlog.md#p2-マルチ戦略ポートフォリオ化)。
 - 2025-12-05: Day ORB のリテスト要求ロジックで初回ブレイク方向（buy/sell）を記録し、方向ごとにリテスト判定を分岐するよう更新。`tests/test_day_orb_retest.py` で売りブレイクが OR 安値へ戻らないケースの回帰を追加し、誤検知を防止。
 
 ## 2. EV 閾値ケーススタディ

--- a/docs/task_backlog.md
+++ b/docs/task_backlog.md
@@ -26,6 +26,7 @@ Document the repeatable workflow that lets Codex keep `state.md`, `docs/todo_nex
 - **P0-12 Codex-first documentation cleanup**
   - **DoD**: Codex operator workflow has a one-page quickstart (`docs/codex_quickstart.md`), the detailed checklist (`docs/state_runbook.md`) is trimmed to actionable bullet lists, README points to both, and `docs/development_roadmap.md` captures immediate→mid-term improvements with backlog links. Backlogとテンプレートは新フローに沿って更新済みであること。
   - **Notes**: Focus on reducing duplication between `docs/codex_quickstart.md`, `docs/codex_workflow.md`, README, and `docs/state_runbook.md`; ensure sandbox/approval rules stay explicit.
+  - 2026-04-24: Normalised internal documentation links to use relative paths so Markdown previews and GitHub navigation stay consistent. Synced quickstart/workflow docs with the updated guideline and logged the change in `state.md`.
 - ~~**P0-13 run_daily_workflow local CSV override fix**~~ (2026-04-07 完了): `scripts/run_daily_workflow.py` がデフォルト ingest で `pull_prices.py` を呼び出す際に `--local-backup-csv` のパスを尊重する。
   - 2026-04-07: CLI オプションを `pull_prices` コマンドへ伝播し、回帰テスト `tests/test_run_daily_workflow.py::test_ingest_pull_prices_respects_local_backup_override` を追加。`python3 -m pytest` を実行して確認。
 - 2026-04-05: `scripts/run_sim.py` を manifest-first CLI へ再設計し、OutDir 実行時にランフォルダ (`params.json` / `metrics.json` / `records.csv` / `daily.csv`) が生成されるよう統合。`tests/test_run_sim_cli.py` / README / `docs/checklists/multi_strategy_validation.md` を更新。
@@ -56,20 +57,20 @@ Document the repeatable workflow that lets Codex keep `state.md`, `docs/todo_nex
 
 ## P1: ローリング検証 + 健全性モニタリング（Archive）
 
-フェーズ1タスクの詳細な進捗記録は [docs/task_backlog_p1_archive.md](docs/task_backlog_p1_archive.md) に保管されています。歴史的な参照が必要な場合は同アーカイブを参照してください。
+フェーズ1タスクの詳細な進捗記録は [docs/task_backlog_p1_archive.md](./task_backlog_p1_archive.md) に保管されています。歴史的な参照が必要な場合は同アーカイブを参照してください。
 
 ## P2: マルチ戦略ポートフォリオ化
 
 ### ~~P2-01 戦略マニフェスト整備~~ ✅ (2026-01-08 クローズ)
 - スキャル/デイ/スイングの候補戦略ごとに、依存特徴量・セッション・リスク上限を YAML で定義し、ルーターが参照できるようにする (`configs/strategies/*.yaml`)。
   - 2025-10-09: `configs/strategies/templates/base_strategy.yaml` に共通テンプレートと記述ガイドを追加し、新規戦略のマニフェスト整備を着手しやすくした。
-- 2024-06-22: `scripts/run_sim.py --manifest` でマニフェストを読み込み、RunnerConfig の許容セッション/リスク上限と戦略固有パラメータを `Strategy.on_start` に直結するフローを整備。`tests/test_run_sim_cli.py` で manifest 経由のパラメタ伝播を検証。DoD: [フェーズ1-戦略別ゲート整備](docs/progress_phase1.md#1-戦略別ゲート整備)。
+- 2024-06-22: `scripts/run_sim.py --manifest` でマニフェストを読み込み、RunnerConfig の許容セッション/リスク上限と戦略固有パラメータを `Strategy.on_start` に直結するフローを整備。`tests/test_run_sim_cli.py` で manifest 経由のパラメタ伝播を検証。DoD: [フェーズ1-戦略別ゲート整備](./progress_phase1.md#1-戦略別ゲート整備)。
   - 2026-01-08: `strategies/scalping_template.py` / `strategies/day_template.py` を追加し、`tokyo_micro_mean_reversion`・`session_momentum_continuation` の manifest/実装を新設。`python3 -m pytest tests/test_strategy_manifest.py` で loader 整合性を確認。次ステップは run_sim CLI ドライランと DoD チェック更新。
 
 ### ~~P2-02 ルーター拡張~~ ✅ (2026-02-13 クローズ)
 - 現行ルールベース (`router/router_v0.py`) を拡張し、カテゴリ配分・相関・キャパ制約を反映。戦略ごとの state/EV/サイズ情報を統合してスコアリングする。
   - 設計ガイド: [docs/router_architecture.md](router_architecture.md)
-  - DoD: [docs/checklists/p2_router.md](docs/checklists/p2_router.md)
+  - DoD: [docs/checklists/p2_router.md](./checklists/p2_router.md)
   - 2026-01-27: `router/router_v1.select_candidates` がカテゴリ/グロスヘッドルームを参照してスコアへボーナス/ペナルティを適用し、理由ログへ残差状況を記録するよう拡張。`tests/test_router_v1.py` にヘッドルーム差分のスコア回帰を追加し、`docs/checklists/p2_router.md` の DoD を更新。
   - 2026-02-05: `scripts/build_router_snapshot.py` に `--correlation-window-minutes` を追加し、相関行列と併せて窓幅メタデータを `telemetry.json` / ポートフォリオサマリーへ保存。`PortfolioTelemetry` / `PortfolioState` が新フィールドを保持できるよう拡張し、`tests/test_report_portfolio_summary.py` に CLI 回帰とヘルプ出力確認を追加。
   - 2026-02-07: `core/router_pipeline.manifest_category_budget` で manifest `governance.category_budget_pct` を吸い上げつつ、`scripts/build_router_snapshot.py --category-budget-csv` から外部 CSV を取り込んで `telemetry.json` へ集約。`router_v1` はカテゴリ予算超過時に `status=warning|breach` を理由ログへ記録し、段階的にペナルティを強化する。`tests/test_router_pipeline.py` / `tests/test_router_v1.py` へカテゴリ予算ヘッドルームとスコア調整の回帰を追加。

--- a/docs/task_backlog_p1_archive.md
+++ b/docs/task_backlog_p1_archive.md
@@ -31,9 +31,9 @@
 **進捗メモ**
 - 2026-02-21: Fixed a calibration regression where `_resolve_calibration_positions` stopped updating pooled EV after the calibration window elapsed. Added regression `tests/test_runner.py::test_calibration_positions_resolve_after_period` to ensure calibration trades opened during warmup continue to settle and feed EV statistics, and reran targeted pytest for the runner suite.
 - 2026-02-13: Verified the counter/record documentation against the latest runner implementation, confirmed that the CSV/daily investigation flow covers `ev_bypass` warm-up tracking, and re-ran `python3 -m pytest tests/test_runner.py tests/test_run_sim_cli.py` to lock regression coverage before closing the task.
-- 2026-01-18: Logged EV warm-up bypass events as `ev_bypass` debug records (capturing `warmup_left` / `warmup_total`), refreshed regression coverage in `tests/test_runner.py`, and expanded [docs/backtest_runner_logging.md](docs/backtest_runner_logging.md) with the new fields.
+- 2026-01-18: Logged EV warm-up bypass events as `ev_bypass` debug records (capturing `warmup_left` / `warmup_total`), refreshed regression coverage in `tests/test_runner.py`, and expanded [docs/backtest_runner_logging.md](./backtest_runner_logging.md) with the new fields.
 - 2025-10-13: Added CLI regression `tests/test_run_sim_cli.py::test_run_sim_debug_records_capture_hook_failures` to lock the debug counters/records when hook exceptions are raised, and expanded the logging reference with the coverage note.
-- 2025-10-08: Added helper-based dispatch and logging reference. See [docs/backtest_runner_logging.md](docs/backtest_runner_logging.md) for counter/record definitions and EV investigation flow.
+- 2025-10-08: Added helper-based dispatch and logging reference. See [docs/backtest_runner_logging.md](./backtest_runner_logging.md) for counter/record definitions and EV investigation flow.
 
 ### ~~P1-06 Fill エンジン / ブローカー仕様アライン~~ ✅ (2026-02-13 クローズ)
 - `core/fill_engine.py` と RunnerConfig を拡張して `SameBarPolicy` / Brownian Bridge パラメータを制御し、manifest (`runner.runner_config.fill_*`) で調整できるよう整備。`python3 -m pytest tests/test_fill_engine.py tests/test_runner.py tests/test_run_sim_cli.py` で回帰確認。
@@ -44,7 +44,7 @@
 
 **完了記録**
 - `docs/checklists/p1-07_phase1_bug_refactor.md` へ調査チェックボード・テスト手順・リファクタリング計画テンプレ・ドキュメント更新チェックを追加し、DoD セクションの項目を全て充足。
-- `docs/todo_next.md` の Ready から当該タスクを除外し、[docs/todo_next_archive.md](docs/todo_next_archive.md) へ移動。`state.md` の `## Log` に完了メモを追記し、`## Next Task` からアンカーを取り外した。
+- `docs/todo_next.md` の Ready から当該タスクを除外し、[docs/todo_next_archive.md](./todo_next_archive.md) へ移動。`state.md` の `## Log` に完了メモを追記し、`## Next Task` からアンカーを取り外した。
 - バックログ本節をクローズ扱いに変更し、後続作業は必要に応じて新タスク（例: P2 系列）として起票する方針。
 
 **進捗メモ（アーカイブ）**

--- a/docs/templates/next_task_entry.md
+++ b/docs/templates/next_task_entry.md
@@ -4,8 +4,8 @@
 
   - Backlog Anchor: [{{TITLE}} ({{TASK_ID}})]({{BACKLOG_ANCHOR}})
   - Vision / Runbook References:
-    - [docs/logic_overview.md](docs/logic_overview.md)
-    - [docs/simulation_plan.md](docs/simulation_plan.md)
+    - [docs/logic_overview.md](./logic_overview.md)
+    - [docs/simulation_plan.md](./simulation_plan.md)
     - 主要ランブック: {{RUNBOOK_LINKS}}
   - Pending Questions:
     - [ ] {{PENDING_QUESTIONS}}

--- a/docs/todo_next.md
+++ b/docs/todo_next.md
@@ -3,11 +3,11 @@
 ## 更新ルール
 - タスクを完了したら、必ず `state.md` の該当項目をログへ移し、本ファイルのセクション（In Progress / Ready / Pending Review / Archive）を同期してください。
 - `state.md` に記録されていないアクティビティは、このファイルにも掲載しない方針です。新しい作業を始める前に `state.md` へ日付と目的を追加しましょう。
-- フローの全体像は [docs/codex_quickstart.md](docs/codex_quickstart.md) / [docs/codex_workflow.md](docs/codex_workflow.md) を参照し、アンカーの整合チェックを忘れずに。
-- Ready または In Progress へ昇格させるタスクは、[docs/templates/dod_checklist.md](docs/templates/dod_checklist.md) を複製し `docs/checklists/<task-slug>.md` へ保存したうえで、該当エントリからリンクするか貼り付けてください。
+- フローの全体像は [docs/codex_quickstart.md](./codex_quickstart.md) / [docs/codex_workflow.md](./codex_workflow.md) を参照し、アンカーの整合チェックを忘れずに。
+- Ready または In Progress へ昇格させるタスクは、[docs/templates/dod_checklist.md](./templates/dod_checklist.md) を複製し `docs/checklists/<task-slug>.md` へ保存したうえで、該当エントリからリンクするか貼り付けてください。
 
 ## Ready 昇格チェックリスト
-- 高レベルのビジョンガイド（例: [docs/logic_overview.md](docs/logic_overview.md), [docs/simulation_plan.md](docs/simulation_plan.md)）を再読し、昇格対象タスクが最新戦略方針と整合しているか確認する。
+- 高レベルのビジョンガイド（例: [docs/logic_overview.md](./logic_overview.md), [docs/simulation_plan.md](./simulation_plan.md)）を再読し、昇格対象タスクが最新戦略方針と整合しているか確認する。
 - `docs/progress_phase*.md`（特に対象フェーズの記録）を確認し、未完了の前提条件や検証ギャップがないかレビューする。
 - 関連するランブック（例: `docs/state_runbook.md`, `docs/benchmark_runbook.md`）を再読し、必要なオペレーション手順が揃っているかを点検する。
 - バックログ該当項目の DoD を最新化し、関係チームへ通知済みであることを確認する。
@@ -29,11 +29,11 @@
 
 ## Archive（達成済み）
 
-> 過去の達成済みログは [docs/todo_next_archive.md](docs/todo_next_archive.md) に集約しました。履歴が必要な場合はアーカイブファイルを参照してください。
+> 過去の達成済みログは [docs/todo_next_archive.md](./todo_next_archive.md) に集約しました。履歴が必要な場合はアーカイブファイルを参照してください。
 > `manage_task_cycle` のアンカープレースホルダのみ下記に残しています（削除しないでください）。
 
 <!-- manage_task_cycle archive placeholder -->
 ✅ <!-- anchor placeholder to satisfy manage_task_cycle start-task detection -->
 - <!-- docs/task_backlog.md#p2-マルチ戦略ポートフォリオ化 -->
-  - DoD チェックリスト: [docs/templates/dod_checklist.md](docs/templates/dod_checklist.md) を [docs/checklists/p2_manifest.md](docs/checklists/p2_manifest.md) にコピーし、進捗リンクを更新する。
+  - DoD チェックリスト: [docs/templates/dod_checklist.md](./templates/dod_checklist.md) を [docs/checklists/p2_manifest.md](./checklists/p2_manifest.md) にコピーし、進捗リンクを更新する。
 

--- a/docs/todo_next_archive.md
+++ b/docs/todo_next_archive.md
@@ -2,11 +2,11 @@
 
 過去の `docs/todo_next.md` Archive セクションに掲載していた完了済みタスクのログをこのファイルへ集約しました。各エントリのアンカーコメントは従来通り維持しています。README / codex 系ワークフロードキュメント / DoD テンプレートからの参照先も本アーカイブへ統一しました。
 
-- **ルーター拡張** (Backlog: `docs/task_backlog.md` → [P2-マルチ戦略ポートフォリオ化](docs/task_backlog.md#p2-マルチ戦略ポートフォリオ化)) — 2026-02-13 完了 <!-- anchor: docs/task_backlog.md#p2-マルチ戦略ポートフォリオ化 -->
+- **ルーター拡張** (Backlog: `docs/task_backlog.md` → [P2-マルチ戦略ポートフォリオ化](./task_backlog.md#p2-マルチ戦略ポートフォリオ化)) — 2026-02-13 完了 <!-- anchor: docs/task_backlog.md#p2-マルチ戦略ポートフォリオ化 -->
   - Finalised PortfolioState budgeting, correlation scoring, and execution-health penalties. Synced `docs/checklists/p2_router.md`, refreshed `docs/progress_phase2.md` deliverable notes, updated backlog progress, and ran `python3 -m pytest tests/test_router_v1.py tests/test_router_pipeline.py` before closing。
-- **マルチ戦略比較バリデーション** (Backlog: `docs/task_backlog.md` → [P2-マルチ戦略ポートフォリオ化](docs/task_backlog.md#p2-マルチ戦略ポートフォリオ化)) — 2026-02-13 完了
+- **マルチ戦略比較バリデーション** (Backlog: `docs/task_backlog.md` → [P2-マルチ戦略ポートフォリオ化](./task_backlog.md#p2-マルチ戦略ポートフォリオ化)) — 2026-02-13 完了
   - Regenerated `runs/multi_strategy/` artefacts, compared Day ORB vs Mean Reversion (`ev_reject=0` vs `330`), and confirmed `--no-ev-profile` の挙動が不変。`docs/checklists/multi_strategy_validation.md` のサマリ表と実測メモを更新し、チェックリスト完了状態を維持。
-- **Fill エンジン / ブローカー仕様アライン** (Backlog: `docs/task_backlog.md` → [P1-06](docs/task_backlog_p1_archive.md#p1-06-fill-エンジン--ブローカー仕様アライン)) — 2026-02-13 完了
+- **Fill エンジン / ブローカー仕様アライン** (Backlog: `docs/task_backlog.md` → [P1-06](./task_backlog_p1_archive.md#p1-06-fill-エンジン--ブローカー仕様アライン)) — 2026-02-13 完了
   - Added fill-engine overrides (`fill_same_bar_policy_*`, `fill_bridge_lambda`, `fill_bridge_drift_scale`) to RunnerConfig と manifest (`runner.runner_config`). Updated docs (`docs/broker_oco_matrix.md`, `docs/benchmark_runbook.md`, `docs/progress_phase1.md`) and regression suites (`tests/test_runner.py`, `tests/test_run_sim_cli.py`) before closing。
 - ~~**フェーズ1 バグチェック & リファクタリング運用整備**~~ ✅ — `state.md` 2026-01-08 <!-- anchor: docs/task_backlog_p1_archive.md#p1-07-フェーズ1-バグチェック--リファクタリング運用整備 -->
   - `docs/checklists/p1-07_phase1_bug_refactor.md` に調査チェックボード・テスト手順・リファクタリング計画テンプレを追加し、運用チェック項目を全て埋めた。`scripts/manage_task_cycle.py` の start/finish 例も掲載。
@@ -42,20 +42,20 @@
 
  
 
-- ~~**戦略マニフェスト整備**~~ (Backlog: `docs/task_backlog.md` → [P2-01](docs/task_backlog.md#p2-マルチ戦略ポートフォリオ化)) — `state.md` 2026-01-08 ✅ <!-- anchor: docs/task_backlog.md#p2-マルチ戦略ポートフォリオ化 -->
+- ~~**戦略マニフェスト整備**~~ (Backlog: `docs/task_backlog.md` → [P2-01](./task_backlog.md#p2-マルチ戦略ポートフォリオ化)) — `state.md` 2026-01-08 ✅ <!-- anchor: docs/task_backlog.md#p2-マルチ戦略ポートフォリオ化 -->
   - `configs/strategies/*.yaml` を整理し、依存特徴量・セッション・リスク上限を統一形式で記述。`docs/checklists/p2_manifest.md` の DoD を参照して、RunnerConfig/CLI へのパラメータ伝播を検証する。
   - `scripts/run_sim.py --manifest` の引数マッピングを再確認し、必要なら loader/CLI を更新。pytest (`tests/test_run_sim_cli.py`, `tests/test_mean_reversion_strategy.py` など) をターゲットに追加実行する。
   - 2026-01-08: `strategies/scalping_template.py` / `strategies/day_template.py` / `strategies/tokyo_micro_mean_reversion.py` / `strategies/session_momentum_continuation.py` を追加し、対応する manifest (`configs/strategies/*.yaml`) を新設。`python3 -m pytest tests/test_strategy_manifest.py` (2 passed) と `python3 -m pytest tests/test_run_sim_cli.py -k manifest` (1 passed, 4 deselected) を実行済み。
   - 2026-01-08: `python3 scripts/run_sim.py --manifest configs/strategies/tokyo_micro_mean_reversion.yaml --csv data/sample_orb.csv --json-out /tmp/tokyo_micro.json`、`python3 scripts/run_sim.py --manifest configs/strategies/session_momentum_continuation.yaml --csv data/sample_orb.csv --json-out /tmp/session_momo.json`、`python3 scripts/run_sim.py --manifest configs/strategies/day_orb_5m.yaml --csv data/sample_orb.csv --json-out /tmp/day_orb.json` を完了。manifest 経由の CLI 配線を確認し、DoD テスト項目を更新済み。各 manifest の `runner.cli_args` で auto_state / aggregate_ev を制御しながら再実行。
   - manage_task_cycle start-task は Ready セクションのアンカー不一致で失敗したため、当面は手動更新を継続。ドキュメント更新後にアンカー修正を検討。
-  - Backlog Anchor: [戦略マニフェスト整備 (P2-01)](docs/task_backlog.md#p2-マルチ戦略ポートフォリオ化)
+  - Backlog Anchor: [戦略マニフェスト整備 (P2-01)](./task_backlog.md#p2-マルチ戦略ポートフォリオ化)
   - Vision / Runbook References:
-    - [docs/logic_overview.md](docs/logic_overview.md)
-    - [docs/simulation_plan.md](docs/simulation_plan.md)
-    - 主要ランブック: [docs/state_runbook.md](docs/state_runbook.md)
+    - [docs/logic_overview.md](./logic_overview.md)
+    - [docs/simulation_plan.md](./simulation_plan.md)
+    - 主要ランブック: [docs/state_runbook.md](./state_runbook.md)
   - Pending Questions:
     - [ ] Clarify gating metrics, data dependencies, or open questions.
-  - DoD チェックリスト: [docs/templates/dod_checklist.md](docs/templates/dod_checklist.md) を [docs/checklists/p2-01.md](docs/checklists/p2-01.md) にコピーし、進捗リンクを更新する。
+  - DoD チェックリスト: [docs/templates/dod_checklist.md](./templates/dod_checklist.md) を [docs/checklists/p2-01.md](./checklists/p2-01.md) にコピーし、進捗リンクを更新する。
 
 - ~~**Workflow Integration Guide**~~ (Backlog: `docs/task_backlog.md` → "ワークフロー統合" section) — `state.md` 2024-06-18, 2025-09-29, 2026-02-13, 2025-10-08 ✅ <!-- anchor: docs/task_backlog.md#codex-session-operations-guide -->
   <!-- REVIEW: Archived after confirming workflow loop, dry-run coverage, and template links met the reviewer DoD. -->

--- a/scripts/sync_task_docs.py
+++ b/scripts/sync_task_docs.py
@@ -338,9 +338,11 @@ def ensure_checklist_note(block: List[str], task_id: str | None) -> List[str]:
         return block
     slug = slugify_task_id(task_id)
     target_path = f"{CHECKLIST_DIR}/{slug}.md"
+    template_link = CHECKLIST_TEMPLATE.replace("docs/", "./", 1)
+    target_link = target_path.replace("docs/", "./", 1)
     note = (
-        f"  - DoD チェックリスト: [{CHECKLIST_TEMPLATE}]({CHECKLIST_TEMPLATE}) を"
-        f" [{target_path}]({target_path}) にコピーし、進捗リンクを更新する。"
+        f"  - DoD チェックリスト: [{CHECKLIST_TEMPLATE}]({template_link}) を"
+        f" [{target_path}]({target_link}) にコピーし、進捗リンクを更新する。"
     )
     for line in block:
         if "DoD チェックリスト" in line:
@@ -561,8 +563,8 @@ def apply_next_task_template(
         pending_questions,
     )
     rendered_template = _render_template(template_lines, context)
-    state_template = list(rendered_template)
-    docs_template = list(rendered_template)
+    state_template = [line.replace("](./", "](docs/") for line in rendered_template]
+    docs_template = [line.replace("](docs/", "](./") for line in rendered_template]
 
     state_lines = read_lines(STATE_PATH)
     state_lines, state_block = remove_state_entry(state_lines, anchor)

--- a/state.md
+++ b/state.md
@@ -2,6 +2,7 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist。
+- 2026-04-24: Normalised `docs/` internal links to relative paths, verified cleanup with `rg '\\]\(docs/' docs`, refreshed `docs/task_backlog.md` notes, and added link hygiene guidance to the workflow doc.
 - 2026-04-23: README のオンデマンドインジェスト CLI 節で `scripts/fetch_prices_api.py` の案内を再整理し、重複記述を 1 つの箇条書きへ統合したまま API キー運用・Sandbox フォールバックの説明を保持。
 - 2026-04-22: `docs/api_ingest_plan.md` の Error Handling & Observability 節で `ops/runtime_snapshot.json.ingest_meta.<symbol>_<tf>`
   の説明を一つの箇条書きへ統合し、ローカルバックアップパスの補足を保持したまま重複を解消。

--- a/tests/test_sync_task_template.py
+++ b/tests/test_sync_task_template.py
@@ -30,7 +30,7 @@ def _write_docs(path: Path) -> None:
 
 ### In Progress
 - **Test Task** — `state.md` 2024-06-25 <!-- anchor: docs/task_backlog.md#p9-99-test-task -->
-  - DoD チェックリスト: [docs/templates/dod_checklist.md](docs/templates/dod_checklist.md) を [docs/checklists/p9-99.md](docs/checklists/p9-99.md) にコピーし、進捗リンクを更新する。
+  - DoD チェックリスト: [docs/templates/dod_checklist.md](./templates/dod_checklist.md) を [docs/checklists/p9-99.md](./checklists/p9-99.md) にコピーし、進捗リンクを更新する。
 """,
         encoding="utf-8",
     )
@@ -44,7 +44,7 @@ def _write_ready_docs(path: Path) -> None:
 
 ### Ready
 - **Test Task** — `state.md` 2024-06-25 <!-- anchor: docs/task_backlog.md#p9-99-test-task -->
-  - DoD チェックリスト: [docs/templates/dod_checklist.md](docs/templates/dod_checklist.md) を [docs/checklists/p9-99.md](docs/checklists/p9-99.md) にコピーし、進捗リンクを更新する。
+  - DoD チェックリスト: [docs/templates/dod_checklist.md](./templates/dod_checklist.md) を [docs/checklists/p9-99.md](./checklists/p9-99.md) にコピーし、進捗リンクを更新する。
 """,
         encoding="utf-8",
     )
@@ -54,8 +54,8 @@ def _write_template(path: Path) -> None:
     path.write_text(
         """  - Backlog Anchor: [{{TITLE}} ({{TASK_ID}})]({{BACKLOG_ANCHOR}})
   - Vision / Runbook References:
-    - [docs/logic_overview.md](docs/logic_overview.md)
-    - [docs/simulation_plan.md](docs/simulation_plan.md)
+    - [docs/logic_overview.md](./logic_overview.md)
+    - [docs/simulation_plan.md](./simulation_plan.md)
     - 主要ランブック: {{RUNBOOK_LINKS}}
   - Pending Questions:
     - [ ] {{PENDING_QUESTIONS}}
@@ -95,7 +95,7 @@ def test_apply_next_task_template_updates_state_and_docs(tmp_path, monkeypatch):
     in_progress_index = docs_lines.index("### In Progress")
     block_lines = docs_lines[in_progress_index + 1 :]
     assert any("Backlog Anchor: [Test Task (P9-99)]" in line for line in block_lines)
-    assert any("docs/simulation_plan.md" in line for line in block_lines)
+    assert any("./simulation_plan.md" in line for line in block_lines)
     assert any("Clarify EV guardrails." in line for line in block_lines)
 
     # Idempotent re-run should not duplicate template sections
@@ -135,7 +135,7 @@ def test_apply_next_task_template_defaults_ready_section(tmp_path, monkeypatch):
     ready_index = docs_lines.index("### Ready")
     block_lines = docs_lines[ready_index + 1 :]
     assert any(
-        "[docs/state_runbook.md](docs/state_runbook.md)" in line for line in block_lines
+        "[docs/state_runbook.md](./state_runbook.md)" in line for line in block_lines
     )
     assert any(
         "Clarify gating metrics, data dependencies, or open questions." in line


### PR DESCRIPTION
## Summary
- normalize markdown links under docs/ to use relative paths so GitHub and local previews resolve correctly
- update codex workflow guidance, backlog notes, and state log to document the new link hygiene process
- adjust sync_task_docs helpers and tests to emit relative links for docs while preserving state.md behaviour

## Testing
- python3 -m pytest tests/test_sync_task_template.py
- python3 -m pytest tests/test_manage_task_cycle.py

------
https://chatgpt.com/codex/tasks/task_e_68e649281988832a920cbaef019e7581