### PR TITLE
Update mid-term roadmap EV tuning reference

### DIFF
--- a/docs/development_roadmap.md
+++ b/docs/development_roadmap.md
@@ -25,7 +25,7 @@
   - 追加戦略の manifest 整備やカテゴリ配分強化（`docs/checklists/p2_manifest.md`, `docs/checklists/p2_router.md`）を段階的に進める。
   - ルーターの執行メトリクスを拡充し、`scripts/build_router_snapshot.py` のテレメトリ出力と `docs/router_architecture.md` の計画を同期する。
 - **EV プロファイル自動校正フロー** — [docs/task_backlog.md#p3-観測性・レポート自動化](task_backlog.md#p3-観測性・レポート自動化)
-  - `scripts/aggregate_ev.py` のパラメータ調整手順を `docs/ev_tuning.md`（作成予定）と連動させ、DoD に必要なテスト/ログを明示する。
+  - `scripts/aggregate_ev.py` のパラメータ調整手順は [docs/ev_tuning.md](ev_tuning.md) に整理済みなので、DoD に必要なテストやログ要件をそこで明示した内容と同期する。
 
 ## Long Term (3ヶ月〜)
 - **Rust/C++ への I/O/Execution 移行準備** — [docs/task_backlog.md#継続タスク--保守](task_backlog.md#継続タスク--保守)

--- a/state.md
+++ b/state.md
@@ -2,6 +2,7 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist。
+- 2026-05-01: Refreshed `docs/development_roadmap.md` mid-term EV calibration note to link the existing `docs/ev_tuning.md` procedures and drop the placeholder wording。
 - 2026-04-30: Updated `docs/todo_next_archive.md` so the P2-01 archive references `./checklists/p2_manifest.md`, fixed remaining `p2-01` checklist slugs, and re-ran `rg 'docs/checklists/' docs/todo_next_archive.md` to confirm link targets。
 - 2026-04-29: Converted the docs/task_backlog.md sample entry to link directly to docs/progress_phase1.md, checked for lingering
   docs/progress/ paths, and ensured the target document exists for navigation.


### PR DESCRIPTION
## Summary
- update the mid-term EV calibration item in the development roadmap to point at the existing docs/ev_tuning.md guidance
- drop the placeholder wording so the roadmap reflects the documented procedure
- record the documentation refresh in state.md for future sessions

## Testing
- not run (documentation-only change)

## 概要 (日本語)
- 開発ロードマップの EV 校正項目を docs/ev_tuning.md の実ドキュメント参照へ更新しました
- プレースホルダ表現を削除し、手順の所在を明確化しました
- 今回の更新内容を state.md に追記しました


------
https://chatgpt.com/codex/tasks/task_e_68e6634889e8832ab491c975778da724