### PR TITLE
Align P2-01 manifest checklist link

### DIFF
--- a/docs/todo_next_archive.md
+++ b/docs/todo_next_archive.md
@@ -55,7 +55,7 @@
     - 主要ランブック: [docs/state_runbook.md](./state_runbook.md)
   - Pending Questions:
     - [ ] Clarify gating metrics, data dependencies, or open questions.
-  - DoD チェックリスト: [docs/templates/dod_checklist.md](./templates/dod_checklist.md) を [docs/checklists/p2_manifest.md](./checklists/p2_manifest.md) にコピーし、進捗リンクを更新する。
+  - DoD チェックリスト: [docs/templates/dod_checklist.md](./templates/dod_checklist.md) を [p2_manifest.md](./checklists/p2_manifest.md) にコピーし、進捗リンクを更新する。
 
 - ~~**Workflow Integration Guide**~~ (Backlog: `docs/task_backlog.md` → "ワークフロー統合" section) — `state.md` 2024-06-18, 2025-09-29, 2026-02-13, 2025-10-08 ✅ <!-- anchor: docs/task_backlog.md#codex-session-operations-guide -->
   <!-- REVIEW: Archived after confirming workflow loop, dry-run coverage, and template links met the reviewer DoD. -->

--- a/state.md
+++ b/state.md
@@ -2,6 +2,7 @@
 
 ## Workflow Rule
 - Review this file before starting any task to confirm the latest context and checklist。
+- 2026-05-02: Updated `docs/todo_next_archive.md` P2-01 DoD 行のリンク表示を `p2_manifest.md` へ揃え、`docs/checklists/` のファイル構成と一致することを確認。
 - 2026-05-01: Refreshed `docs/development_roadmap.md` mid-term EV calibration note to link the existing `docs/ev_tuning.md` procedures and drop the placeholder wording。
 - 2026-04-30: Updated `docs/todo_next_archive.md` so the P2-01 archive references `./checklists/p2_manifest.md`, fixed remaining `p2-01` checklist slugs, and re-ran `rg 'docs/checklists/' docs/todo_next_archive.md` to confirm link targets。
 - 2026-04-29: Converted the docs/task_backlog.md sample entry to link directly to docs/progress_phase1.md, checked for lingering


### PR DESCRIPTION
## Summary
- update the P2-01 archive DoD checklist reference so the visible text matches the `p2_manifest.md` file name
- confirm the checklist directory listing stays consistent with the updated link

## Testing
- not run (not requested)

## 備考
- P2-01 戦略マニフェスト DoD リンクを `p2_manifest.md` 表記へ統一しました。


------
https://chatgpt.com/codex/tasks/task_e_68e6642c0534832ab2cccb6fbc4121a4