### PR TITLE
Document link hygiene follow-up

### DIFF
--- a/docs/codex_workflow.md
+++ b/docs/codex_workflow.md
@@ -39,7 +39,7 @@ One-page の流れは [docs/codex_quickstart.md](codex_quickstart.md) に集約�
 
 ### 3. Wrap-up
 - `state.md` → `## Log` にセッション結果を追記し、`## Next Task` から完了したタスクを除外。
-- ドキュメント内リンクはリポジトリ内の相対パス（例: `./codex_quickstart.md`, `checklists/<task>.md`）で統一し、`rg '\\]\(docs/' docs` で `docs/` 始まりのリンクが残っていないか確認する。
+- ドキュメント内リンクはリポジトリ内の相対パス（例: `./codex_quickstart.md`, `checklists/<task>.md`）で統一する。特に `docs/` 配下から別の Markdown を参照する際に `] (docs/...)` 形式のリンクを使うと `docs/docs/...` へ解決されて壊れるため、`./` で始まるパスへ置き換えたうえで `rg '\\]\(docs/' docs` で誤りが残っていないか確認する。
 - `docs/todo_next.md` の該当ブロックを [docs/todo_next_archive.md](./todo_next_archive.md) へ移動し、アンカーコメント（`<!-- anchor: ... -->`）が残っているか確認。
 - `docs/task_backlog.md` の対象項目にリンクやノートを追加する。完了済みなら該当タスクを打ち消し線で囲み、進捗メモを最終ログとして残す。
 - テスト証跡（実行コマンド）はコミットメッセージと PR テンプレの両方に記録する。

--- a/docs/task_backlog.md
+++ b/docs/task_backlog.md
@@ -26,7 +26,8 @@ Document the repeatable workflow that lets Codex keep `state.md`, `docs/todo_nex
 - **P0-12 Codex-first documentation cleanup**
   - **DoD**: Codex operator workflow has a one-page quickstart (`docs/codex_quickstart.md`), the detailed checklist (`docs/state_runbook.md`) is trimmed to actionable bullet lists, README points to both, and `docs/development_roadmap.md` captures immediate→mid-term improvements with backlog links. Backlogとテンプレートは新フローに沿って更新済みであること。
   - **Notes**: Focus on reducing duplication between `docs/codex_quickstart.md`, `docs/codex_workflow.md`, README, and `docs/state_runbook.md`; ensure sandbox/approval rules stay explicit.
-  - 2026-04-24: Normalised internal documentation links to use relative paths so Markdown previews and GitHub navigation stay consistent. Synced quickstart/workflow docs with the updated guideline and logged the change in `state.md`.
+- 2026-04-24: Normalised internal documentation links to use relative paths so Markdown previews and GitHub navigation stay consistent. Synced quickstart/workflow docs with the updated guideline and logged the change in `state.md`.
+- 2026-04-25: Re-audited `docs/` Markdown to ensure no `] (docs/...)` style links slipped back in, expanded the workflow guideline with the failure mode, and recorded the hygiene check in `state.md`.
 - ~~**P0-13 run_daily_workflow local CSV override fix**~~ (2026-04-07 完了): `scripts/run_daily_workflow.py` がデフォルト ingest で `pull_prices.py` を呼び出す際に `--local-backup-csv` のパスを尊重する。
   - 2026-04-07: CLI オプションを `pull_prices` コマンドへ伝播し、回帰テスト `tests/test_run_daily_workflow.py::test_ingest_pull_prices_respects_local_backup_override` を追加。`python3 -m pytest` を実行して確認。
 - 2026-04-05: `scripts/run_sim.py` を manifest-first CLI へ再設計し、OutDir 実行時にランフォルダ (`params.json` / `metrics.json` / `records.csv` / `daily.csv`) が生成されるよう統合。`tests/test_run_sim_cli.py` / README / `docs/checklists/multi_strategy_validation.md` を更新。

--- a/state.md
+++ b/state.md
@@ -2,6 +2,7 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist。
+- 2026-04-25: Re-verified all `docs/` Markdown for stray `] (docs/...)` links, found none, and updated `docs/codex_workflow.md` with the explicit `docs/docs` failure note so future sessions keep using `./`-style relative paths.
 - 2026-04-24: Normalised `docs/` internal links to relative paths, verified cleanup with `rg '\\]\(docs/' docs`, refreshed `docs/task_backlog.md` notes, and added link hygiene guidance to the workflow doc.
 - 2026-04-23: README のオンデマンドインジェスト CLI 節で `scripts/fetch_prices_api.py` の案内を再整理し、重複記述を 1 つの箇条書きへ統合したまま API キー運用・Sandbox フォールバックの説明を保持。
 - 2026-04-22: `docs/api_ingest_plan.md` の Error Handling & Observability 節で `ops/runtime_snapshot.json.ingest_meta.<symbol>_<tf>`


### PR DESCRIPTION
## Summary
- note the risk of using "] (docs/...)" style links from within docs/ and remind editors to keep using ./-relative paths
- log the April 25 doc-link audit in both docs/task_backlog.md and state.md so the maintenance history stays synchronized

## Testing
- not run (docs-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e64dc1b598832aa1b23c9094123957