### PR TITLE
Fix backlog sample link to progress_phase1

### DIFF
--- a/docs/task_backlog.md
+++ b/docs/task_backlog.md
@@ -6,7 +6,7 @@
 
 各タスクに着手する前に、該当するバックログ項目を `state.md` の `Next Task` ブロックへ明示的に引き込み、進行中であることを記録してください。作業完了後は、成果ノートや反省点を `docs/todo_next.md` に反映し、`state.md` の完了ログと整合するよう同期します。
 
-- 例: `[P1-02] 2024-06-18 state.md ログ / docs/progress_phase1.md`
+- 例: [P1-02] 2024-06-18 state.md ログ / [docs/progress_phase1.md](docs/progress_phase1.md)
 
 ### Codex Session Operations Guide
 Document the repeatable workflow that lets Codex keep `state.md`, `docs/todo_next.md`, and `docs/task_backlog.md` synchronized across sessions, including how to use the supporting scripts and templates.

--- a/state.md
+++ b/state.md
@@ -2,6 +2,8 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist。
+- 2026-04-29: Converted the docs/task_backlog.md sample entry to link directly to docs/progress_phase1.md, checked for lingering
+  docs/progress/ paths, and ensured the target document exists for navigation.
 - 2026-04-28: Created placeholder docs for roadmap long-term items referenced in docs/development_roadmap.md and rechecked link resolution.
 - 2026-04-28: Inserted explicit anchors for P0-12 / P0-07 in `docs/task_backlog.md` and verified roadmap links resolve to the updated sections.
 - 2026-04-27: Corrected the example link in `docs/task_backlog.md` to reference `docs/progress_phase1.md`, keeping backlog guidance aligned with the actual file structure.


### PR DESCRIPTION
## Summary
- replace the backlog example so it links directly to docs/progress_phase1.md
- record the link hygiene update in state.md for future sessions

## Testing
- `rg 'docs/progress/' docs/task_backlog.md`
- `python3 - <<'PY'
import markdown
from pathlib import Path
text = Path('docs/task_backlog.md').read_text(encoding='utf-8')
html = markdown.markdown(text)
for line in html.split('\n'):
    if 'docs/progress_phase1.md' in line:
        print(line)
        break
else:
    print('not found')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68e65c1d5b9c832aa02dfdac2dc90ff5