### PR TITLE
Fix backlog example link for phase 1 progress doc

### DIFF
--- a/docs/task_backlog.md
+++ b/docs/task_backlog.md
@@ -6,7 +6,7 @@
 
 各タスクに着手する前に、該当するバックログ項目を `state.md` の `Next Task` ブロックへ明示的に引き込み、進行中であることを記録してください。作業完了後は、成果ノートや反省点を `docs/todo_next.md` に反映し、`state.md` の完了ログと整合するよう同期します。
 
-- 例: `[P1-02] 2024-06-18 state.md ログ / docs/progress/phase1.md`
+- 例: `[P1-02] 2024-06-18 state.md ログ / docs/progress_phase1.md`
 
 ### Codex Session Operations Guide
 Document the repeatable workflow that lets Codex keep `state.md`, `docs/todo_next.md`, and `docs/task_backlog.md` synchronized across sessions, including how to use the supporting scripts and templates.

--- a/state.md
+++ b/state.md
@@ -2,6 +2,7 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist。
+- 2026-04-27: Corrected the example link in `docs/task_backlog.md` to reference `docs/progress_phase1.md`, keeping backlog guidance aligned with the actual file structure.
 - 2026-04-26: README のオンデマンドインジェスト CLI 節で `scripts/fetch_prices_api.py` の REST API ガイダンスを単一の箇条書きに統合し、Sandbox 向け注意点をサブ項目へ整理して重複記述を解消。
 - 2026-04-25: Re-verified all `docs/` Markdown for stray `] (docs/...)` links, found none, and updated `docs/codex_workflow.md` with the explicit `docs/docs` failure note so future sessions keep using `./`-style relative paths.
 - 2026-04-24: Normalised `docs/` internal links to relative paths, verified cleanup with `rg '\\]\(docs/' docs`, refreshed `docs/task_backlog.md` notes, and added link hygiene guidance to the workflow doc.


### PR DESCRIPTION
## Summary
- update the example reference in `docs/task_backlog.md` to point at the existing `docs/progress_phase1.md`
- record the link hygiene adjustment in `state.md` so the workflow log stays current

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68e6531eb8d0832a9de05e327394cc98