### PR TITLE
Add placeholder roadmap docs and update state log

### DIFF
--- a/docs/architecture_migration.md
+++ b/docs/architecture_migration.md
@@ -1,0 +1,26 @@
+# Architecture Migration Plan
+
+This document will capture the strategy for migrating performance-critical I/O and execution paths to Rust or C++.
+
+## Scope
+- Define current Python-based system boundaries and identify FFI seams for candidate modules.
+- Track profiling data that motivates each migration phase.
+- Outline testing and rollout safeguards to preserve behaviour.
+
+## Current Status
+- **Owner**: _Unassigned_
+- **Last Reviewed**: _TODO_
+- Existing ADR references and profiling measurements still need to be collated.
+
+## Open Questions
+- Which runner components should move first without disrupting CLI workflows?
+- How will deployment packaging change once native extensions are introduced?
+- What telemetry must remain available during and after the migration?
+
+## Next Steps
+- [ ] Compile baseline architecture diagrams and call graphs.
+- [ ] Gather recent profiling snapshots that justify native rewrites.
+- [ ] Propose phased milestones with validation criteria and fallback plans.
+- [ ] Coordinate with docs/task_backlog.md owners to add dedicated tasks.
+
+> **TODO**: Flesh out each section with concrete plans, ADR links, and decision history.

--- a/docs/audit_playbook.md
+++ b/docs/audit_playbook.md
@@ -1,0 +1,27 @@
+# Audit & Compliance Playbook
+
+This document will codify how artifacts and operational changes are reviewed, approved, and preserved for compliance.
+
+## Purpose
+- Establish a repeatable process for verifying artifact integrity (e.g., hashes, signatures, immutable storage).
+- Clarify required approvals and documentation for production changes.
+- Provide quick-reference checklists for internal or external audits.
+
+## Current Gaps
+- Artifact ledger (ADR-020) procedures are not yet summarised for day-to-day operators.
+- Evidence retention timelines and storage policies are undefined.
+- Links to relevant ADRs, runbooks, and ticketing systems remain to be added.
+
+## Planned Sections
+1. **Governance Roles** — Responsibilities for approvers, reviewers, and operators.
+2. **Artifact Ledger Workflow** — How to register, verify, and rotate artifacts.
+3. **Change Management** — Required records for code, configuration, and dataset updates.
+4. **Audit Preparation Checklist** — Documents, logs, and metrics to export ahead of reviews.
+
+## Next Steps
+- [ ] Draft role definitions and approval matrices.
+- [ ] Document end-to-end artifact ledger procedures with examples.
+- [ ] Specify evidence retention SLAs and storage locations.
+- [ ] Integrate escalation contacts and communication templates.
+
+> **TODO**: Populate each section with authoritative guidance and link to supporting ADRs/runbooks.

--- a/docs/observability_plan.md
+++ b/docs/observability_plan.md
@@ -1,0 +1,25 @@
+# Observability Expansion Plan
+
+This placeholder outlines the desired evolution of telemetry and dashboards that support trading and research workflows.
+
+## Objectives
+- Consolidate KPI definitions (EV trends, slippage projections, win-rate LCB, turnover) across CLI outputs and dashboards.
+- Ensure notebook- and BI-based views align with operational alerting requirements.
+- Document dependencies on data pipelines, storage, and access controls.
+
+## Current Coverage
+- `docs/observability_dashboard.md` captures the existing dashboard pipeline, but alignment with roadmap milestones is pending.
+- Runtime snapshots and webhook alerts cover select metrics; broader SLA tracking remains undocumented.
+
+## Risks & Considerations
+- Dashboard refresh cadence versus data ingestion latency tolerances.
+- Versioning and reproducibility of dashboard artifacts for audits.
+- Sandbox or offline review paths when production credentials are unavailable.
+
+## Action Items
+- [ ] Inventory current telemetry sources and responsible owners.
+- [ ] Describe the desired BI/Notebook integration architecture.
+- [ ] Define alert thresholds and escalation paths for each KPI.
+- [ ] Add cross-references to docs/task_backlog.md for observability workstreams.
+
+> **TODO**: Replace this scaffold with detailed plans, diagrams, and validation checklists.

--- a/state.md
+++ b/state.md
@@ -2,6 +2,7 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist。
+- 2026-04-28: Created placeholder docs for roadmap long-term items referenced in docs/development_roadmap.md and rechecked link resolution.
 - 2026-04-28: Inserted explicit anchors for P0-12 / P0-07 in `docs/task_backlog.md` and verified roadmap links resolve to the updated sections.
 - 2026-04-27: Corrected the example link in `docs/task_backlog.md` to reference `docs/progress_phase1.md`, keeping backlog guidance aligned with the actual file structure.
 - 2026-04-26: README のオンデマンドインジェスト CLI 節で `scripts/fetch_prices_api.py` の REST API ガイダンスを単一の箇条書きに統合し、Sandbox 向け注意点をサブ項目へ整理して重複記述を解消。


### PR DESCRIPTION
## Summary
- add placeholder documents for long-term roadmap items referenced by docs/development_roadmap.md
- outline scope, questions, and next steps for architecture migration, observability expansion, and audit playbook planning
- log the roadmap link verification in state.md for future sessions

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e657853668832aa8c38b12287d62dd